### PR TITLE
Add donation workflow and donated-item visibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ npm run dev
 
 - `GET /api/data`：儀表板資訊
 - `GET /api/items`：取得清單
+- `GET /api/items?include_donated=true`：取得含已捐贈資料的清單
 - `GET /api/items/{item_id}`：取得單筆
 - `POST /api/items`：新增
 - `PUT /api/items/{item_id}`：更新
 - `DELETE /api/items/{item_id}`：軟刪除
+- `GET /api/donations`：取得捐贈清單
+- `GET /api/donations/{request_id}`：取得單筆捐贈單
+- `POST /api/donations`：建立捐贈單
+- `PUT /api/donations/{request_id}`：更新捐贈單
+- `DELETE /api/donations/{request_id}`：刪除捐贈單（並解除庫存捐贈標記）
 - `POST /api/items/import`：上傳 Excel 匯入（`multipart/form-data`）
 
 ## Excel 匯入欄位

--- a/backend/README.md
+++ b/backend/README.md
@@ -64,10 +64,19 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ### 庫存資料
 
 - `GET /api/items`：列出所有未刪除資料
+- `GET /api/items?include_donated=true`：列出包含已捐贈資料
 - `GET /api/items/{item_id}`：取得單筆資料
 - `POST /api/items`：新增資料
 - `PUT /api/items/{item_id}`：更新資料
 - `DELETE /api/items/{item_id}`：軟刪除資料
+
+### 捐贈資料
+
+- `GET /api/donations`：列出捐贈單
+- `GET /api/donations/{request_id}`：取得單筆捐贈單
+- `POST /api/donations`：建立捐贈單（`recipient` 必填）
+- `PUT /api/donations/{request_id}`：更新捐贈單（`recipient` 必填）
+- `DELETE /api/donations/{request_id}`：刪除捐贈單，解除關聯品項的捐贈標記
 
 ### 批次匯入
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -27,6 +27,8 @@ SHEETS: dict[str, list[str]] = {
         "memo",
         "keeper",
         "deleted_at",
+        "donated_at",
+        "donation_request_id",
     ],
     "order_sn": [
         "name",
@@ -76,6 +78,23 @@ SHEETS: dict[str, list[str]] = {
         "quantity",
         "note",
     ],
+    "donation_requests": [
+        "id",
+        "donor",
+        "department",
+        "recipient",
+        "purpose",
+        "donation_date",
+        "memo",
+        "created_at",
+    ],
+    "donation_items": [
+        "id",
+        "request_id",
+        "item_id",
+        "quantity",
+        "note",
+    ],
 }
 
 STRING_FIELDS: dict[str, list[str]] = {
@@ -93,6 +112,16 @@ STRING_FIELDS: dict[str, list[str]] = {
         "created_at",
     ],
     "borrow_items": ["note"],
+    "donation_requests": [
+        "donor",
+        "department",
+        "recipient",
+        "purpose",
+        "donation_date",
+        "memo",
+        "created_at",
+    ],
+    "donation_items": ["note"],
 }
 
 
@@ -271,7 +300,7 @@ def get_pending_fix_count() -> int:
     )
 
 
-def list_items() -> list[dict[str, Any]]:
+def list_items(*, include_donated: bool = False) -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         rows = _read_rows(wb["inventory_items"])
     results = [
@@ -287,10 +316,13 @@ def list_items() -> list[dict[str, Any]]:
             "location": row.get("location", ""),
             "keeper": row.get("keeper", ""),
             "memo": row.get("memo", ""),
+            "donated_at": row.get("donated_at", ""),
+            "donation_request_id": row.get("donation_request_id", ""),
             "deleted_at": row.get("deleted_at", ""),
         }
         for row in rows
         if _is_blank(row.get("deleted_at"))
+        and (include_donated or _is_blank(row.get("donated_at")))
     ]
     return sorted(results, key=lambda row: _to_int(row.get("id")), reverse=True)
 
@@ -312,6 +344,8 @@ def get_item_by_id(item_id: int) -> dict[str, Any] | None:
                 "location": row.get("location", ""),
                 "keeper": row.get("keeper", ""),
                 "memo": row.get("memo", ""),
+                "donated_at": row.get("donated_at", ""),
+                "donation_request_id": row.get("donation_request_id", ""),
             }
     return None
 
@@ -342,6 +376,8 @@ def create_item(item_data: dict[str, Any]) -> int:
                 "keeper": item_data["keeper"],
                 "memo": item_data["memo"],
                 "deleted_at": "",
+                "donated_at": "",
+                "donation_request_id": "",
             }
         )
         _write_rows(ws, SHEETS["inventory_items"], rows)
@@ -397,6 +433,8 @@ def create_items_bulk(items: list[dict[str, Any]]) -> int:
                     "keeper": item_data["keeper"],
                     "memo": item_data["memo"],
                     "deleted_at": "",
+                    "donated_at": "",
+                    "donation_request_id": "",
                 }
             )
             next_id += 1
@@ -521,6 +559,34 @@ def get_order_sn(name: str) -> dict[str, Any] | None:
                 wb.save(DB_PATH)
                 return {"tmp_no": tmp_no}
         return None
+
+
+def validate_item_ids_available(
+    item_ids: list[int],
+    *,
+    allow_donation_request_id: int | None = None,
+    enforce_unique: bool = False,
+) -> tuple[bool, str | None]:
+    with _locked_workbook() as wb:
+        inventory_rows = _read_rows(wb["inventory_items"])
+
+    if enforce_unique and len(item_ids) != len(set(item_ids)):
+        return False, "item_id cannot be duplicated"
+
+    inventory_map = {_to_int(row.get("id")): row for row in inventory_rows if _is_blank(row.get("deleted_at"))}
+    for item_id in item_ids:
+        row = inventory_map.get(item_id)
+        if row is None:
+            return False, f"item_id {item_id} not found"
+        donated_at = row.get("donated_at")
+        donation_request_id = _to_int(row.get("donation_request_id"))
+        if _is_blank(donated_at):
+            continue
+        if allow_donation_request_id is not None and donation_request_id == allow_donation_request_id:
+            continue
+        return False, f"item_id {item_id} is already donated"
+
+    return True, None
 
 
 def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
