### PR TITLE
POS：新增掃描查詢並補齊庫存財產編號欄位

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,6 +4,7 @@
 
 - 提供 Dashboard 與庫存 CRUD API
 - 提供 Excel（`.xlsx`）批次匯入 API
+- 提供 POS 結帳與庫存異動 API（不含金流）
 - 管理 XLSX 資料檔與資料表初始化
 - 記錄操作日誌（create/read/update/delete/import/purge）
 - 提供前端靜態資源（當 `frontend/dist` 存在時）
@@ -77,6 +78,22 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 - `POST /api/donations`：建立捐贈單（`recipient` 必填）
 - `PUT /api/donations/{request_id}`：更新捐贈單（`recipient` 必填）
 - `DELETE /api/donations/{request_id}`：刪除捐贈單，解除關聯品項的捐贈標記
+
+### POS（不含金流）
+
+- `POST /api/pos/checkout`：建立 POS 訂單並寫入庫存異動
+- `GET /api/pos/orders`：列出 POS 訂單
+- `GET /api/pos/orders/{order_id}`：取得單筆 POS 訂單
+- `GET /api/pos/stock`：查看各品項庫存餘額
+- `PUT /api/pos/stock/{item_id}`：設定單一品項庫存數量
+- `GET /api/pos/stock-movements`：查看庫存異動台帳
+
+`order_type` 支援：
+- `sale`：一般銷售（扣庫）
+- `issue`：領用（扣庫，並自動建立 issue request）
+- `borrow`：借用（扣庫，並自動建立 borrow request）
+- `issue_restock`：領用回補（加庫）
+- `borrow_return`：借用歸還（加庫；可帶 `borrow_request_id` 直接回填借用單狀態）
 
 ### 批次匯入
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -95,6 +95,50 @@ SHEETS: dict[str, list[str]] = {
         "quantity",
         "note",
     ],
+    "pos_orders": [
+        "id",
+        "order_no",
+        "order_type",
+        "customer_name",
+        "operator_name",
+        "purpose",
+        "request_ref_type",
+        "request_ref_id",
+        "subtotal",
+        "discount_total",
+        "total",
+        "note",
+        "created_at",
+    ],
+    "pos_order_items": [
+        "id",
+        "order_id",
+        "item_id",
+        "item_name",
+        "item_model",
+        "quantity",
+        "unit_price",
+        "discount",
+        "line_total",
+        "note",
+    ],
+    "stock_balances": [
+        "item_id",
+        "quantity",
+        "updated_at",
+    ],
+    "stock_movements": [
+        "id",
+        "order_id",
+        "order_no",
+        "item_id",
+        "delta",
+        "balance_after",
+        "reason",
+        "related_type",
+        "related_id",
+        "created_at",
+    ],
 }
 
 STRING_FIELDS: dict[str, list[str]] = {
@@ -122,6 +166,18 @@ STRING_FIELDS: dict[str, list[str]] = {
         "created_at",
     ],
     "donation_items": ["note"],
+    "pos_orders": [
+        "order_no",
+        "order_type",
+        "customer_name",
+        "operator_name",
+        "purpose",
+        "request_ref_type",
+        "note",
+        "created_at",
+    ],
+    "pos_order_items": ["item_name", "item_model", "note"],
+    "stock_movements": ["order_no", "reason", "related_type", "created_at"],
 }
 
 
@@ -1097,3 +1153,443 @@ def delete_borrow_request(request_id: int) -> bool:
         _write_rows(item_ws, SHEETS["borrow_items"], remaining_items)
         wb.save(DB_PATH)
         return True
+
+
+POS_ORDER_TYPES_DECREASE_STOCK = {"sale", "issue", "borrow"}
+POS_ORDER_TYPES_INCREASE_STOCK = {"issue_restock", "borrow_return"}
+POS_ORDER_TYPES = POS_ORDER_TYPES_DECREASE_STOCK | POS_ORDER_TYPES_INCREASE_STOCK
+
+
+def _make_pos_order_no(order_rows: list[dict[str, Any]]) -> str:
+    date_sn = _date_sn()
+    prefix = f"POS-{date_sn}-"
+    max_seq = 0
+    for row in order_rows:
+        order_no = str(row.get("order_no", ""))
+        if not order_no.startswith(prefix):
+            continue
+        seq = _to_int(order_no.replace(prefix, ""), default=0)
+        if seq > max_seq:
+            max_seq = seq
+    return f"{prefix}{max_seq + 1:04d}"
+
+
+def _active_inventory_map(inventory_rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    return {
+        _to_int(row.get("id")): row
+        for row in inventory_rows
+        if _is_blank(row.get("deleted_at"))
+    }
+
+
+def _stock_balance_map(stock_rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    return {
+        _to_int(row.get("item_id")): row
+        for row in stock_rows
+        if not _is_blank(row.get("item_id"))
+    }
+
+
+def _apply_stock_changes_locked(
+    *,
+    inventory_rows: list[dict[str, Any]],
+    stock_rows: list[dict[str, Any]],
+    stock_changes: dict[int, int],
+) -> dict[int, int]:
+    inventory_map = _active_inventory_map(inventory_rows)
+    stock_map = _stock_balance_map(stock_rows)
+
+    for item_id, delta in stock_changes.items():
+        if item_id not in inventory_map:
+            raise ValueError(f"item_id {item_id} not found")
+        current_qty = _to_int(stock_map.get(item_id, {}).get("quantity"), default=0)
+        next_qty = current_qty + delta
+        if next_qty < 0:
+            raise ValueError(f"item_id {item_id} stock is insufficient")
+
+    now = _now_str()
+    balances_after: dict[int, int] = {}
+    for item_id, delta in stock_changes.items():
+        current_qty = _to_int(stock_map.get(item_id, {}).get("quantity"), default=0)
+        next_qty = current_qty + delta
+        row = stock_map.get(item_id)
+        if row is None:
+            row = {"item_id": item_id, "quantity": next_qty, "updated_at": now}
+            stock_rows.append(row)
+            stock_map[item_id] = row
+        else:
+            row["quantity"] = next_qty
+            row["updated_at"] = now
+        balances_after[item_id] = next_qty
+
+    return balances_after
+
+
+def _create_issue_request_locked(
+    *,
+    request_rows: list[dict[str, Any]],
+    item_rows: list[dict[str, Any]],
+    request_data: dict[str, Any],
+    items: list[dict[str, Any]],
+) -> int:
+    request_id = _next_id(request_rows)
+    request_rows.append(
+        {
+            "id": request_id,
+            "requester": request_data["requester"],
+            "department": request_data["department"],
+            "purpose": request_data["purpose"],
+            "request_date": request_data["request_date"],
+            "memo": request_data["memo"],
+            "created_at": _now_str(),
+        }
+    )
+    next_item_id = _next_id(item_rows)
+    for index, item in enumerate(items):
+        item_rows.append(
+            {
+                "id": next_item_id + index,
+                "request_id": request_id,
+                "item_id": item["item_id"],
+                "quantity": item["quantity"],
+                "note": item.get("note", ""),
+            }
+        )
+    return request_id
+
+
+def _create_borrow_request_locked(
+    *,
+    request_rows: list[dict[str, Any]],
+    item_rows: list[dict[str, Any]],
+    request_data: dict[str, Any],
+    items: list[dict[str, Any]],
+) -> int:
+    request_id = _next_id(request_rows)
+    request_rows.append(
+        {
+            "id": request_id,
+            "borrower": request_data["borrower"],
+            "department": request_data["department"],
+            "purpose": request_data["purpose"],
+            "borrow_date": request_data["borrow_date"],
+            "due_date": request_data["due_date"],
+            "return_date": request_data["return_date"],
+            "status": request_data["status"],
+            "memo": request_data["memo"],
+            "created_at": _now_str(),
+        }
+    )
+    next_item_id = _next_id(item_rows)
+    for index, item in enumerate(items):
+        item_rows.append(
+            {
+                "id": next_item_id + index,
+                "request_id": request_id,
+                "item_id": item["item_id"],
+                "quantity": item["quantity"],
+                "note": item.get("note", ""),
+            }
+        )
+    return request_id
+
+
+def _mark_borrow_request_returned_locked(
+    *,
+    request_rows: list[dict[str, Any]],
+    request_id: int,
+) -> None:
+    for row in request_rows:
+        if _to_int(row.get("id")) != request_id:
+            continue
+        row["status"] = "returned"
+        row["return_date"] = datetime.now().strftime("%Y/%m/%d")
+        return
+    raise ValueError(f"borrow_request_id {request_id} not found")
+
+
+def create_pos_order(order_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
+    order_type = str(order_data.get("order_type", "")).strip()
+    if order_type not in POS_ORDER_TYPES:
+        raise ValueError("invalid order_type")
+    if not items:
+        raise ValueError("items is required")
+
+    stock_changes: dict[int, int] = {}
+    subtotal = 0.0
+    discount_total = 0.0
+    normalized_items: list[dict[str, Any]] = []
+    for item in items:
+        item_id = _to_int(item.get("item_id"))
+        quantity = _to_int(item.get("quantity"))
+        if item_id <= 0:
+            raise ValueError("item_id is required")
+        if quantity <= 0:
+            raise ValueError("quantity must be greater than 0")
+        unit_price = float(item.get("unit_price", 0))
+        discount = float(item.get("discount", 0))
+        if unit_price < 0:
+            raise ValueError("unit_price cannot be negative")
+        if discount < 0:
+            raise ValueError("discount cannot be negative")
+        line_amount = unit_price * quantity
+        if discount > line_amount:
+            raise ValueError("discount cannot exceed line amount")
+        line_total = line_amount - discount
+        subtotal += line_amount
+        discount_total += discount
+        delta = -quantity if order_type in POS_ORDER_TYPES_DECREASE_STOCK else quantity
+        stock_changes[item_id] = stock_changes.get(item_id, 0) + delta
+        normalized_items.append(
+            {
+                "item_id": item_id,
+                "quantity": quantity,
+                "unit_price": unit_price,
+                "discount": discount,
+                "line_total": line_total,
+                "note": item.get("note", ""),
+            }
+        )
+
+    with _locked_workbook() as wb:
+        pos_orders_ws = wb["pos_orders"]
+        pos_order_items_ws = wb["pos_order_items"]
+        stock_balances_ws = wb["stock_balances"]
+        stock_movements_ws = wb["stock_movements"]
+        inventory_ws = wb["inventory_items"]
+        issue_requests_ws = wb["issue_requests"]
+        issue_items_ws = wb["issue_items"]
+        borrow_requests_ws = wb["borrow_requests"]
+        borrow_items_ws = wb["borrow_items"]
+
+        pos_orders = _read_rows(pos_orders_ws)
+        pos_order_items = _read_rows(pos_order_items_ws)
+        stock_balances = _read_rows(stock_balances_ws)
+        stock_movements = _read_rows(stock_movements_ws)
+        inventory_rows = _read_rows(inventory_ws)
+        issue_request_rows = _read_rows(issue_requests_ws)
+        issue_item_rows = _read_rows(issue_items_ws)
+        borrow_request_rows = _read_rows(borrow_requests_ws)
+        borrow_item_rows = _read_rows(borrow_items_ws)
+        inventory_map = _active_inventory_map(inventory_rows)
+
+        for line in normalized_items:
+            if line["item_id"] not in inventory_map:
+                raise ValueError(f"item_id {line['item_id']} not found")
+            details = inventory_map[line["item_id"]]
+            line["item_name"] = details.get("name", "")
+            line["item_model"] = details.get("model", "")
+
+        balances_after = _apply_stock_changes_locked(
+            inventory_rows=inventory_rows,
+            stock_rows=stock_balances,
+            stock_changes=stock_changes,
+        )
+
+        request_ref_type = ""
+        request_ref_id: int | None = None
+        today = datetime.now().strftime("%Y/%m/%d")
+        if order_type == "issue":
+            request_ref_type = "issue_request"
+            request_ref_id = _create_issue_request_locked(
+                request_rows=issue_request_rows,
+                item_rows=issue_item_rows,
+                request_data={
+                    "requester": str(order_data.get("customer_name", "")).strip() or "POS",
+                    "department": str(order_data.get("department", "")).strip(),
+                    "purpose": str(order_data.get("purpose", "")).strip() or "POS 領用",
+                    "request_date": today,
+                    "memo": str(order_data.get("note", "")).strip(),
+                },
+                items=normalized_items,
+            )
+        elif order_type == "borrow":
+            request_ref_type = "borrow_request"
+            request_ref_id = _create_borrow_request_locked(
+                request_rows=borrow_request_rows,
+                item_rows=borrow_item_rows,
+                request_data={
+                    "borrower": str(order_data.get("customer_name", "")).strip() or "POS",
+                    "department": str(order_data.get("department", "")).strip(),
+                    "purpose": str(order_data.get("purpose", "")).strip() or "POS 借用",
+                    "borrow_date": today,
+                    "due_date": str(order_data.get("due_date", "")).strip(),
+                    "return_date": "",
+                    "status": "borrowed",
+                    "memo": str(order_data.get("note", "")).strip(),
+                },
+                items=normalized_items,
+            )
+        elif order_type == "borrow_return":
+            ref_id = _to_int(order_data.get("borrow_request_id"))
+            if ref_id > 0:
+                _mark_borrow_request_returned_locked(request_rows=borrow_request_rows, request_id=ref_id)
+                request_ref_type = "borrow_request"
+                request_ref_id = ref_id
+            else:
+                request_ref_type = "borrow_return"
+        elif order_type == "issue_restock":
+            request_ref_type = "issue_restock"
+
+        order_id = _next_id(pos_orders)
+        order_no = _make_pos_order_no(pos_orders)
+        total = subtotal - discount_total
+        pos_orders.append(
+            {
+                "id": order_id,
+                "order_no": order_no,
+                "order_type": order_type,
+                "customer_name": str(order_data.get("customer_name", "")).strip(),
+                "operator_name": str(order_data.get("operator_name", "")).strip(),
+                "purpose": str(order_data.get("purpose", "")).strip(),
+                "request_ref_type": request_ref_type,
+                "request_ref_id": request_ref_id if request_ref_id is not None else "",
+                "subtotal": round(subtotal, 2),
+                "discount_total": round(discount_total, 2),
+                "total": round(total, 2),
+                "note": str(order_data.get("note", "")).strip(),
+                "created_at": _now_str(),
+            }
+        )
+
+        next_item_id = _next_id(pos_order_items)
+        next_movement_id = _next_id(stock_movements)
+        for index, line in enumerate(normalized_items):
+            pos_order_items.append(
+                {
+                    "id": next_item_id + index,
+                    "order_id": order_id,
+                    "item_id": line["item_id"],
+                    "item_name": line["item_name"],
+                    "item_model": line["item_model"],
+                    "quantity": line["quantity"],
+                    "unit_price": line["unit_price"],
+                    "discount": round(line["discount"], 2),
+                    "line_total": round(line["line_total"], 2),
+                    "note": line["note"],
+                }
+            )
+            delta = -line["quantity"] if order_type in POS_ORDER_TYPES_DECREASE_STOCK else line["quantity"]
+            stock_movements.append(
+                {
+                    "id": next_movement_id + index,
+                    "order_id": order_id,
+                    "order_no": order_no,
+                    "item_id": line["item_id"],
+                    "delta": delta,
+                    "balance_after": balances_after[line["item_id"]],
+                    "reason": order_type,
+                    "related_type": request_ref_type,
+                    "related_id": request_ref_id if request_ref_id is not None else "",
+                    "created_at": _now_str(),
+                }
+            )
+
+        _write_rows(pos_orders_ws, SHEETS["pos_orders"], pos_orders)
+        _write_rows(pos_order_items_ws, SHEETS["pos_order_items"], pos_order_items)
+        _write_rows(stock_balances_ws, SHEETS["stock_balances"], stock_balances)
+        _write_rows(stock_movements_ws, SHEETS["stock_movements"], stock_movements)
+        _write_rows(issue_requests_ws, SHEETS["issue_requests"], issue_request_rows)
+        _write_rows(issue_items_ws, SHEETS["issue_items"], issue_item_rows)
+        _write_rows(borrow_requests_ws, SHEETS["borrow_requests"], borrow_request_rows)
+        _write_rows(borrow_items_ws, SHEETS["borrow_items"], borrow_item_rows)
+        wb.save(DB_PATH)
+        return order_id
+
+
+def list_pos_orders() -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["pos_orders"])
+    return sorted(rows, key=lambda row: _to_int(row.get("id")), reverse=True)
+
+
+def get_pos_order(order_id: int) -> dict[str, Any] | None:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["pos_orders"])
+    for row in rows:
+        if _to_int(row.get("id")) == order_id:
+            return row
+    return None
+
+
+def list_pos_order_items(order_id: int) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["pos_order_items"])
+    results = [row for row in rows if _to_int(row.get("order_id")) == order_id]
+    return sorted(results, key=lambda row: _to_int(row.get("id")))
+
+
+def list_stock_balances() -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        inventory_rows = _read_rows(wb["inventory_items"])
+        stock_rows = _read_rows(wb["stock_balances"])
+
+    stock_map = _stock_balance_map(stock_rows)
+    results = []
+    for item_id, item in _active_inventory_map(inventory_rows).items():
+        quantity = _to_int(stock_map.get(item_id, {}).get("quantity"), default=0)
+        results.append(
+            {
+                "item_id": item_id,
+                "item_name": item.get("name", ""),
+                "item_model": item.get("model", ""),
+                "quantity": quantity,
+            }
+        )
+    return sorted(results, key=lambda row: _to_int(row.get("item_id")))
+
+
+def set_stock_quantity(item_id: int, quantity: int) -> bool:
+    if quantity < 0:
+        raise ValueError("quantity cannot be negative")
+
+    with _locked_workbook() as wb:
+        inventory_rows = _read_rows(wb["inventory_items"])
+        stock_ws = wb["stock_balances"]
+        stock_rows = _read_rows(stock_ws)
+        inventory_map = _active_inventory_map(inventory_rows)
+        if item_id not in inventory_map:
+            return False
+
+        stock_map = _stock_balance_map(stock_rows)
+        row = stock_map.get(item_id)
+        now = _now_str()
+        if row is None:
+            stock_rows.append({"item_id": item_id, "quantity": quantity, "updated_at": now})
+        else:
+            row["quantity"] = quantity
+            row["updated_at"] = now
+        _write_rows(stock_ws, SHEETS["stock_balances"], stock_rows)
+        wb.save(DB_PATH)
+        return True
+
+
+def list_stock_movements(limit: int = 200) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        movement_rows = _read_rows(wb["stock_movements"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+
+    inventory_map = _active_inventory_map(inventory_rows)
+    results = []
+    for row in movement_rows:
+        item_id = _to_int(row.get("item_id"))
+        item = inventory_map.get(item_id, {})
+        results.append(
+            {
+                "id": row.get("id"),
+                "order_id": row.get("order_id"),
+                "order_no": row.get("order_no"),
+                "item_id": item_id,
+                "item_name": item.get("name", ""),
+                "item_model": item.get("model", ""),
+                "delta": _to_int(row.get("delta")),
+                "balance_after": _to_int(row.get("balance_after")),
+                "reason": row.get("reason", ""),
+                "related_type": row.get("related_type", ""),
+                "related_id": _to_int(row.get("related_id")),
+                "created_at": row.get("created_at", ""),
+            }
+        )
+    sorted_rows = sorted(results, key=lambda row: _to_int(row.get("id")), reverse=True)
+    safe_limit = max(1, min(limit, 1000))
+    return sorted_rows[:safe_limit]

--- a/backend/db.py
+++ b/backend/db.py
@@ -1539,6 +1539,7 @@ def list_stock_balances() -> list[dict[str, Any]]:
                 "item_id": item_id,
                 "item_name": _to_str(item.get("name")),
                 "item_model": _to_str(item.get("model")),
+                "property_number": _to_str(item.get("property_number")),
                 "quantity": quantity,
             }
         )

--- a/backend/db.py
+++ b/backend/db.py
@@ -196,6 +196,12 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _to_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return value if isinstance(value, str) else str(value)
+
+
 def _is_blank(value: Any) -> bool:
     return value is None or str(value).strip() == ""
 