@@ -658,6 +724,232 @@ def delete_issue_request(request_id: int) -> bool:
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["issue_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["issue_items"], remaining_items)
+        wb.save(DB_PATH)
+        return True
+
+
+def create_donation_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
+    with _locked_workbook() as wb:
+        request_ws = wb["donation_requests"]
+        item_ws = wb["donation_items"]
+        inventory_ws = wb["inventory_items"]
+        request_rows = _read_rows(request_ws)
+        item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        selected_item_ids = [_to_int(item.get("item_id")) for item in items]
+        if len(selected_item_ids) != len(set(selected_item_ids)):
+            raise ValueError("item_id cannot be duplicated")
+
+        inventory_map = {_to_int(row.get("id")): row for row in inventory_rows if _is_blank(row.get("deleted_at"))}
+        for item_id in selected_item_ids:
+            row = inventory_map.get(item_id)
+            if row is None:
+                raise ValueError(f"item_id {item_id} not found")
+            if not _is_blank(row.get("donated_at")):
+                raise ValueError(f"item_id {item_id} is already donated")
+
+        request_id = _next_id(request_rows)
+        request_rows.append(
+            {
+                "id": request_id,
+                "donor": request_data["donor"],
+                "department": request_data["department"],
+                "recipient": request_data["recipient"],
+                "purpose": request_data["purpose"],
+                "donation_date": request_data["donation_date"],
+                "memo": request_data["memo"],
+                "created_at": _now_str(),
+            }
+        )
+
+        next_item_id = _next_id(item_rows)
+        for index, item in enumerate(items):
+            item_rows.append(
+                {
+                    "id": next_item_id + index,
+                    "request_id": request_id,
+                    "item_id": item["item_id"],
+                    "quantity": item["quantity"],
+                    "note": item.get("note", ""),
+                }
+            )
+
+        marked_item_ids = set(selected_item_ids)
+        now = _now_str()
+        for row in inventory_rows:
+            if _to_int(row.get("id")) in marked_item_ids and _is_blank(row.get("deleted_at")):
+                row["donated_at"] = now
+                row["donation_request_id"] = request_id
+
+        _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
+        _write_rows(item_ws, SHEETS["donation_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        wb.save(DB_PATH)
+        return request_id
+
+
+def list_donation_requests() -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["donation_requests"])
+    return sorted(rows, key=lambda row: _to_int(row.get("id")), reverse=True)
+
+
+def get_donation_request(request_id: int) -> dict[str, Any] | None:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["donation_requests"])
+    for row in rows:
+        if _to_int(row.get("id")) == request_id:
+            return row
+    return None
+
+
+def list_donation_items(request_id: int) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        item_rows = _read_rows(wb["donation_items"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+    inventory_map = {
+        _to_int(row.get("id")): {
+            "item_name": row.get("name", ""),
+            "item_model": row.get("model", ""),
+        }
+        for row in inventory_rows
+        if _is_blank(row.get("deleted_at"))
+    }
+    results = []
+    for row in item_rows:
+        if _to_int(row.get("request_id")) != request_id:
+            continue
+        details = inventory_map.get(_to_int(row.get("item_id")), {"item_name": None, "item_model": None})
+        results.append(
+            {
+                "id": row.get("id"),
+                "request_id": row.get("request_id"),
+                "item_id": row.get("item_id"),
+                "quantity": row.get("quantity"),
+                "note": row.get("note", ""),
+                "item_name": details.get("item_name"),
+                "item_model": details.get("item_model"),
+            }
+        )
+    return sorted(results, key=lambda row: _to_int(row.get("id")))
+
+
+def update_donation_request(request_id: int, request_data: dict[str, Any], items: list[dict[str, Any]]) -> bool:
+    with _locked_workbook() as wb:
+        request_ws = wb["donation_requests"]
+        item_ws = wb["donation_items"]
+        inventory_ws = wb["inventory_items"]
+        request_rows = _read_rows(request_ws)
+        item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        request_row = None
+        for row in request_rows:
+            if _to_int(row.get("id")) == request_id:
+                request_row = row
+                break
+        if request_row is None:
+            return False
+
+        selected_item_ids = [_to_int(item.get("item_id")) for item in items]
+        if len(selected_item_ids) != len(set(selected_item_ids)):
+            raise ValueError("item_id cannot be duplicated")
+
+        inventory_map = {_to_int(row.get("id")): row for row in inventory_rows if _is_blank(row.get("deleted_at"))}
+        for item_id in selected_item_ids:
+            row = inventory_map.get(item_id)
+            if row is None:
+                raise ValueError(f"item_id {item_id} not found")
+            donated_at = row.get("donated_at")
+            donation_request_id = _to_int(row.get("donation_request_id"))
+            if _is_blank(donated_at):
+                continue
+            if donation_request_id != request_id:
+                raise ValueError(f"item_id {item_id} is already donated")
+
+        old_item_ids = {
+            _to_int(row.get("item_id"))
+            for row in item_rows
+            if _to_int(row.get("request_id")) == request_id
+        }
+        for row in inventory_rows:
+            item_id = _to_int(row.get("id"))
+            if item_id not in old_item_ids or not _is_blank(row.get("deleted_at")):
+                continue
+            if _to_int(row.get("donation_request_id")) == request_id:
+                row["donated_at"] = ""
+                row["donation_request_id"] = ""
+
+        request_row.update(
+            {
+                "donor": request_data["donor"],
+                "department": request_data["department"],
+                "recipient": request_data["recipient"],
+                "purpose": request_data["purpose"],
+                "donation_date": request_data["donation_date"],
+                "memo": request_data["memo"],
+            }
+        )
+
+        item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
+        next_item_id = _next_id(item_rows)
+        for index, item in enumerate(items):
+            item_rows.append(
+                {
+                    "id": next_item_id + index,
+                    "request_id": request_id,
+                    "item_id": item["item_id"],
+                    "quantity": item["quantity"],
+                    "note": item.get("note", ""),
+                }
+            )
+
+        now = _now_str()
+        marked_item_ids = set(selected_item_ids)
+        for row in inventory_rows:
+            if _to_int(row.get("id")) in marked_item_ids and _is_blank(row.get("deleted_at")):
+                row["donated_at"] = now
+                row["donation_request_id"] = request_id
+
+        _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
+        _write_rows(item_ws, SHEETS["donation_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        wb.save(DB_PATH)
+        return True
+
+
+def delete_donation_request(request_id: int) -> bool:
+    with _locked_workbook() as wb:
+        request_ws = wb["donation_requests"]
+        item_ws = wb["donation_items"]
+        inventory_ws = wb["inventory_items"]
+        request_rows = _read_rows(request_ws)
+        item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
+        deleted = len(remaining_requests) != len(request_rows)
+        if not deleted:
+            return False
+
+        removed_item_ids = {
+            _to_int(row.get("item_id"))
+            for row in item_rows
+            if _to_int(row.get("request_id")) == request_id
+        }
+        remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
+
+        for row in inventory_rows:
+            if _to_int(row.get("id")) not in removed_item_ids:
+                continue
+            if _to_int(row.get("donation_request_id")) == request_id:
+                row["donated_at"] = ""
+                row["donation_request_id"] = ""
+
+        _write_rows(request_ws, SHEETS["donation_requests"], remaining_requests)
+        _write_rows(item_ws, SHEETS["donation_items"], remaining_items)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return True
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,25 +11,32 @@ from db import (
     create_items_bulk,
     create_issue_request,
     create_borrow_request,
+    create_donation_request,
     delete_item,
     delete_issue_request,
     delete_borrow_request,
+    delete_donation_request,
     get_item_by_id,
     get_items_count,
     get_issue_request,
     get_borrow_request,
+    get_donation_request,
     get_pending_fix_count,
     init_db,
     list_issue_items,
     list_issue_requests,
     list_borrow_items,
     list_borrow_requests,
+    list_donation_items,
+    list_donation_requests,
     list_items,
     log_inventory_action,
     purge_soft_deleted_items,
     update_item,
     update_issue_request,
     update_borrow_request,
+    update_donation_request,
+    validate_item_ids_available,
 )
 from xlsx_import import import_inventory_items_from_xlsx_content
 from google_sheets import ensure_google_oauth, is_google_sheets_configured, sync_requests_to_google_sheets
@@ -70,6 +77,8 @@ class InventoryItemCreate(BaseModel):
 
 class InventoryItem(InventoryItemCreate):
     id: int
+    donated_at: datetime | None = None
+    donation_request_id: int | None = None
 
 
 class IssueItemCreate(BaseModel):
@@ -127,6 +136,33 @@ class BorrowRequest(BorrowRequestCreate):
     items: list[BorrowItem]
 
 
+class DonationItemCreate(BaseModel):
+    item_id: int
+    quantity: int = 1
+    note: str = ""
+
+
+class DonationItem(DonationItemCreate):
+    id: int
+    item_name: str | None = None
+    item_model: str | None = None
+
+
+class DonationRequestCreate(BaseModel):
+    donor: str = ""
+    department: str = ""
+    recipient: str = ""
+    purpose: str = ""
+    donation_date: date | None = None
+    memo: str = ""
+    items: list[DonationItemCreate] = Field(default_factory=list)
+
+
+class DonationRequest(DonationRequestCreate):
+    id: int
+    items: list[DonationItem]
+
+
 class ImportErrorDetail(BaseModel):
     row: int
     message: str
@@ -146,6 +182,15 @@ def _parse_purchase_date(value: str) -> date:
         except ValueError:
             continue
     raise ValueError(f"Invalid purchase_date format: {value}")
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
 
 
 def _resolve_frontend_index() -> Path | None:
@@ -198,6 +243,12 @@ def _coerce_str(value) -> str:
 def row_to_item(row) -> InventoryItem:
     purchase_date_value = row["purchase_date"]
     parsed_date = _parse_purchase_date(purchase_date_value) if purchase_date_value else None
+    donated_at_value = _coerce_str(row.get("donated_at"))
+    donation_request_id_raw = row.get("donation_request_id")
+    try:
+        donation_request_id = int(donation_request_id_raw) if donation_request_id_raw not in (None, "") else None
+    except (TypeError, ValueError):
+        donation_request_id = None
     return InventoryItem(
         id=row["id"],
         kind=_coerce_str(row["kind"]),
@@ -210,6 +261,8 @@ def row_to_item(row) -> InventoryItem:
         location=_coerce_str(row["location"]),
         memo=_coerce_str(row["memo"]),
         keeper=_coerce_str(row["keeper"]),
+        donated_at=_parse_datetime(donated_at_value),
+        donation_request_id=donation_request_id,
     )
 
 
@@ -226,6 +279,17 @@ def row_to_issue_item(row) -> IssueItem:
 
 def row_to_borrow_item(row) -> BorrowItem:
     return BorrowItem(
+        id=row["id"],
+        item_id=row["item_id"],
+        quantity=row["quantity"],
+        note=_coerce_str(row["note"]),
+        item_name=row["item_name"],
+        item_model=row["item_model"],
+    )
+
+
+def row_to_donation_item(row) -> DonationItem:
+    return DonationItem(
         id=row["id"],
         item_id=row["item_id"],
         quantity=row["quantity"],
@@ -254,6 +318,17 @@ def borrow_request_to_db_payload(request: BorrowRequestCreate) -> dict:
         "due_date": _format_date(request.due_date),
         "return_date": _format_date(request.return_date),
         "status": request.status,
+        "memo": request.memo,
+    }
+
+
+def donation_request_to_db_payload(request: DonationRequestCreate) -> dict:
+    return {
+        "donor": request.donor,
+        "department": request.department,
+        "recipient": request.recipient.strip(),
+        "purpose": request.purpose,
+        "donation_date": _format_date(request.donation_date),
         "memo": request.memo,
     }
 
@@ -287,6 +362,35 @@ def borrow_request_row_to_model(row, items: list[BorrowItem]) -> BorrowRequest:
         memo=_coerce_str(row["memo"]),
         items=items,
     )
+
+
+def donation_request_row_to_model(row, items: list[DonationItem]) -> DonationRequest:
+    donation_date = _parse_purchase_date(row["donation_date"]) if row["donation_date"] else None
+    return DonationRequest(
+        id=row["id"],
+        donor=_coerce_str(row["donor"]),
+        department=_coerce_str(row["department"]),
+        recipient=_coerce_str(row["recipient"]),
+        purpose=_coerce_str(row["purpose"]),
+        donation_date=donation_date,
+        memo=_coerce_str(row["memo"]),
+        items=items,
+    )
+
+
+def _ensure_available_item_ids(
+    item_ids: list[int],
+    *,
+    allow_donation_request_id: int | None = None,
+    enforce_unique: bool = False,
+) -> None:
+    is_available, error_message = validate_item_ids_available(
+        item_ids,
+        allow_donation_request_id=allow_donation_request_id,
+        enforce_unique=enforce_unique,
+    )
+    if not is_available:
+        raise HTTPException(status_code=400, detail=error_message or "invalid item_id")
 
 
 def _sync_requests_safe() -> None:
@@ -330,8 +434,8 @@ def get_dashboard_data():
 
 
 @app.get("/api/items", response_model=list[InventoryItem], response_model_by_alias=False)
-def get_inventory_items():
-    rows = list_items()
+def get_inventory_items(include_donated: bool = False):
+    rows = list_items(include_donated=include_donated)
     log_inventory_action(action="read", entity="inventory_item", detail={"count": len(rows), "mode": "list"})
     return [row_to_item(row) for row in rows]
 
@@ -445,6 +549,7 @@ def create_issue_request_api(request: IssueRequestCreate, background_tasks: Back
     for item in request.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids([item.item_id for item in request.items])
     request_id = create_issue_request(issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
     row = get_issue_request(request_id)
     if row is None:
@@ -470,6 +575,7 @@ def update_issue_request_api(request_id: int, request: IssueRequestCreate, backg
     for item in request.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids([item.item_id for item in request.items])
     updated = update_issue_request(request_id, issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
     if not updated:
         log_inventory_action(
@@ -543,6 +649,7 @@ def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: Ba
     for item in request.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids([item.item_id for item in request.items])
     request_id = create_borrow_request(borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
     row = get_borrow_request(request_id)
     if row is None:
@@ -568,6 +675,7 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
     for item in request.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids([item.item_id for item in request.items])
     updated = update_borrow_request(request_id, borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
     if not updated:
         log_inventory_action(
@@ -610,6 +718,123 @@ def delete_borrow_request_api(request_id: int, background_tasks: BackgroundTasks
     log_inventory_action(action="delete", entity="borrow_request", entity_id=request_id)
     if is_google_sheets_configured():
         background_tasks.add_task(_sync_requests_safe)
+    return {"success": True}
+
+
+@app.get("/api/donations", response_model=list[DonationRequest], response_model_by_alias=False)
+def list_donation_requests_api():
+    rows = list_donation_requests()
+    results = []
+    for row in rows:
+        items = [row_to_donation_item(item) for item in list_donation_items(row["id"])]
+        results.append(donation_request_row_to_model(row, items))
+    log_inventory_action(action="read", entity="donation_request", detail={"count": len(results), "mode": "list"})
+    return results
+
+
+@app.get("/api/donations/{request_id}", response_model=DonationRequest, response_model_by_alias=False)
+def get_donation_request_api(request_id: int):
+    row = get_donation_request(request_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Donation request not found")
+    items = [row_to_donation_item(item) for item in list_donation_items(request_id)]
+    log_inventory_action(action="read", entity="donation_request", entity_id=request_id, detail={"mode": "single"})
+    return donation_request_row_to_model(row, items)
+
+
+@app.post("/api/donations", response_model=DonationRequest, response_model_by_alias=False)
+def create_donation_request_api(request: DonationRequestCreate):
+    if not request.items:
+        raise HTTPException(status_code=400, detail="items is required")
+    if not request.recipient.strip():
+        raise HTTPException(status_code=400, detail="recipient is required")
+    for item in request.items:
+        if item.quantity <= 0:
+            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids([item.item_id for item in request.items], enforce_unique=True)
+    try:
+        request_id = create_donation_request(
+            donation_request_to_db_payload(request),
+            [item.model_dump() for item in request.items],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    row = get_donation_request(request_id)
+    if row is None:
+        log_inventory_action(
+            action="create",
+            entity="donation_request",
+            entity_id=request_id,
+            status="failed",
+            detail={"reason": "Donation request created but cannot be loaded"},
+        )
+        raise HTTPException(status_code=500, detail="Donation request created but cannot be loaded")
+    items = [row_to_donation_item(item) for item in list_donation_items(request_id)]
+    log_inventory_action(action="create", entity="donation_request", entity_id=request_id)
+    return donation_request_row_to_model(row, items)
+
+
+@app.put("/api/donations/{request_id}", response_model=DonationRequest, response_model_by_alias=False)
+def update_donation_request_api(request_id: int, request: DonationRequestCreate):
+    if not request.items:
+        raise HTTPException(status_code=400, detail="items is required")
+    if not request.recipient.strip():
+        raise HTTPException(status_code=400, detail="recipient is required")
+    for item in request.items:
+        if item.quantity <= 0:
+            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+    _ensure_available_item_ids(
+        [item.item_id for item in request.items],
+        allow_donation_request_id=request_id,
+        enforce_unique=True,
+    )
+    try:
+        updated = update_donation_request(
+            request_id,
+            donation_request_to_db_payload(request),
+            [item.model_dump() for item in request.items],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if not updated:
+        log_inventory_action(
+            action="update",
+            entity="donation_request",
+            entity_id=request_id,
+            status="failed",
+            detail={"reason": "Donation request not found"},
+        )
+        raise HTTPException(status_code=404, detail="Donation request not found")
+    row = get_donation_request(request_id)
+    if row is None:
+        log_inventory_action(
+            action="update",
+            entity="donation_request",
+            entity_id=request_id,
+            status="failed",
+            detail={"reason": "Donation request not found after update"},
+        )
+        raise HTTPException(status_code=404, detail="Donation request not found")
+    items = [row_to_donation_item(item) for item in list_donation_items(request_id)]
+    log_inventory_action(action="update", entity="donation_request", entity_id=request_id)
+    return donation_request_row_to_model(row, items)
+
+
+@app.delete("/api/donations/{request_id}")
+def delete_donation_request_api(request_id: int):
+    deleted = delete_donation_request(request_id)
+    if not deleted:
+        log_inventory_action(
+            action="delete",
+            entity="donation_request",
+            entity_id=request_id,
+            status="failed",
+            detail={"reason": "Donation request not found"},
+        )
+        raise HTTPException(status_code=404, detail="Donation request not found")
+    log_inventory_action(action="delete", entity="donation_request", entity_id=request_id)
     return {"success": True}
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -65,13 +65,18 @@ npm run lint     # ESLint 檢查
 - `/inventory/new`：新增財產
 - `/inventory/edit/:id`：編輯財產
 - `/upload`：Excel 匯入
+- `/donations`：捐贈清單
+- `/donations/new`：新增捐贈
+- `/donations/:id`：編輯捐贈單
 
 ## 畫面與資料行為
 
 - 清單資料由 `GET /api/items` 載入。
+- 財產清單預設隱藏已捐贈資料，可切換顯示（`GET /api/items?include_donated=true`）。
 - 新增資料使用 `POST /api/items`。
 - 編輯資料使用 `PUT /api/items/{id}`。
 - 刪除資料使用 `DELETE /api/items/{id}`（軟刪除）。
+- 捐贈清單/表單使用 `/api/donations` 系列 API。
 - 匯入頁使用 `POST /api/items/import` 上傳 `.xlsx`。
 
 ## 建置輸出

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { TopNav } from './components/TopNav'
 import { DashboardPage } from './components/pages/DashboardPage'
 import { BorrowPage } from './components/pages/BorrowPage'
 import { BorrowListPage } from './components/pages/BorrowListPage'
+import { DonationPage } from './components/pages/DonationPage'
+import { DonationListPage } from './components/pages/DonationListPage'
 import { InventoryFormPage } from './components/pages/InventoryFormPage'
 import { InventoryListPage } from './components/pages/InventoryListPage'
 import { IssueListPage } from './components/pages/IssueListPage'
@@ -38,6 +40,16 @@ function parseBorrowRequestId(pathname: string): number | null {
   return Number.isInteger(parsedId) ? parsedId : null
 }
 
+function parseDonationRequestId(pathname: string): number | null {
+  const matchedParts = pathname.match(/^\/donations\/(\d+)$/)
+  if (!matchedParts) {
+    return null
+  }
+
+  const parsedId = Number(matchedParts[1])
+  return Number.isInteger(parsedId) ? parsedId : null
+}
+
 function App() {
   const pathname = window.location.pathname
   const isUploadPage = pathname === '/upload'
@@ -46,11 +58,14 @@ function App() {
   const isIssueCreatePage = pathname === '/issues/new'
   const isBorrowListPage = pathname === '/borrows'
   const isBorrowCreatePage = pathname === '/borrows/new'
+  const isDonationListPage = pathname === '/donations'
+  const isDonationCreatePage = pathname === '/donations/new'
   const isInventoryPage = pathname === '/inventory'
   const isCreateInventoryPage = pathname === '/inventory/new'
   const editItemId = parseEditItemId(pathname)
   const editIssueRequestId = parseIssueRequestId(pathname)
   const editBorrowRequestId = parseBorrowRequestId(pathname)
+  const editDonationRequestId = parseDonationRequestId(pathname)
 
   return (
     <main className="mx-auto grid max-h-screen w-full max-w-[980px] gap-5 px-4 pb-12 pt-8">
@@ -63,6 +78,9 @@ function App() {
       {isBorrowListPage ? <BorrowListPage /> : null}
       {isBorrowCreatePage ? <BorrowPage /> : null}
       {editBorrowRequestId ? <BorrowPage requestId={editBorrowRequestId} /> : null}
+      {isDonationListPage ? <DonationListPage /> : null}
+      {isDonationCreatePage ? <DonationPage /> : null}
+      {editDonationRequestId ? <DonationPage requestId={editDonationRequestId} /> : null}
       {isInventoryPage ? <InventoryListPage /> : null}
       {isUploadPage ? <UploadPage /> : null}
       {isCreateInventoryPage ? <InventoryFormPage /> : null}
@@ -73,15 +91,18 @@ function App() {
       !isIssueCreatePage &&
       !isBorrowListPage &&
       !isBorrowCreatePage &&
+      !isDonationListPage &&
+      !isDonationCreatePage &&
       !editIssueRequestId &&
       !editBorrowRequestId &&
+      !editDonationRequestId &&
       !isUploadPage &&
       !isInventoryPage &&
       !isCreateInventoryPage &&
       !editItemId ? (
         <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
           <h1 className="mt-0">找不到頁面</h1>
-          <p className="mt-2 text-slate-500">請使用上方導覽前往 Dashboard、領用/借用清單、財產清單、新增資料或上傳頁面。</p>
+          <p className="mt-2 text-slate-500">請使用上方導覽前往 Dashboard、領用/借用/捐贈清單、財產清單、新增資料或上傳頁面。</p>
         </section>
       ) : null}
     </main>

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -8,12 +8,15 @@ const activeNavLinkClass = 'bg-blue-600 text-white'
 export function TopNav({ pathname }: TopNavProps) {
   const isIssueEditPage = /^\/issues\/\d+$/.test(pathname)
   const isBorrowEditPage = /^\/borrows\/\d+$/.test(pathname)
+  const isDonationEditPage = /^\/donations\/\d+$/.test(pathname)
   const isUploadPage = pathname === '/upload'
   const isDashboardPage = pathname === '/'
   const isIssueListPage = pathname === '/issues' || isIssueEditPage
   const isIssueCreatePage = pathname === '/issues/new'
   const isBorrowListPage = pathname === '/borrows' || isBorrowEditPage
   const isBorrowCreatePage = pathname === '/borrows/new'
+  const isDonationListPage = pathname === '/donations' || isDonationEditPage
+  const isDonationCreatePage = pathname === '/donations/new'
   const isInventoryPage = pathname === '/inventory'
   const isCreatePage = pathname === '/inventory/new'
 
@@ -39,6 +42,12 @@ export function TopNav({ pathname }: TopNavProps) {
       </a>
       <a className={isBorrowCreatePage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/borrows/new">
         新增借用
+      </a>
+      <a className={isDonationListPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/donations">
+        捐贈清單
+      </a>
+      <a className={isDonationCreatePage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/donations/new">
+        新增捐贈
       </a>
       <a className={isUploadPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/upload">
         上傳頁面

--- a/frontend/src/components/pages/DonationListPage.tsx
+++ b/frontend/src/components/pages/DonationListPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react'
+import { apiUrl } from '../../api'
+import type { DonationRequest } from './types'
+
+const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
+const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+
+export function DonationListPage() {
+  const [requests, setRequests] = useState<DonationRequest[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [keyword, setKeyword] = useState('')
+
+  useEffect(() => {
+    const loadRequests = async () => {
+      setLoading(true)
+      setLoadError('')
+      try {
+        const response = await fetch(apiUrl('/api/donations'))
+        if (!response.ok) {
+          throw new Error('無法載入捐贈清單')
+        }
+        const payload = (await response.json()) as DonationRequest[]
+        setRequests(payload)
+      } catch {
+        setLoadError('目前無法讀取捐贈清單，請稍後重試。')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void loadRequests()
+  }, [])
+
+  const filteredRequests = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase()
+    if (!normalizedKeyword) {
+      return requests
+    }
+
+    const normalize = (value: string | null | undefined) => (value ?? '').toLowerCase()
+    return requests.filter((request) => {
+      const itemMatches = request.items.some((item) => normalize(item.item_name).includes(normalizedKeyword))
+      const fields = [request.donor, request.department, request.recipient, request.purpose, request.memo, request.donation_date]
+      return itemMatches || fields.some((field) => normalize(field).includes(normalizedKeyword))
+    })
+  }, [keyword, requests])
+
+  return (
+    <>
+      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h1 className="mt-0">捐贈清單</h1>
+        <p className="mt-2 text-slate-500">可依捐贈人、受贈對象、用途、品項快速查詢。</p>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <div className="mb-4 grid gap-2">
+          <label htmlFor="donation-search" className="font-bold">
+            關鍵字搜尋
+          </label>
+          <input
+            className={fieldClass}
+            id="donation-search"
+            type="search"
+            placeholder="輸入捐贈人、受贈對象、品項..."
+            value={keyword}
+            onChange={(event) => setKeyword(event.target.value)}
+          />
+          <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredRequests.length} 筆資料</p>
+        </div>
+
+        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
+        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+
+        {!loading && !loadError ? (
+          <div className="w-full overflow-x-auto">
+            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+              <thead>
+                <tr>
+                  {['#', '捐贈日期', '捐贈人/單位', '受贈對象', '用途', '品項', '備註'].map((header) => (
+                    <th key={header} className={tableHeaderClass}>{header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredRequests.length === 0 ? (
+                  <tr>
+                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
+                      目前沒有符合條件的捐贈單。
+                    </td>
+                  </tr>
+                ) : (
+                  filteredRequests.map((request) => (
+                    <tr key={request.id}>
+                      <td className={tableCellClass}>
+                        <a className="font-bold text-blue-700 no-underline" href={`/donations/${request.id}`}>
+                          {request.id}
+                        </a>
+                      </td>
+                      <td className={tableCellClass}>{request.donation_date || '--'}</td>
+                      <td className={tableCellClass}>
+                        <div className="font-bold">{request.donor || '--'}</div>
+                        <div className="text-sm text-slate-500">{request.department || ''}</div>
+                      </td>
+                      <td className={tableCellClass}>{request.recipient || '--'}</td>
+                      <td className={tableCellClass}>{request.purpose || '--'}</td>
+                      <td className={tableCellClass}>
+                        <div className="grid gap-1">
+                          {request.items.map((item) => (
+                            <div key={item.id} className="text-sm">
+                              {(item.item_name || `#${item.item_id}`)} x {item.quantity}
+                            </div>
+                          ))}
+                        </div>
+                      </td>
+                      <td className={tableCellClass}>{request.memo || '--'}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+    </>
+  )
+}

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Swal from 'sweetalert2'
+import { apiUrl } from '../../api'
+import type { DonationRequest, InventoryItem } from './types'
+
+type DonationLine = {
+  item_id: number | ''
+  quantity: number
+  note: string
+}
+
+const FIXED_DONOR = '固定捐贈人'
+const FIXED_DEPARTMENT = '固定單位'
+const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '' })
+const toast = Swal.mixin({
+  toast: true,
+  position: 'top-end',
+  showConfirmButton: false,
+  timer: 2600,
+  timerProgressBar: true,
+})
+
+type DonationPageProps = {
+  requestId?: number
+}
+
+export function DonationPage({ requestId }: DonationPageProps) {
+  const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([])
+  const [loadError, setLoadError] = useState('')
+
+  const [donor, setDonor] = useState(FIXED_DONOR)
+  const [department, setDepartment] = useState(FIXED_DEPARTMENT)
+  const [recipient, setRecipient] = useState('')
+  const [purpose, setPurpose] = useState('')
+  const [donationDate, setDonationDate] = useState('')
+  const [memo, setMemo] = useState('')
+  const [lines, setLines] = useState<DonationLine[]>([emptyLine()])
+  const [submitting, setSubmitting] = useState(false)
+  const isEditing = Number.isInteger(requestId)
+
+  const loadInventoryItems = useCallback(async () => {
+    setLoadError('')
+    try {
+      const itemsResponse = await fetch(apiUrl('/api/items?include_donated=true'))
+      if (!itemsResponse.ok) {
+        throw new Error('無法載入資料')
+      }
+      const itemsPayload = (await itemsResponse.json()) as InventoryItem[]
+      setInventoryItems(itemsPayload)
+    } catch {
+      setLoadError('目前無法讀取捐贈資料，請稍後重試。')
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadInventoryItems()
+  }, [loadInventoryItems])
+
+  useEffect(() => {
+    if (!isEditing || !requestId) {
+      return
+    }
+
+    const loadRequest = async () => {
+      setLoadError('')
+      try {
+        const response = await fetch(apiUrl(`/api/donations/${requestId}`))
+        if (!response.ok) {
+          throw new Error('無法載入捐贈單')
+        }
+
+        const payload = (await response.json()) as DonationRequest
+        setDonor(payload.donor || FIXED_DONOR)
+        setDepartment(payload.department || FIXED_DEPARTMENT)
+        setRecipient(payload.recipient ?? '')
+        setPurpose(payload.purpose ?? '')
+        setDonationDate(payload.donation_date ?? '')
+        setMemo(payload.memo ?? '')
+        setLines(
+          payload.items.length > 0
+            ? payload.items.map((item) => ({
+              item_id: item.item_id,
+              quantity: item.quantity,
+              note: item.note ?? '',
+            }))
+            : [emptyLine()]
+        )
+      } catch {
+        setLoadError('目前無法讀取捐贈單資料，請稍後重試。')
+      }
+    }
+
+    void loadRequest()
+  }, [isEditing, requestId])
+
+  const itemOptions = useMemo(() => {
+    if (!isEditing || !requestId) {
+      return inventoryItems.filter((item) => !item.donated_at)
+    }
+
+    return inventoryItems.filter((item) => {
+      if (!item.donated_at) {
+        return true
+      }
+      return item.donation_request_id === requestId
+    })
+  }, [inventoryItems, isEditing, requestId])
+
+  const handleLineChange = (index: number, patch: Partial<DonationLine>) => {
+    setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleAddLine = () => {
+    setLines((prev) => [...prev, emptyLine()])
+  }
+
+  const handleRemoveLine = (index: number) => {
+    setLines((prev) => prev.filter((_, idx) => idx !== index))
+  }
+
+  const validateLines = () => {
+    if (lines.length === 0) {
+      return false
+    }
+    return lines.every((line) => line.item_id !== '' && line.quantity > 0)
+  }
+
+  const handleSubmit = async () => {
+    if (!recipient.trim()) {
+      void toast.fire({ icon: 'error', title: '請填寫受贈對象。' })
+      return
+    }
+    if (!validateLines()) {
+      void toast.fire({ icon: 'error', title: '請確認每筆捐贈品項已選擇品項且數量大於 0。' })
+      return
+    }
+
+    setSubmitting(true)
+    setLoadError('')
+
+    try {
+      const response = await fetch(apiUrl(isEditing && requestId ? `/api/donations/${requestId}` : '/api/donations'), {
+        method: isEditing ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          donor,
+          department,
+          recipient,
+          purpose,
+          donation_date: donationDate,
+          memo,
+          items: lines.map((line) => ({
+            item_id: line.item_id,
+            quantity: line.quantity,
+            note: line.note,
+          })),
+        }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? '建立失敗')
+      }
+
+      await response.json()
+      if (isEditing) {
+        void toast.fire({ icon: 'success', title: '捐贈單已更新。' })
+      } else {
+        setDonor(FIXED_DONOR)
+        setDepartment(FIXED_DEPARTMENT)
+        setRecipient('')
+        setPurpose('')
+        setDonationDate('')
+        setMemo('')
+        setLines([emptyLine()])
+        void toast.fire({ icon: 'success', title: '捐贈單已建立。' })
+      }
+      void loadInventoryItems()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      void toast.fire({
+        icon: 'error',
+        title: message || (isEditing ? '更新捐贈單失敗，請稍後再試。' : '建立捐贈單失敗，請稍後再試。'),
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h1 className="mt-0">捐贈管理</h1>
+        <p className="mt-2 text-slate-500">建立捐贈單，並可一次選擇多個品項。</p>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯捐贈單' : '新增捐贈單'}</h2>
+        <div className="mt-4 grid gap-3">
+          <div className="grid gap-2 md:grid-cols-2">
+            <label className="grid gap-2 font-bold">
+              <span className="inline-flex items-center gap-1">
+                受贈對象
+                <span className="text-red-600">*</span>
+              </span>
+              <input className={fieldClass} value={recipient} onChange={(event) => setRecipient(event.target.value)} />
+            </label>
+            <label className="grid gap-2 font-bold">
+              捐贈日期
+              <input className={fieldClass} type="date" value={donationDate} onChange={(event) => setDonationDate(event.target.value)} />
+            </label>
+          </div>
+          <label className="grid gap-2 font-bold">
+            用途
+            <input className={fieldClass} value={purpose} onChange={(event) => setPurpose(event.target.value)} />
+          </label>
+          <label className="grid gap-2 font-bold">
+            備註
+            <input className={fieldClass} value={memo} onChange={(event) => setMemo(event.target.value)} />
+          </label>
+        </div>
+
+        <div className="mt-6">
+          <div className="flex items-center justify-between">
+            <h3 className="m-0 text-base font-bold">捐贈品項</h3>
+          </div>
+
+          <div className="mt-3 grid gap-3">
+            {lines.map((line, index) => (
+              <div key={`donation-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
+                <label className="grid gap-2 font-bold">
+                  品項
+                  <select
+                    className={fieldClass}
+                    value={line.item_id}
+                    onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
+                  >
+                    <option value="">請選擇品項</option>
+                    {itemOptions.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {`${item.name || '未命名'} ${item.model ? `(${item.model})` : ''}`.trim()}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="grid gap-2 font-bold">
+                  數量
+                  <input
+                    className={fieldClass}
+                    type="number"
+                    min={1}
+                    value={line.quantity}
+                    onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
+                  />
+                </label>
+                <label className="grid gap-2 font-bold">
+                  備註
+                  <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                </label>
+                <div className="flex items-end">
+                  <button
+                    type="button"
+                    className="cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600"
+                    onClick={() => handleRemoveLine(index)}
+                    disabled={lines.length <= 1}
+                  >
+                    移除
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-xl px-4 py-3">
+            <button className={buttonClass} type="button" onClick={handleAddLine}>
+              新增品項
+            </button>
+            <button className={buttonClass} type="button" onClick={() => void handleSubmit()} disabled={submitting}>
+              {submitting ? (isEditing ? '更新中...' : '建立中...') : (isEditing ? '更新捐贈單' : '建立捐贈單')}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {loadError ? <p className="rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+    </>
+  )
+}

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -24,6 +24,7 @@ export function InventoryListPage() {
   const [keyword, setKeyword] = useState('')
   const [selectedKind, setSelectedKind] = useState('all')
   const [selectedCorrectionStatus, setSelectedCorrectionStatus] = useState<'all' | 'needs_fix'>('all')
+  const [showDonated, setShowDonated] = useState(false)
   const [pageSize, setPageSize] = useState(10)
   const [customPageSize, setCustomPageSize] = useState('10')
   const [currentPage, setCurrentPage] = useState(1)
@@ -34,7 +35,7 @@ export function InventoryListPage() {
       setLoading(true)
       setLoadError('')
       try {
-        const response = await fetch(apiUrl('/api/items'))
+        const response = await fetch(apiUrl(showDonated ? '/api/items?include_donated=true' : '/api/items'))
         if (!response.ok) {
           throw new Error('無法載入財產清單')
         }
@@ -48,7 +49,7 @@ export function InventoryListPage() {
     }
 
     void loadItems()
-  }, [])
+  }, [showDonated])
 
   const toKindLabel = (kind: string) => {
     if (!kind) {
@@ -206,6 +207,15 @@ export function InventoryListPage() {
             <option value="needs_fix">僅顯示待修正資料</option>
           </select>
 
+          <label className="mt-1 inline-flex items-center gap-2 font-bold">
+            <input
+              type="checkbox"
+              checked={showDonated}
+              onChange={(event) => setShowDonated(event.target.checked)}
+            />
+            顯示已捐贈資料
+          </label>
+
           <div className="grid gap-2">
             <span className="font-bold">每頁筆數</span>
             <div className="flex flex-wrap gap-2">
@@ -250,7 +260,7 @@ export function InventoryListPage() {
               <table className="mt-2 w-full table-fixed border-collapse bg-white">
                 <thead>
                   <tr>
-                    {['#', '類別', '財產編號', '品名', '型號', '規格', '單位', '購置日期', '放置地點', '保管人', '操作'].map((header) => (
+                    {['#', '類別', '財產編號', '品名', '型號', '規格', '單位', '購置日期', '放置地點', '保管人', '捐贈狀態', '操作'].map((header) => (
                       <th key={header} className={tableHeaderClass}>{header}</th>
                     ))}
                   </tr>
@@ -258,7 +268,7 @@ export function InventoryListPage() {
                 <tbody>
                   {paginatedItems.length === 0 ? (
                     <tr>
-                      <td colSpan={11} className="border border-slate-200 p-2 text-center text-slate-500">
+                      <td colSpan={12} className="border border-slate-200 p-2 text-center text-slate-500">
                         查無符合條件的財產資料
                       </td>
                     </tr>
@@ -277,6 +287,17 @@ export function InventoryListPage() {
                         <td className={`${tableCellClass} whitespace-nowrap`}>{item.purchase_date ?? '--'}</td>
                         <td className={tableCellClass}>{item.location || '--'}</td>
                         <td className={tableCellClass}>{item.keeper || '--'}</td>
+                        <td className={`${tableCellClass} whitespace-nowrap`}>
+                          {item.donated_at ? (
+                            <span className="inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-700">
+                              已捐贈
+                            </span>
+                          ) : (
+                            <span className="inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-700">
+                              可使用
+                            </span>
+                          )}
+                        </td>
                         <td className={`${tableCellClass} whitespace-nowrap`}>
                           <button
                             type="button"

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -17,6 +17,8 @@ export type InventoryItem = {
   location: string
   memo: string
   keeper: string
+  donated_at?: string | null
+  donation_request_id?: number | null
 }
 
 export type IssueItem = {
@@ -58,4 +60,24 @@ export type BorrowRequest = {
   status: string
   memo: string
   items: BorrowItem[]
+}
+
+export type DonationItem = {
+  id: number
+  item_id: number
+  quantity: number
+  note: string
+  item_name?: string | null
+  item_model?: string | null
+}
+
+export type DonationRequest = {
+  id: number
+  donor: string
+  department: string
+  recipient: string
+  purpose: string
+  donation_date: string | null
+  memo: string
+  items: DonationItem[]
 }


### PR DESCRIPTION
## Summary
- Add a new donation workflow with dedicated backend APIs and frontend pages for list/create/edit
- Extend inventory records with donation metadata and hide donated items from default item queries
- Enforce donation validation (`recipient` required, positive quantities, unavailable donated items)
- Update navigation, routes, shared types, and docs for donation endpoints and `include_donated`
- Add inventory UI toggle to show/hide donated items and display donation status

## Testing
- `uv run python -m compileall backend/main.py backend/db.py`
- Frontend lint/tests not run in this environment (`node`/`npm` unavailable)