@@ -1531,8 +1537,8 @@ def list_stock_balances() -> list[dict[str, Any]]:
         results.append(
             {
                 "item_id": item_id,
-                "item_name": item.get("name", ""),
-                "item_model": item.get("model", ""),
+                "item_name": _to_str(item.get("name")),
+                "item_model": _to_str(item.get("model")),
                 "quantity": quantity,
             }
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -223,6 +223,7 @@ class PosStockBalance(BaseModel):
     item_id: int
     item_name: str = ""
     item_model: str = ""
+    property_number: str = ""
     quantity: int = 0
 
 
@@ -461,6 +462,7 @@ def row_to_pos_stock_balance(row) -> PosStockBalance:
         item_id=int(row.get("item_id", 0)),
         item_name=_coerce_str(row.get("item_name")),
         item_model=_coerce_str(row.get("item_model")),
+        property_number=_coerce_str(row.get("property_number")),
         quantity=int(row.get("quantity", 0)),
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from db import (
     create_issue_request,
     create_borrow_request,
     create_donation_request,
+    create_pos_order,
     delete_item,
     delete_issue_request,
     delete_borrow_request,
@@ -22,6 +23,7 @@ from db import (
     get_borrow_request,
     get_donation_request,
     get_pending_fix_count,
+    get_pos_order,
     init_db,
     list_issue_items,
     list_issue_requests,
@@ -30,8 +32,13 @@ from db import (
     list_donation_items,
     list_donation_requests,
     list_items,
+    list_pos_order_items,
+    list_pos_orders,
+    list_stock_balances,
+    list_stock_movements,
     log_inventory_action,
     purge_soft_deleted_items,
+    set_stock_quantity,
     update_item,
     update_issue_request,
     update_borrow_request,
@@ -163,6 +170,81 @@ class DonationRequest(DonationRequestCreate):
     items: list[DonationItem]
 
 
+class PosCheckoutItem(BaseModel):
+    item_id: int
+    quantity: int = 1
+    unit_price: float = 0
+    discount: float = 0
+    note: str = ""
+
+
+class PosCheckoutRequest(BaseModel):
+    order_type: str = "sale"
+    customer_name: str = ""
+    operator_name: str = ""
+    department: str = ""
+    purpose: str = ""
+    note: str = ""
+    due_date: date | None = None
+    borrow_request_id: int | None = None
+    items: list[PosCheckoutItem] = Field(default_factory=list)
+
+
+class PosOrderItem(BaseModel):
+    id: int
+    item_id: int
+    item_name: str = ""
+    item_model: str = ""
+    quantity: int = 1
+    unit_price: float = 0
+    discount: float = 0
+    line_total: float = 0
+    note: str = ""
+
+
+class PosOrder(BaseModel):
+    id: int
+    order_no: str
+    order_type: str
+    customer_name: str = ""
+    operator_name: str = ""
+    purpose: str = ""
+    request_ref_type: str = ""
+    request_ref_id: int | None = None
+    subtotal: float = 0
+    discount_total: float = 0
+    total: float = 0
+    note: str = ""
+    created_at: datetime | None = None
+    items: list[PosOrderItem] = Field(default_factory=list)
+
+
+class PosStockBalance(BaseModel):
+    item_id: int
+    item_name: str = ""
+    item_model: str = ""
+    quantity: int = 0
+
+
+class PosStockSetRequest(BaseModel):
+    quantity: int
+
+
+class PosStockMovement(BaseModel):
+    id: int
+    order_id: int
+    order_no: str = ""
+    item_id: int
+    item_name: str = ""
+    item_model: str = ""
+    delta: int
+    balance_after: int
+    reason: str = ""
+    related_type: str = ""
+    related_id: int | None = None
+    created_at: datetime | None = None
+
+
 class ImportErrorDetail(BaseModel):
     row: int
     message: str
@@ -240,6 +322,19 @@ def _coerce_str(value) -> str:
     return value if isinstance(value, str) else "" if value is None else str(value)
 
 
+def pos_checkout_to_db_payload(request: PosCheckoutRequest) -> dict:
+    return {
+        "order_type": request.order_type.strip(),
+        "customer_name": request.customer_name,
+        "operator_name": request.operator_name,
+        "department": request.department,
+        "purpose": request.purpose,
+        "note": request.note,
+        "due_date": _format_date(request.due_date),
+        "borrow_request_id": request.borrow_request_id or "",
+    }
+
+
 def row_to_item(row) -> InventoryItem:
     purchase_date_value = row["purchase_date"]
     parsed_date = _parse_purchase_date(purchase_date_value) if purchase_date_value else None
@@ -296,6 +391,68 @@ def row_to_donation_item(row) -> DonationItem:
         note=_coerce_str(row["note"]),
         item_name=row["item_name"],
         item_model=row["item_model"],
+    )
+
+
+def row_to_pos_item(row) -> PosOrderItem:
+    return PosOrderItem(
+        id=int(row.get("id", 0)),
+        item_id=int(row.get("item_id", 0)),
+        item_name=_coerce_str(row.get("item_name")),
+        item_model=_coerce_str(row.get("item_model")),
+        quantity=int(row.get("quantity", 0)),
+        unit_price=float(row.get("unit_price", 0) or 0),
+        discount=float(row.get("discount", 0) or 0),
+        line_total=float(row.get("line_total", 0) or 0),
+        note=_coerce_str(row.get("note")),
+    )
+
+
+def row_to_pos_order(row, items: list[PosOrderItem]) -> PosOrder:
+    created_at = _parse_datetime(_coerce_str(row.get("created_at")))
+    request_ref_id_raw = row.get("request_ref_id")
+    try:
+        request_ref_id = int(request_ref_id_raw) if request_ref_id_raw not in ("", None) else None
+    except (TypeError, ValueError):
+        request_ref_id = None
+    return PosOrder(
+        id=int(row.get("id", 0)),
+        order_no=_coerce_str(row.get("order_no")),
+        order_type=_coerce_str(row.get("order_type")),
+        customer_name=_coerce_str(row.get("customer_name")),
+        operator_name=_coerce_str(row.get("operator_name")),
+        purpose=_coerce_str(row.get("purpose")),
+        request_ref_type=_coerce_str(row.get("request_ref_type")),
+        request_ref_id=request_ref_id,
+        subtotal=float(row.get("subtotal", 0) or 0),
+        discount_total=float(row.get("discount_total", 0) or 0),
+        total=float(row.get("total", 0) or 0),
+        note=_coerce_str(row.get("note")),
+        created_at=created_at,
+        items=items,
+    )
+
+
+def row_to_pos_stock_movement(row) -> PosStockMovement:
+    created_at = _parse_datetime(_coerce_str(row.get("created_at")))
+    related_id_raw = row.get("related_id")
+    try:
+        related_id = int(related_id_raw) if related_id_raw not in ("", None) else None
+    except (TypeError, ValueError):
+        related_id = None
+    return PosStockMovement(
+        id=int(row.get("id", 0)),
+        order_id=int(row.get("order_id", 0)),
+        order_no=_coerce_str(row.get("order_no")),
+        item_id=int(row.get("item_id", 0)),
+        item_name=_coerce_str(row.get("item_name")),
+        item_model=_coerce_str(row.get("item_model")),
+        delta=int(row.get("delta", 0)),
+        balance_after=int(row.get("balance_after", 0)),
+        reason=_coerce_str(row.get("reason")),
+        related_type=_coerce_str(row.get("related_type")),
+        related_id=related_id,
+        created_at=created_at,
     )
 
 
@@ -836,6 +993,104 @@ def delete_donation_request_api(request_id: int):
         raise HTTPException(status_code=404, detail="Donation request not found")
     log_inventory_action(action="delete", entity="donation_request", entity_id=request_id)
     return {"success": True}
+
+
+@app.post("/api/pos/checkout", response_model=PosOrder, response_model_by_alias=False)
+def checkout_pos_order_api(request: PosCheckoutRequest):
+    allowed_types = {"sale", "issue", "borrow", "issue_restock", "borrow_return"}
+    order_type = request.order_type.strip()
+    if order_type not in allowed_types:
+        raise HTTPException(status_code=400, detail="invalid order_type")
+    if not request.items:
+        raise HTTPException(status_code=400, detail="items is required")
+
+    for item in request.items:
+        if item.quantity <= 0:
+            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
+        if item.unit_price < 0:
+            raise HTTPException(status_code=400, detail="unit_price cannot be negative")
+        if item.discount < 0:
+            raise HTTPException(status_code=400, detail="discount cannot be negative")
+        if item.discount > item.unit_price * item.quantity:
+            raise HTTPException(status_code=400, detail="discount cannot exceed line amount")
+
+    try:
+        order_id = create_pos_order(
+            pos_checkout_to_db_payload(request),
+            [item.model_dump() for item in request.items],
+        )
+    except ValueError as exc:
+        log_inventory_action(
+            action="create",
+            entity="pos_order",
+            status="failed",
+            detail={"reason": str(exc), "order_type": order_type},
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    row = get_pos_order(order_id)
+    if row is None:
+        log_inventory_action(
+            action="create",
+            entity="pos_order",
+            entity_id=order_id,
+            status="failed",
+            detail={"reason": "POS order created but cannot be loaded"},
+        )
+        raise HTTPException(status_code=500, detail="POS order created but cannot be loaded")
+    items = [row_to_pos_item(item) for item in list_pos_order_items(order_id)]
+    log_inventory_action(action="create", entity="pos_order", entity_id=order_id, detail={"order_type": order_type})
+    return row_to_pos_order(row, items)
+
+
+@app.get("/api/pos/orders", response_model=list[PosOrder], response_model_by_alias=False)
+def list_pos_orders_api():
+    rows = list_pos_orders()
+    results = []
+    for row in rows:
+        items = [row_to_pos_item(item) for item in list_pos_order_items(int(row["id"]))]
+        results.append(row_to_pos_order(row, items))
+    log_inventory_action(action="read", entity="pos_order", detail={"count": len(results), "mode": "list"})
+    return results
+
+
+@app.get("/api/pos/orders/{order_id}", response_model=PosOrder, response_model_by_alias=False)
+def get_pos_order_api(order_id: int):
+    row = get_pos_order(order_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="POS order not found")
+    items = [row_to_pos_item(item) for item in list_pos_order_items(order_id)]
+    log_inventory_action(action="read", entity="pos_order", entity_id=order_id, detail={"mode": "single"})
+    return row_to_pos_order(row, items)
+
+
+@app.get("/api/pos/stock", response_model=list[PosStockBalance], response_model_by_alias=False)
+def list_pos_stock_api():
+    rows = list_stock_balances()
+    return [PosStockBalance(**row) for row in rows]
+
+
+@app.put("/api/pos/stock/{item_id}", response_model=PosStockBalance, response_model_by_alias=False)
+def set_pos_stock_api(item_id: int, request: PosStockSetRequest):
+    try:
+        updated = set_stock_quantity(item_id=item_id, quantity=request.quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if not updated:
+        raise HTTPException(status_code=404, detail="item not found")
+    row = next((stock for stock in list_stock_balances() if stock["item_id"] == item_id), None)
+    if row is None:
+        raise HTTPException(status_code=500, detail="stock updated but cannot be loaded")
+    log_inventory_action(action="update", entity="stock_balance", entity_id=item_id, detail={"quantity": request.quantity})
+    return PosStockBalance(**row)
+
+
+@app.get("/api/pos/stock-movements", response_model=list[PosStockMovement], response_model_by_alias=False)
+def list_pos_stock_movements_api(limit: int = 200):
+    rows = list_stock_movements(limit=limit)
+    log_inventory_action(action="read", entity="stock_movement", detail={"count": len(rows), "mode": "list", "limit": limit})
+    return [row_to_pos_stock_movement(row) for row in rows]
 
 
 @app.post("/api/items/import", response_model=ImportResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -456,6 +456,15 @@ def row_to_pos_stock_movement(row) -> PosStockMovement:
     )
 
 
+def row_to_pos_stock_balance(row) -> PosStockBalance:
+    return PosStockBalance(
+        item_id=int(row.get("item_id", 0)),
+        item_name=_coerce_str(row.get("item_name")),
+        item_model=_coerce_str(row.get("item_model")),
+        quantity=int(row.get("quantity", 0)),
+    )
+
+
 def issue_request_to_db_payload(request: IssueRequestCreate) -> dict:
     return {
         "requester": request.requester,
@@ -1067,7 +1076,7 @@ def get_pos_order_api(order_id: int):
 @app.get("/api/pos/stock", response_model=list[PosStockBalance], response_model_by_alias=False)
 def list_pos_stock_api():
     rows = list_stock_balances()
-    return [PosStockBalance(**row) for row in rows]
+    return [row_to_pos_stock_balance(row) for row in rows]
 
 
 @app.put("/api/pos/stock/{item_id}", response_model=PosStockBalance, response_model_by_alias=False)
@@ -1083,7 +1092,7 @@ def set_pos_stock_api(item_id: int, request: PosStockSetRequest):
     if row is None:
         raise HTTPException(status_code=500, detail="stock updated but cannot be loaded")
     log_inventory_action(action="update", entity="stock_balance", entity_id=item_id, detail={"quantity": request.quantity})
-    return PosStockBalance(**row)
+    return row_to_pos_stock_balance(row)
 
 
 @app.get("/api/pos/stock-movements", response_model=list[PosStockMovement], response_model_by_alias=False)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,9 @@ import { DonationPage } from './components/pages/DonationPage'
 import { DonationListPage } from './components/pages/DonationListPage'
 import { InventoryFormPage } from './components/pages/InventoryFormPage'
 import { InventoryListPage } from './components/pages/InventoryListPage'
+import { PosCheckoutPage } from './components/pages/PosCheckoutPage'
+import { PosOrdersPage } from './components/pages/PosOrdersPage'
+import { PosStockPage } from './components/pages/PosStockPage'
 import { IssueListPage } from './components/pages/IssueListPage'
 import { IssuePage } from './components/pages/IssuePage'
 import { UploadPage } from './components/pages/UploadPage'
@@ -62,6 +65,9 @@ function App() {
   const isDonationCreatePage = pathname === '/donations/new'
   const isInventoryPage = pathname === '/inventory'
   const isCreateInventoryPage = pathname === '/inventory/new'
+  const isPosCheckoutPage = pathname === '/pos/checkout'
+  const isPosOrdersPage = pathname === '/pos/orders'
+  const isPosStockPage = pathname === '/pos/stock'
   const editItemId = parseEditItemId(pathname)
   const editIssueRequestId = parseIssueRequestId(pathname)
   const editBorrowRequestId = parseBorrowRequestId(pathname)
@@ -85,6 +91,9 @@ function App() {
       {isUploadPage ? <UploadPage /> : null}
       {isCreateInventoryPage ? <InventoryFormPage /> : null}
       {editItemId ? <InventoryFormPage itemId={editItemId} /> : null}
+      {isPosCheckoutPage ? <PosCheckoutPage /> : null}
+      {isPosOrdersPage ? <PosOrdersPage /> : null}
+      {isPosStockPage ? <PosStockPage /> : null}
 
       {!isDashboardPage &&
       !isIssueListPage &&
@@ -99,10 +108,13 @@ function App() {
       !isUploadPage &&
       !isInventoryPage &&
       !isCreateInventoryPage &&
+      !isPosCheckoutPage &&
+      !isPosOrdersPage &&
+      !isPosStockPage &&
       !editItemId ? (
         <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
           <h1 className="mt-0">找不到頁面</h1>
-          <p className="mt-2 text-slate-500">請使用上方導覽前往 Dashboard、領用/借用/捐贈清單、財產清單、新增資料或上傳頁面。</p>
+          <p className="mt-2 text-slate-500">請使用上方導覽前往 Dashboard、POS、領用/借用/捐贈清單、財產清單、新增資料或上傳頁面。</p>
         </section>
       ) : null}
     </main>

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -19,9 +19,12 @@ export function TopNav({ pathname }: TopNavProps) {
   const isDonationCreatePage = pathname === '/donations/new'
   const isInventoryPage = pathname === '/inventory'
   const isCreatePage = pathname === '/inventory/new'
+  const isPosCheckoutPage = pathname === '/pos/checkout'
+  const isPosOrdersPage = pathname === '/pos/orders'
+  const isPosStockPage = pathname === '/pos/stock'
 
   return (
-    <nav className="flex items-start gap-3">
+    <nav className="flex flex-wrap items-start gap-3">
       <a className={isDashboardPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/">
         Dashboard
       </a>
@@ -30,6 +33,15 @@ export function TopNav({ pathname }: TopNavProps) {
       </a>
       <a className={isCreatePage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/inventory/new">
         新增庫存
+      </a>
+      <a className={isPosCheckoutPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/pos/checkout">
+        POS 結帳
+      </a>
+      <a className={isPosOrdersPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/pos/orders">
+        POS 訂單
+      </a>
+      <a className={isPosStockPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/pos/stock">
+        POS 庫存
       </a>
       <a className={isIssueListPage ? `${navLinkClass} ${activeNavLinkClass}` : navLinkClass} href="/issues">
         領用清單

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import type { InventoryItem } from './types'
@@ -15,6 +15,21 @@ const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
 const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
 const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
 const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const SCAN_MAX_KEY_INTERVAL_MS = 45
+const SCAN_MIN_LENGTH = 4
+
+const toast = Swal.mixin({
+  toast: true,
+  position: 'top-end',
+  showConfirmButton: false,
+  timer: 2600,
+  timerProgressBar: true,
+})
+
+type ScanBuffer = {
+  value: string
+  lastTs: number
+}
 
 export function InventoryListPage() {
   const [items, setItems] = useState<InventoryItem[]>([])
@@ -29,6 +44,10 @@ export function InventoryListPage() {
   const [customPageSize, setCustomPageSize] = useState('10')
   const [currentPage, setCurrentPage] = useState(1)
   const [deletingItemId, setDeletingItemId] = useState<number | null>(null)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const scanBufferRef = useRef<ScanBuffer>({ value: '', lastTs: 0 })
+  const lastInputSourceRef = useRef<'manual' | 'scan'>('manual')
+  const lastNotifiedScanKeywordRef = useRef('')
 
   useEffect(() => {
     const loadItems = async () => {
@@ -50,6 +69,10 @@ export function InventoryListPage() {
 
     void loadItems()
   }, [showDonated])
+
+  useEffect(() => {
+    searchInputRef.current?.focus()
+  }, [])
 
   const toKindLabel = (kind: string) => {
     if (!kind) {
@@ -107,6 +130,45 @@ export function InventoryListPage() {
       setCurrentPage(totalPages)
     }
   }, [currentPage, totalPages])
+
+  useEffect(() => {
+    if (lastInputSourceRef.current !== 'scan') {
+      return
+    }
+    const normalizedKeyword = keyword.trim()
+    if (!normalizedKeyword || filteredItems.length > 0 || lastNotifiedScanKeywordRef.current === normalizedKeyword) {
+      return
+    }
+    lastNotifiedScanKeywordRef.current = normalizedKeyword
+    void toast.fire({ icon: 'error', title: '查無此財產編號。' })
+  }, [filteredItems.length, keyword])
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const now = Date.now()
+    const buffer = scanBufferRef.current
+    const key = event.key
+
+    if (key === 'Enter') {
+      if (buffer.value.length >= SCAN_MIN_LENGTH) {
+        lastInputSourceRef.current = 'scan'
+      }
+      buffer.value = ''
+      buffer.lastTs = 0
+      return
+    }
+
+    if (key.length !== 1) {
+      return
+    }
+
+    lastInputSourceRef.current = 'manual'
+    if (buffer.lastTs > 0 && now - buffer.lastTs > SCAN_MAX_KEY_INTERVAL_MS) {
+      buffer.value = key
+    } else {
+      buffer.value += key
+    }
+    buffer.lastTs = now
+  }
 
   const handlePresetPageSize = (size: number) => {
     setPageSize(size)
@@ -166,7 +228,7 @@ export function InventoryListPage() {
     <>
       <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h1 className="mt-0">財產清單</h1>
-        <p className="mt-2 text-slate-500">可依財產編號、品名、型號、放置地點或保管人快速查詢。</p>
+        <p className="mt-2 text-slate-500">可依財產編號、品名、型號、放置地點或保管人快速查詢（支援掃描槍）。</p>
       </section>
 
       <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
@@ -177,10 +239,17 @@ export function InventoryListPage() {
           <input
             className={fieldClass}
             id="search-input"
+            ref={searchInputRef}
             type="search"
-            placeholder="輸入財產編號、品名、型號..."
+            placeholder="可輸入/掃描財產編號、品名、型號..."
             value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            onChange={(event) => {
+              if (lastInputSourceRef.current !== 'scan') {
+                lastInputSourceRef.current = 'manual'
+              }
+              setKeyword(event.target.value)
+            }}
           />
 
           <label htmlFor="kind-filter" className="font-bold">

--- a/frontend/src/components/pages/PosCheckoutPage.tsx
+++ b/frontend/src/components/pages/PosCheckoutPage.tsx
@@ -13,7 +13,7 @@ type CheckoutLine = {
 
 type StockLookup = Record<number, number>
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const fieldClass = 'min-w-0 w-full rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
 const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
 const removeButtonClass = 'cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600 disabled:cursor-not-allowed disabled:opacity-50'
 const emptyLine = (): CheckoutLine => ({ item_id: '', quantity: 1, unit_price: 0, discount: 0, note: '' })
@@ -376,8 +376,8 @@ export function PosCheckoutPage() {
                     </button>
                   </div>
 
-                  <div className="md:col-span-6">
-                    <p className="m-0 text-sm text-slate-500">
+                  <div className="min-w-0 md:col-span-6">
+                    <p className="m-0 break-all text-sm text-slate-500">
                       {selectedItem ? `${selectedItem.name || '未命名'}${selectedItem.model ? ` (${selectedItem.model})` : ''}` : '尚未選擇品項'}
                       {' · '}
                       目前庫存 {line.stockQuantity}

--- a/frontend/src/components/pages/PosCheckoutPage.tsx
+++ b/frontend/src/components/pages/PosCheckoutPage.tsx
@@ -5,6 +5,7 @@ import type { InventoryItem, PosOrder, PosStockBalance } from './types'
 
 type CheckoutLine = {
   item_id: number | ''
+  searchText: string
   quantity: number
   unit_price: number
   discount: number
@@ -16,7 +17,7 @@ type StockLookup = Record<number, number>
 const fieldClass = 'min-w-0 w-full rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
 const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
 const removeButtonClass = 'cursor-pointer rounded-[10px] border-none bg-red-600 px-3 py-2.5 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-red-300'
-const emptyLine = (): CheckoutLine => ({ item_id: '', quantity: 1, unit_price: 0, discount: 0, note: '' })
+const emptyLine = (): CheckoutLine => ({ item_id: '', searchText: '', quantity: 1, unit_price: 0, discount: 0, note: '' })
 const ORDER_TYPE_OPTIONS = [
   { value: 'sale', label: '一般銷售（扣庫）' },
   { value: 'issue', label: '領用（扣庫）' },
@@ -152,6 +153,34 @@ export function PosCheckoutPage() {
 
   const handleRemoveLine = (index: number) => {
     setLines((previousLines) => previousLines.filter((_, currentIndex) => currentIndex !== index))
+  }
+
+  const getFilteredOptionsForLine = (line: CheckoutLine) => {
+    const keyword = line.searchText.trim().toLowerCase()
+    const nextOptions = itemOptions.filter((option) => {
+      if (!keyword) {
+        return true
+      }
+
+      const item = itemOptionMap[option.value]
+      if (!item) {
+        return false
+      }
+
+      const name = item.name?.toLowerCase() || ''
+      const model = item.model?.toLowerCase() || ''
+      const propertyNumber = item.property_number?.toLowerCase() || ''
+      return name.includes(keyword) || model.includes(keyword) || propertyNumber.includes(keyword)
+    })
+
+    if (typeof line.item_id === 'number' && !nextOptions.some((option) => option.value === line.item_id)) {
+      const selectedOption = itemOptions.find((option) => option.value === line.item_id)
+      if (selectedOption) {
+        nextOptions.unshift(selectedOption)
+      }
+    }
+
+    return nextOptions
   }
 
   const validatePayload = (): boolean => {
@@ -310,18 +339,25 @@ export function PosCheckoutPage() {
             {computedLines.map((line, index) => {
               const selectedItem = typeof line.item_id === 'number' ? itemOptionMap[line.item_id] : null
               const stockWarning = DECREASE_ORDER_TYPES.has(orderType) && typeof line.item_id === 'number' && line.quantity > line.stockQuantity
+              const filteredOptions = getFilteredOptionsForLine(line)
 
               return (
                 <div key={`pos-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,1fr,1fr,2fr]">
                   <label className="grid gap-2 font-bold md:col-span-2">
                     品項
+                    <input
+                      className={fieldClass}
+                      value={line.searchText}
+                      onChange={(event) => handleLineChange(index, { searchText: event.target.value })}
+                      placeholder="輸入名稱、型號或財產編號"
+                    />
                     <select
                       className={fieldClass}
                       value={line.item_id}
                       onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
                     >
                       <option value="">請選擇品項</option>
-                      {itemOptions.map((option) => (
+                      {filteredOptions.map((option) => (
                         <option key={option.value} value={option.value}>{option.label}</option>
                       ))}
                     </select>

--- a/frontend/src/components/pages/PosCheckoutPage.tsx
+++ b/frontend/src/components/pages/PosCheckoutPage.tsx
@@ -15,7 +15,7 @@ type StockLookup = Record<number, number>
 
 const fieldClass = 'min-w-0 w-full rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
 const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
-const removeButtonClass = 'cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600 disabled:cursor-not-allowed disabled:opacity-50'
+const removeButtonClass = 'cursor-pointer rounded-[10px] border-none bg-red-600 px-3 py-2.5 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-red-300'
 const emptyLine = (): CheckoutLine => ({ item_id: '', quantity: 1, unit_price: 0, discount: 0, note: '' })
 const ORDER_TYPE_OPTIONS = [
   { value: 'sale', label: '一般銷售（扣庫）' },
@@ -312,7 +312,7 @@ export function PosCheckoutPage() {
               const stockWarning = DECREASE_ORDER_TYPES.has(orderType) && typeof line.item_id === 'number' && line.quantity > line.stockQuantity
 
               return (
-                <div key={`pos-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,1fr,1fr,2fr,auto]">
+                <div key={`pos-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,1fr,1fr,2fr]">
                   <label className="grid gap-2 font-bold md:col-span-2">
                     品項
                     <select
@@ -367,22 +367,22 @@ export function PosCheckoutPage() {
                     <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
                   </label>
 
-                  <div className="grid content-end gap-2">
-                    <div className="rounded-[10px] bg-slate-50 px-3 py-2 text-sm">
-                      行小計：{line.lineTotal.toFixed(2)}
-                    </div>
-                    <button type="button" className={removeButtonClass} onClick={() => handleRemoveLine(index)} disabled={lines.length <= 1}>
-                      移除
-                    </button>
-                  </div>
-
-                  <div className="min-w-0 md:col-span-6">
+                  <div className="min-w-0 md:col-span-5">
                     <p className="m-0 break-all text-sm text-slate-500">
                       {selectedItem ? `${selectedItem.name || '未命名'}${selectedItem.model ? ` (${selectedItem.model})` : ''}` : '尚未選擇品項'}
                       {' · '}
                       目前庫存 {line.stockQuantity}
                     </p>
                     {stockWarning ? <p className="m-0 mt-1 text-sm font-bold text-red-600">此筆數量超過目前庫存，送出時可能被後端拒絕。</p> : null}
+                    <div className="mt-2 rounded-[10px] bg-amber-50 px-3 py-2 text-base font-bold text-amber-800">
+                      行小計：{line.lineTotal.toFixed(2)}
+                    </div>
+                  </div>
+
+                  <div className="mt-1 flex justify-end md:col-span-5">
+                    <button type="button" className={removeButtonClass} onClick={() => handleRemoveLine(index)} disabled={lines.length <= 1}>
+                      移除
+                    </button>
                   </div>
                 </div>
               )

--- a/frontend/src/components/pages/PosCheckoutPage.tsx
+++ b/frontend/src/components/pages/PosCheckoutPage.tsx
@@ -1,0 +1,421 @@
+import { useEffect, useMemo, useState } from 'react'
+import Swal from 'sweetalert2'
+import { apiUrl } from '../../api'
+import type { InventoryItem, PosOrder, PosStockBalance } from './types'
+
+type CheckoutLine = {
+  item_id: number | ''
+  quantity: number
+  unit_price: number
+  discount: number
+  note: string
+}
+
+type StockLookup = Record<number, number>
+
+const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const removeButtonClass = 'cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600 disabled:cursor-not-allowed disabled:opacity-50'
+const emptyLine = (): CheckoutLine => ({ item_id: '', quantity: 1, unit_price: 0, discount: 0, note: '' })
+const ORDER_TYPE_OPTIONS = [
+  { value: 'sale', label: '一般銷售（扣庫）' },
+  { value: 'issue', label: '領用（扣庫）' },
+  { value: 'borrow', label: '借用（扣庫）' },
+  { value: 'issue_restock', label: '領用回補（加庫）' },
+  { value: 'borrow_return', label: '借用歸還（加庫）' },
+] as const
+const DECREASE_ORDER_TYPES = new Set(['sale', 'issue', 'borrow'])
+
+const toast = Swal.mixin({
+  toast: true,
+  position: 'top-end',
+  showConfirmButton: false,
+  timer: 2600,
+  timerProgressBar: true,
+})
+
+function toDisplayDatetime(value: string | null): string {
+  if (!value) {
+    return '--'
+  }
+
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleString('zh-TW', { hour12: false })
+  }
+
+  return value
+}
+
+export function PosCheckoutPage() {
+  const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([])
+  const [stockMap, setStockMap] = useState<StockLookup>({})
+  const [loadError, setLoadError] = useState('')
+
+  const [orderType, setOrderType] = useState<(typeof ORDER_TYPE_OPTIONS)[number]['value']>('sale')
+  const [customerName, setCustomerName] = useState('')
+  const [operatorName, setOperatorName] = useState('')
+  const [department, setDepartment] = useState('')
+  const [purpose, setPurpose] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [borrowRequestId, setBorrowRequestId] = useState('')
+  const [note, setNote] = useState('')
+  const [lines, setLines] = useState<CheckoutLine[]>([emptyLine()])
+  const [submitting, setSubmitting] = useState(false)
+  const [latestOrder, setLatestOrder] = useState<PosOrder | null>(null)
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoadError('')
+      try {
+        const [itemsResponse, stockResponse] = await Promise.all([
+          fetch(apiUrl('/api/items')),
+          fetch(apiUrl('/api/pos/stock')),
+        ])
+
+        if (!itemsResponse.ok || !stockResponse.ok) {
+          throw new Error('無法載入 POS 初始資料')
+        }
+
+        const itemsPayload = (await itemsResponse.json()) as InventoryItem[]
+        const stockPayload = (await stockResponse.json()) as PosStockBalance[]
+        const nextStockMap = stockPayload.reduce<StockLookup>((accumulator, stock) => {
+          accumulator[stock.item_id] = stock.quantity
+          return accumulator
+        }, {})
+
+        setInventoryItems(itemsPayload)
+        setStockMap(nextStockMap)
+      } catch {
+        setLoadError('目前無法讀取 POS 結帳資料，請稍後重試。')
+      }
+    }
+
+    void loadData()
+  }, [])
+
+  const itemOptionMap = useMemo(() => {
+    return inventoryItems.reduce<Record<number, InventoryItem>>((accumulator, item) => {
+      accumulator[item.id] = item
+      return accumulator
+    }, {})
+  }, [inventoryItems])
+
+  const itemOptions = useMemo(() => {
+    return inventoryItems.map((item) => {
+      const stock = stockMap[item.id] ?? 0
+      const title = `${item.name || '未命名'}${item.model ? ` (${item.model})` : ''}`
+      return {
+        value: item.id,
+        label: `${title}｜庫存 ${stock}`,
+      }
+    })
+  }, [inventoryItems, stockMap])
+
+  const computedLines = useMemo(() => {
+    return lines.map((line) => {
+      const quantity = Number.isFinite(line.quantity) ? line.quantity : 0
+      const unitPrice = Number.isFinite(line.unit_price) ? line.unit_price : 0
+      const discount = Number.isFinite(line.discount) ? line.discount : 0
+      const lineAmount = quantity * unitPrice
+      const lineTotal = lineAmount - discount
+      const stockQuantity = typeof line.item_id === 'number' ? stockMap[line.item_id] ?? 0 : 0
+
+      return {
+        ...line,
+        lineAmount,
+        lineTotal,
+        stockQuantity,
+      }
+    })
+  }, [lines, stockMap])
+
+  const totals = useMemo(() => {
+    return computedLines.reduce(
+      (accumulator, line) => {
+        accumulator.subtotal += line.lineAmount
+        accumulator.discountTotal += line.discount
+        accumulator.total += line.lineTotal
+        return accumulator
+      },
+      { subtotal: 0, discountTotal: 0, total: 0 }
+    )
+  }, [computedLines])
+
+  const handleLineChange = (index: number, patch: Partial<CheckoutLine>) => {
+    setLines((previousLines) => previousLines.map((line, currentIndex) => (index === currentIndex ? { ...line, ...patch } : line)))
+  }
+
+  const handleAddLine = () => {
+    setLines((previousLines) => [...previousLines, emptyLine()])
+  }
+
+  const handleRemoveLine = (index: number) => {
+    setLines((previousLines) => previousLines.filter((_, currentIndex) => currentIndex !== index))
+  }
+
+  const validatePayload = (): boolean => {
+    if (lines.length === 0) {
+      return false
+    }
+
+    const linesValid = lines.every((line) => {
+      if (line.item_id === '') {
+        return false
+      }
+      if (line.quantity <= 0) {
+        return false
+      }
+      if (line.unit_price < 0 || line.discount < 0) {
+        return false
+      }
+      return line.discount <= line.quantity * line.unit_price
+    })
+
+    if (!linesValid) {
+      return false
+    }
+
+    if (orderType === 'borrow_return' && borrowRequestId.trim() && Number(borrowRequestId) <= 0) {
+      return false
+    }
+
+    return true
+  }
+
+  const handleSubmit = async () => {
+    if (!validatePayload()) {
+      void toast.fire({ icon: 'error', title: '請確認品項、數量與金額欄位格式正確。' })
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload = {
+        order_type: orderType,
+        customer_name: customerName,
+        operator_name: operatorName,
+        department,
+        purpose,
+        note,
+        due_date: orderType === 'borrow' ? dueDate || null : null,
+        borrow_request_id: orderType === 'borrow_return' && borrowRequestId.trim() ? Number(borrowRequestId) : null,
+        items: lines.map((line) => ({
+          item_id: Number(line.item_id),
+          quantity: line.quantity,
+          unit_price: line.unit_price,
+          discount: line.discount,
+          note: line.note,
+        })),
+      }
+
+      const response = await fetch(apiUrl('/api/pos/checkout'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        throw new Error('POS 建單失敗')
+      }
+
+      const createdOrder = (await response.json()) as PosOrder
+      setLatestOrder(createdOrder)
+      setLines([emptyLine()])
+      setBorrowRequestId('')
+      setDueDate('')
+      setNote('')
+      void toast.fire({ icon: 'success', title: `POS 訂單 ${createdOrder.order_no} 已建立。` })
+    } catch {
+      void toast.fire({ icon: 'error', title: 'POS 結帳失敗，請稍後再試。' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h1 className="mt-0">POS 結帳台</h1>
+        <p className="mt-2 text-slate-500">支援銷售、領用、借用、領用回補與借用歸還，送出後會同步寫入庫存台帳。</p>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h2 className="mt-0 text-lg font-bold">訂單資訊</h2>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="grid gap-2 font-bold">
+            訂單型態
+            <select className={fieldClass} value={orderType} onChange={(event) => setOrderType(event.target.value as (typeof ORDER_TYPE_OPTIONS)[number]['value'])}>
+              {ORDER_TYPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grid gap-2 font-bold">
+            操作人
+            <input className={fieldClass} value={operatorName} onChange={(event) => setOperatorName(event.target.value)} placeholder="例：櫃台 A" />
+          </label>
+
+          <label className="grid gap-2 font-bold">
+            客戶/對象
+            <input className={fieldClass} value={customerName} onChange={(event) => setCustomerName(event.target.value)} placeholder="例：王小明 / 行政課" />
+          </label>
+
+          <label className="grid gap-2 font-bold">
+            單位
+            <input className={fieldClass} value={department} onChange={(event) => setDepartment(event.target.value)} placeholder="例：總務處" />
+          </label>
+
+          <label className="grid gap-2 font-bold md:col-span-2">
+            用途
+            <input className={fieldClass} value={purpose} onChange={(event) => setPurpose(event.target.value)} placeholder="例：門市銷售 / 活動借用" />
+          </label>
+
+          {orderType === 'borrow' ? (
+            <label className="grid gap-2 font-bold">
+              預計歸還日
+              <input className={fieldClass} type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
+            </label>
+          ) : null}
+
+          {orderType === 'borrow_return' ? (
+            <label className="grid gap-2 font-bold">
+              借用單 ID（可選）
+              <input
+                className={fieldClass}
+                type="number"
+                min={1}
+                value={borrowRequestId}
+                onChange={(event) => setBorrowRequestId(event.target.value)}
+                placeholder="例：12"
+              />
+            </label>
+          ) : null}
+
+          <label className="grid gap-2 font-bold md:col-span-2">
+            備註
+            <input className={fieldClass} value={note} onChange={(event) => setNote(event.target.value)} placeholder="可填寫補充資訊" />
+          </label>
+        </div>
+
+        <div className="mt-7">
+          <div className="flex items-center justify-between">
+            <h3 className="m-0 text-base font-bold">品項明細</h3>
+            <button className={buttonClass} type="button" onClick={handleAddLine}>新增品項</button>
+          </div>
+
+          <div className="mt-3 grid gap-3">
+            {computedLines.map((line, index) => {
+              const selectedItem = typeof line.item_id === 'number' ? itemOptionMap[line.item_id] : null
+              const stockWarning = DECREASE_ORDER_TYPES.has(orderType) && typeof line.item_id === 'number' && line.quantity > line.stockQuantity
+
+              return (
+                <div key={`pos-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,1fr,1fr,2fr,auto]">
+                  <label className="grid gap-2 font-bold md:col-span-2">
+                    品項
+                    <select
+                      className={fieldClass}
+                      value={line.item_id}
+                      onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
+                    >
+                      <option value="">請選擇品項</option>
+                      {itemOptions.map((option) => (
+                        <option key={option.value} value={option.value}>{option.label}</option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="grid gap-2 font-bold">
+                    數量
+                    <input
+                      className={fieldClass}
+                      type="number"
+                      min={1}
+                      value={line.quantity}
+                      onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
+                    />
+                  </label>
+
+                  <label className="grid gap-2 font-bold">
+                    單價
+                    <input
+                      className={fieldClass}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={line.unit_price}
+                      onChange={(event) => handleLineChange(index, { unit_price: Number(event.target.value) })}
+                    />
+                  </label>
+
+                  <label className="grid gap-2 font-bold">
+                    折扣
+                    <input
+                      className={fieldClass}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={line.discount}
+                      onChange={(event) => handleLineChange(index, { discount: Number(event.target.value) })}
+                    />
+                  </label>
+
+                  <label className="grid gap-2 font-bold md:col-span-2">
+                    備註
+                    <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                  </label>
+
+                  <div className="grid content-end gap-2">
+                    <div className="rounded-[10px] bg-slate-50 px-3 py-2 text-sm">
+                      行小計：{line.lineTotal.toFixed(2)}
+                    </div>
+                    <button type="button" className={removeButtonClass} onClick={() => handleRemoveLine(index)} disabled={lines.length <= 1}>
+                      移除
+                    </button>
+                  </div>
+
+                  <div className="md:col-span-6">
+                    <p className="m-0 text-sm text-slate-500">
+                      {selectedItem ? `${selectedItem.name || '未命名'}${selectedItem.model ? ` (${selectedItem.model})` : ''}` : '尚未選擇品項'}
+                      {' · '}
+                      目前庫存 {line.stockQuantity}
+                    </p>
+                    {stockWarning ? <p className="m-0 mt-1 text-sm font-bold text-red-600">此筆數量超過目前庫存，送出時可能被後端拒絕。</p> : null}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-2 rounded-xl bg-slate-50 px-4 py-3 text-sm">
+          <p className="m-0">小計：<span className="font-bold">{totals.subtotal.toFixed(2)}</span></p>
+          <p className="m-0">折扣：<span className="font-bold">{totals.discountTotal.toFixed(2)}</span></p>
+          <p className="m-0">總計：<span className="text-lg font-bold text-blue-700">{totals.total.toFixed(2)}</span></p>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <button className={buttonClass} type="button" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? '送出中...' : '送出結帳'}
+          </button>
+        </div>
+
+        {loadError ? <p className="mt-3 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+      </section>
+
+      {latestOrder ? (
+        <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+          <h2 className="mt-0 text-lg font-bold">最近建立訂單</h2>
+          <div className="grid gap-2 text-sm text-slate-700 md:grid-cols-2">
+            <p className="m-0">訂單編號：<span className="font-bold">{latestOrder.order_no}</span></p>
+            <p className="m-0">訂單型態：<span className="font-bold">{latestOrder.order_type}</span></p>
+            <p className="m-0">建立時間：<span className="font-bold">{toDisplayDatetime(latestOrder.created_at)}</span></p>
+            <p className="m-0">總金額：<span className="font-bold text-blue-700">{latestOrder.total.toFixed(2)}</span></p>
+          </div>
+        </section>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/pages/PosOrdersPage.tsx
+++ b/frontend/src/components/pages/PosOrdersPage.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useMemo, useState } from 'react'
+import { apiUrl } from '../../api'
+import type { PosOrder } from './types'
+
+const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
+const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const ORDER_TYPE_LABELS: Record<string, string> = {
+  sale: '一般銷售',
+  issue: '領用',
+  borrow: '借用',
+  issue_restock: '領用回補',
+  borrow_return: '借用歸還',
+}
+
+function toDisplayDatetime(value: string | null): string {
+  if (!value) {
+    return '--'
+  }
+
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleString('zh-TW', { hour12: false })
+  }
+
+  return value
+}
+
+function toOrderTypeLabel(type: string): string {
+  const normalizedType = type.trim()
+  if (!normalizedType) {
+    return '--'
+  }
+  return ORDER_TYPE_LABELS[normalizedType] ?? normalizedType
+}
+
+export function PosOrdersPage() {
+  const [orders, setOrders] = useState<PosOrder[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [keyword, setKeyword] = useState('')
+  const [selectedType, setSelectedType] = useState('all')
+
+  useEffect(() => {
+    const loadOrders = async () => {
+      setLoading(true)
+      setLoadError('')
+      try {
+        const response = await fetch(apiUrl('/api/pos/orders'))
+        if (!response.ok) {
+          throw new Error('無法載入 POS 訂單')
+        }
+        const payload = (await response.json()) as PosOrder[]
+        setOrders(payload)
+      } catch {
+        setLoadError('目前無法讀取 POS 訂單，請稍後重試。')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void loadOrders()
+  }, [])
+
+  const typeOptions = useMemo(() => {
+    const uniqueTypes = new Set(orders.map((order) => order.order_type).filter((type) => Boolean(type?.trim())))
+    return ['all', ...Array.from(uniqueTypes)]
+  }, [orders])
+
+  const filteredOrders = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase()
+
+    return orders.filter((order) => {
+      if (selectedType !== 'all' && order.order_type !== selectedType) {
+        return false
+      }
+
+      if (!normalizedKeyword) {
+        return true
+      }
+
+      const fields = [
+        order.order_no,
+        order.customer_name,
+        order.operator_name,
+        order.purpose,
+        order.note,
+        order.request_ref_type,
+      ]
+      const inFields = fields.some((field) => (field ?? '').toLowerCase().includes(normalizedKeyword))
+      const inItems = order.items.some((item) => {
+        const itemFields = [item.item_name, item.item_model, item.note]
+        return itemFields.some((field) => (field ?? '').toLowerCase().includes(normalizedKeyword))
+      })
+
+      return inFields || inItems
+    })
+  }, [keyword, orders, selectedType])
+
+  return (
+    <>
+      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h1 className="mt-0">POS 訂單查詢</h1>
+        <p className="mt-2 text-slate-500">可依訂單編號、客戶、操作人或品項快速查詢，並查看每筆訂單明細。</p>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <div className="mb-4 grid gap-3 md:grid-cols-2">
+          <label className="grid gap-2 font-bold">
+            關鍵字搜尋
+            <input
+              className={fieldClass}
+              type="search"
+              placeholder="輸入訂單編號、客戶、品項..."
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+            />
+          </label>
+
+          <label className="grid gap-2 font-bold">
+            訂單型態
+            <select className={fieldClass} value={selectedType} onChange={(event) => setSelectedType(event.target.value)}>
+              {typeOptions.map((type) => (
+                <option key={type} value={type}>
+                  {type === 'all' ? '全部型態' : toOrderTypeLabel(type)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredOrders.length} 筆資料</p>
+
+        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
+        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+
+        {!loading && !loadError ? (
+          <div className="w-full overflow-x-auto">
+            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+              <thead>
+                <tr>
+                  {['#', '訂單編號', '型態', '客戶/操作人', '時間', '金額', '關聯', '品項明細'].map((header) => (
+                    <th key={header} className={tableHeaderClass}>{header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredOrders.length === 0 ? (
+                  <tr>
+                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={8}>
+                      查無符合條件的 POS 訂單。
+                    </td>
+                  </tr>
+                ) : (
+                  filteredOrders.map((order) => (
+                    <tr key={order.id}>
+                      <td className={tableCellClass}>{order.id}</td>
+                      <td className={tableCellClass}>
+                        <div className="font-bold text-blue-700">{order.order_no || '--'}</div>
+                        <div className="text-xs text-slate-500">備註：{order.note || '--'}</div>
+                      </td>
+                      <td className={tableCellClass}>{toOrderTypeLabel(order.order_type)}</td>
+                      <td className={tableCellClass}>
+                        <div className="font-bold">{order.customer_name || '--'}</div>
+                        <div className="text-xs text-slate-500">操作人：{order.operator_name || '--'}</div>
+                        <div className="text-xs text-slate-500">單位：{order.purpose || '--'}</div>
+                      </td>
+                      <td className={tableCellClass}>{toDisplayDatetime(order.created_at)}</td>
+                      <td className={tableCellClass}>
+                        <div>小計：{order.subtotal.toFixed(2)}</div>
+                        <div>折扣：{order.discount_total.toFixed(2)}</div>
+                        <div className="font-bold text-blue-700">總計：{order.total.toFixed(2)}</div>
+                      </td>
+                      <td className={tableCellClass}>
+                        <div>{order.request_ref_type || '--'}</div>
+                        <div className="text-xs text-slate-500">#{order.request_ref_id ?? '--'}</div>
+                      </td>
+                      <td className={tableCellClass}>
+                        <details>
+                          <summary className="cursor-pointer text-sm font-bold text-blue-700">查看明細（{order.items.length}）</summary>
+                          <div className="mt-2 grid gap-2">
+                            {order.items.map((item) => (
+                              <div key={item.id} className="rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                                <div className="font-bold">{item.item_name || `#${item.item_id}`}{item.item_model ? ` (${item.item_model})` : ''}</div>
+                                <div>數量：{item.quantity}，單價：{item.unit_price.toFixed(2)}，折扣：{item.discount.toFixed(2)}</div>
+                                <div className="font-bold">小計：{item.line_total.toFixed(2)}</div>
+                                <div className="text-slate-500">備註：{item.note || '--'}</div>
+                              </div>
+                            ))}
+                          </div>
+                        </details>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+    </>
+  )
+}

--- a/frontend/src/components/pages/PosStockPage.tsx
+++ b/frontend/src/components/pages/PosStockPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import type { PosStockBalance, PosStockMovement } from './types'
@@ -7,9 +7,15 @@ const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
 const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
 const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
 const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const SCAN_MAX_KEY_INTERVAL_MS = 45
+const SCAN_MIN_LENGTH = 4
 
 type EditingMap = Record<number, string>
 type SavingMap = Record<number, boolean>
+type ScanBuffer = {
+  value: string
+  lastTs: number
+}
 
 const toast = Swal.mixin({
   toast: true,
@@ -40,6 +46,10 @@ export function PosStockPage() {
   const [keyword, setKeyword] = useState('')
   const [editingValues, setEditingValues] = useState<EditingMap>({})
   const [savingMap, setSavingMap] = useState<SavingMap>({})
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const scanBufferRef = useRef<ScanBuffer>({ value: '', lastTs: 0 })
+  const lastInputSourceRef = useRef<'manual' | 'scan'>('manual')
+  const lastNotifiedScanKeywordRef = useRef('')
 
   const loadData = async () => {
     setLoading(true)
@@ -76,6 +86,10 @@ export function PosStockPage() {
     void loadData()
   }, [])
 
+  useEffect(() => {
+    searchInputRef.current?.focus()
+  }, [])
+
   const filteredStockRows = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase()
     if (!normalizedKeyword) {
@@ -83,10 +97,49 @@ export function PosStockPage() {
     }
 
     return stockRows.filter((row) => {
-      const fields = [row.item_name, row.item_model, String(row.item_id)]
+      const fields = [row.item_name, row.item_model, row.property_number, String(row.item_id)]
       return fields.some((field) => field.toLowerCase().includes(normalizedKeyword))
     })
   }, [keyword, stockRows])
+
+  useEffect(() => {
+    if (lastInputSourceRef.current !== 'scan') {
+      return
+    }
+    const normalizedKeyword = keyword.trim()
+    if (!normalizedKeyword || filteredStockRows.length > 0 || lastNotifiedScanKeywordRef.current === normalizedKeyword) {
+      return
+    }
+    lastNotifiedScanKeywordRef.current = normalizedKeyword
+    void toast.fire({ icon: 'error', title: '查無此財產編號。' })
+  }, [filteredStockRows.length, keyword])
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const now = Date.now()
+    const buffer = scanBufferRef.current
+    const key = event.key
+
+    if (key === 'Enter') {
+      if (buffer.value.length >= SCAN_MIN_LENGTH) {
+        lastInputSourceRef.current = 'scan'
+      }
+      buffer.value = ''
+      buffer.lastTs = 0
+      return
+    }
+
+    if (key.length !== 1) {
+      return
+    }
+
+    lastInputSourceRef.current = 'manual'
+    if (buffer.lastTs > 0 && now - buffer.lastTs > SCAN_MAX_KEY_INTERVAL_MS) {
+      buffer.value = key
+    } else {
+      buffer.value += key
+    }
+    buffer.lastTs = now
+  }
 
   const handleUpdateStock = async (itemId: number) => {
     const rawValue = editingValues[itemId] ?? ''
@@ -124,7 +177,7 @@ export function PosStockPage() {
     <>
       <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h1 className="mt-0">POS 庫存與台帳</h1>
-        <p className="mt-2 text-slate-500">上半部可查詢與調整庫存，下半部顯示最近 200 筆庫存異動紀錄。</p>
+        <p className="mt-2 text-slate-500">上半部可查詢與調整庫存（支援掃描財產編號），下半部顯示最近 200 筆庫存異動紀錄。</p>
       </section>
 
       <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
@@ -132,11 +185,18 @@ export function PosStockPage() {
           <label className="grid gap-2 font-bold">
             庫存關鍵字搜尋
             <input
+              ref={searchInputRef}
               className={fieldClass}
               type="search"
-              placeholder="輸入品名、型號或 item_id..."
+              placeholder="可輸入/掃描財產編號、品名、型號或 item_id..."
               value={keyword}
-              onChange={(event) => setKeyword(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              onChange={(event) => {
+                if (lastInputSourceRef.current !== 'scan') {
+                  lastInputSourceRef.current = 'manual'
+                }
+                setKeyword(event.target.value)
+              }}
             />
           </label>
           <button className={buttonClass} type="button" onClick={() => void loadData()} disabled={loading}>重新整理</button>
@@ -152,7 +212,7 @@ export function PosStockPage() {
             <table className="mt-2 w-full table-auto border-collapse bg-white">
               <thead>
                 <tr>
-                  {['item_id', '品項', '型號', '目前庫存', '調整為', '操作'].map((header) => (
+                  {['item_id', '財產編號', '品項', '型號', '目前庫存', '調整為', '操作'].map((header) => (
                     <th key={header} className={tableHeaderClass}>{header}</th>
                   ))}
                 </tr>
@@ -160,7 +220,7 @@ export function PosStockPage() {
               <tbody>
                 {filteredStockRows.length === 0 ? (
                   <tr>
-                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={6}>查無符合條件的庫存資料。</td>
+                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>查無符合條件的庫存資料。</td>
                   </tr>
                 ) : (
                   filteredStockRows.map((row) => {
@@ -168,6 +228,7 @@ export function PosStockPage() {
                     return (
                       <tr key={row.item_id}>
                         <td className={tableCellClass}>{row.item_id}</td>
+                        <td className={tableCellClass}>{row.property_number || '--'}</td>
                         <td className={tableCellClass}>{row.item_name || '--'}</td>
                         <td className={tableCellClass}>{row.item_model || '--'}</td>
                         <td className={`${tableCellClass} font-bold text-blue-700`}>{row.quantity}</td>

--- a/frontend/src/components/pages/PosStockPage.tsx
+++ b/frontend/src/components/pages/PosStockPage.tsx
@@ -149,7 +149,7 @@ export function PosStockPage() {
 
         {!loading && !loadError ? (
           <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+            <table className="mt-2 w-full table-auto border-collapse bg-white">
               <thead>
                 <tr>
                   {['item_id', '品項', '型號', '目前庫存', '調整為', '操作'].map((header) => (
@@ -204,7 +204,7 @@ export function PosStockPage() {
       <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h2 className="mt-0 text-lg font-bold">庫存異動台帳</h2>
         <div className="w-full overflow-x-auto">
-          <table className="mt-2 w-full table-fixed border-collapse bg-white">
+          <table className="mt-2 min-w-[980px] table-auto border-collapse bg-white">
             <thead>
               <tr>
                 {['#', '時間', '訂單編號', 'item_id', '品項', 'delta', 'balance_after', 'reason', 'related'].map((header) => (

--- a/frontend/src/components/pages/PosStockPage.tsx
+++ b/frontend/src/components/pages/PosStockPage.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'react'
+import Swal from 'sweetalert2'
+import { apiUrl } from '../../api'
+import type { PosStockBalance, PosStockMovement } from './types'
+
+const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
+const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+
+type EditingMap = Record<number, string>
+type SavingMap = Record<number, boolean>
+
+const toast = Swal.mixin({
+  toast: true,
+  position: 'top-end',
+  showConfirmButton: false,
+  timer: 2600,
+  timerProgressBar: true,
+})
+
+function toDisplayDatetime(value: string | null): string {
+  if (!value) {
+    return '--'
+  }
+
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleString('zh-TW', { hour12: false })
+  }
+
+  return value
+}
+
+export function PosStockPage() {
+  const [stockRows, setStockRows] = useState<PosStockBalance[]>([])
+  const [movementRows, setMovementRows] = useState<PosStockMovement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [keyword, setKeyword] = useState('')
+  const [editingValues, setEditingValues] = useState<EditingMap>({})
+  const [savingMap, setSavingMap] = useState<SavingMap>({})
+
+  const loadData = async () => {
+    setLoading(true)
+    setLoadError('')
+    try {
+      const [stockResponse, movementsResponse] = await Promise.all([
+        fetch(apiUrl('/api/pos/stock')),
+        fetch(apiUrl('/api/pos/stock-movements?limit=200')),
+      ])
+
+      if (!stockResponse.ok || !movementsResponse.ok) {
+        throw new Error('無法載入 POS 庫存資料')
+      }
+
+      const stockPayload = (await stockResponse.json()) as PosStockBalance[]
+      const movementPayload = (await movementsResponse.json()) as PosStockMovement[]
+
+      setStockRows(stockPayload)
+      setMovementRows(movementPayload)
+      setEditingValues(
+        stockPayload.reduce<EditingMap>((accumulator, row) => {
+          accumulator[row.item_id] = String(row.quantity)
+          return accumulator
+        }, {})
+      )
+    } catch {
+      setLoadError('目前無法讀取 POS 庫存資料，請稍後重試。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadData()
+  }, [])
+
+  const filteredStockRows = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase()
+    if (!normalizedKeyword) {
+      return stockRows
+    }
+
+    return stockRows.filter((row) => {
+      const fields = [row.item_name, row.item_model, String(row.item_id)]
+      return fields.some((field) => field.toLowerCase().includes(normalizedKeyword))
+    })
+  }, [keyword, stockRows])
+
+  const handleUpdateStock = async (itemId: number) => {
+    const rawValue = editingValues[itemId] ?? ''
+    const quantity = Number(rawValue)
+    if (!Number.isInteger(quantity) || quantity < 0) {
+      void toast.fire({ icon: 'error', title: '庫存數量必須是大於等於 0 的整數。' })
+      return
+    }
+
+    setSavingMap((previous) => ({ ...previous, [itemId]: true }))
+    try {
+      const response = await fetch(apiUrl(`/api/pos/stock/${itemId}`), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quantity }),
+      })
+
+      if (!response.ok) {
+        throw new Error('庫存更新失敗')
+      }
+
+      const updatedRow = (await response.json()) as PosStockBalance
+      setStockRows((previousRows) => previousRows.map((row) => (row.item_id === itemId ? updatedRow : row)))
+      setEditingValues((previous) => ({ ...previous, [itemId]: String(updatedRow.quantity) }))
+      void toast.fire({ icon: 'success', title: `品項 #${itemId} 庫存已更新。` })
+      void loadData()
+    } catch {
+      void toast.fire({ icon: 'error', title: '更新庫存失敗，請稍後再試。' })
+    } finally {
+      setSavingMap((previous) => ({ ...previous, [itemId]: false }))
+    }
+  }
+
+  return (
+    <>
+      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h1 className="mt-0">POS 庫存與台帳</h1>
+        <p className="mt-2 text-slate-500">上半部可查詢與調整庫存，下半部顯示最近 200 筆庫存異動紀錄。</p>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <div className="mb-4 grid gap-3 md:grid-cols-[2fr,auto] md:items-end">
+          <label className="grid gap-2 font-bold">
+            庫存關鍵字搜尋
+            <input
+              className={fieldClass}
+              type="search"
+              placeholder="輸入品名、型號或 item_id..."
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+            />
+          </label>
+          <button className={buttonClass} type="button" onClick={() => void loadData()} disabled={loading}>重新整理</button>
+        </div>
+
+        <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredStockRows.length} 筆庫存</p>
+
+        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
+        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+
+        {!loading && !loadError ? (
+          <div className="w-full overflow-x-auto">
+            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+              <thead>
+                <tr>
+                  {['item_id', '品項', '型號', '目前庫存', '調整為', '操作'].map((header) => (
+                    <th key={header} className={tableHeaderClass}>{header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredStockRows.length === 0 ? (
+                  <tr>
+                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={6}>查無符合條件的庫存資料。</td>
+                  </tr>
+                ) : (
+                  filteredStockRows.map((row) => {
+                    const isSaving = savingMap[row.item_id] ?? false
+                    return (
+                      <tr key={row.item_id}>
+                        <td className={tableCellClass}>{row.item_id}</td>
+                        <td className={tableCellClass}>{row.item_name || '--'}</td>
+                        <td className={tableCellClass}>{row.item_model || '--'}</td>
+                        <td className={`${tableCellClass} font-bold text-blue-700`}>{row.quantity}</td>
+                        <td className={tableCellClass}>
+                          <input
+                            className={`${fieldClass} w-28`}
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={editingValues[row.item_id] ?? ''}
+                            onChange={(event) => setEditingValues((previous) => ({ ...previous, [row.item_id]: event.target.value }))}
+                          />
+                        </td>
+                        <td className={tableCellClass}>
+                          <button
+                            className={buttonClass}
+                            type="button"
+                            onClick={() => void handleUpdateStock(row.item_id)}
+                            disabled={isSaving}
+                          >
+                            {isSaving ? '更新中...' : '更新'}
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+        <h2 className="mt-0 text-lg font-bold">庫存異動台帳</h2>
+        <div className="w-full overflow-x-auto">
+          <table className="mt-2 w-full table-fixed border-collapse bg-white">
+            <thead>
+              <tr>
+                {['#', '時間', '訂單編號', 'item_id', '品項', 'delta', 'balance_after', 'reason', 'related'].map((header) => (
+                  <th key={header} className={tableHeaderClass}>{header}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {movementRows.length === 0 ? (
+                <tr>
+                  <td className={`${tableCellClass} text-center text-slate-500`} colSpan={9}>目前沒有庫存異動資料。</td>
+                </tr>
+              ) : (
+                movementRows.map((movement) => (
+                  <tr key={movement.id}>
+                    <td className={tableCellClass}>{movement.id}</td>
+                    <td className={tableCellClass}>{toDisplayDatetime(movement.created_at)}</td>
+                    <td className={tableCellClass}>{movement.order_no || '--'}</td>
+                    <td className={tableCellClass}>{movement.item_id}</td>
+                    <td className={tableCellClass}>{movement.item_name || '--'}{movement.item_model ? ` (${movement.item_model})` : ''}</td>
+                    <td className={`${tableCellClass} ${movement.delta < 0 ? 'text-red-700' : 'text-emerald-700'} font-bold`}>{movement.delta}</td>
+                    <td className={`${tableCellClass} font-bold`}>{movement.balance_after}</td>
+                    <td className={tableCellClass}>{movement.reason || '--'}</td>
+                    <td className={tableCellClass}>
+                      <div>{movement.related_type || '--'}</div>
+                      <div className="text-xs text-slate-500">#{movement.related_id ?? '--'}</div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -123,6 +123,7 @@ export type PosStockBalance = {
   item_id: number
   item_name: string
   item_model: string
+  property_number: string
   quantity: number
 }
 

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -81,3 +81,62 @@ export type DonationRequest = {
   memo: string
   items: DonationItem[]
 }
+
+export type PosCheckoutItem = {
+  item_id: number
+  quantity: number
+  unit_price: number
+  discount: number
+  note: string
+}
+
+export type PosOrderItem = {
+  id: number
+  item_id: number
+  item_name: string
+  item_model: string
+  quantity: number
+  unit_price: number
+  discount: number
+  line_total: number
+  note: string
+}
+
+export type PosOrder = {
+  id: number
+  order_no: string
+  order_type: string
+  customer_name: string
+  operator_name: string
+  purpose: string
+  request_ref_type: string
+  request_ref_id: number | null
+  subtotal: number
+  discount_total: number
+  total: number
+  note: string
+  created_at: string | null
+  items: PosOrderItem[]
+}
+
+export type PosStockBalance = {
+  item_id: number
+  item_name: string
+  item_model: string
+  quantity: number
+}
+
+export type PosStockMovement = {
+  id: number
+  order_id: number
+  order_no: string
+  item_id: number
+  item_name: string
+  item_model: string
+  delta: number
+  balance_after: number
+  reason: string
+  related_type: string
+  related_id: number | null
+  created_at: string | null
+}


### PR DESCRIPTION
## 變更摘要
- 財產清單頁新增掃描槍搜尋流程與無結果提示
- POS 庫存頁新增掃描搜尋流程，並在清單顯示財產編號欄位
- POS 結帳頁新增品項關鍵字篩選（名稱/型號/財產編號）
- 後端與前端型別補齊 `property_number` 欄位

## 測試
- [ ] 尚未執行自動化測試
- [x] 已確認分支可成功 push 到遠端
