### PR TITLE
feat(frontend): shadcn-style admin UI refresh

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime
+import math
 from pathlib import Path
 
-from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
@@ -195,6 +196,38 @@ class DonationRequest(DonationRequestCreate):
     items: list[DonationItem]
 
 
+class InventoryItemListResponse(BaseModel):
+    items: list[InventoryItem]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class IssueRequestListResponse(BaseModel):
+    items: list[IssueRequest]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class BorrowRequestListResponse(BaseModel):
+    items: list[BorrowRequest]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class DonationRequestListResponse(BaseModel):
+    items: list[DonationRequest]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
 class ImportErrorDetail(BaseModel):
     row: int
     message: str
@@ -281,6 +314,28 @@ def _format_date(value: date | None) -> str:
 
 def _coerce_str(value) -> str:
     return value if isinstance(value, str) else "" if value is None else str(value)
+
+
+def _contains_cjk(value: str) -> bool:
+    return any("\u4e00" <= char <= "\u9fff" for char in value)
+
+
+def _normalize_pagination(page: int, page_size: int) -> tuple[int, int]:
+    if page < 1:
+        raise HTTPException(status_code=400, detail="page must be greater than 0")
+    if page_size < 1:
+        raise HTTPException(status_code=400, detail="page_size must be greater than 0")
+    return page, page_size
+
+
+def _paginate_rows[T](rows: list[T], page: int, page_size: int) -> tuple[list[T], int, int]:
+    total = len(rows)
+    total_pages = max(1, math.ceil(total / page_size)) if total > 0 else 1
+    start_index = (page - 1) * page_size
+    if start_index >= total:
+        return [], total, total_pages
+    end_index = start_index + page_size
+    return rows[start_index:end_index], total, total_pages
 
 
 def row_to_item(row) -> InventoryItem:
@@ -554,11 +609,54 @@ def delete_asset_status_code_api(code: str):
     return {"success": True}
 
 
-@app.get("/api/items", response_model=list[InventoryItem], response_model_by_alias=False)
-def get_inventory_items(include_donated: bool = False):
-    rows = list_items(include_donated=include_donated)
-    log_inventory_action(action="read", entity="inventory_item", detail={"count": len(rows), "mode": "list"})
-    return [row_to_item(row) for row in rows]
+@app.get("/api/items", response_model=InventoryItemListResponse, response_model_by_alias=False)
+def get_inventory_items(
+    include_donated: bool = False,
+    keyword: str = "",
+    asset_type: str = "all",
+    correction_status: str = "all",
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
+    rows = [row_to_item(row) for row in list_items(include_donated=include_donated)]
+
+    normalized_keyword = keyword.strip().lower()
+    filtered_rows: list[InventoryItem] = []
+    for row in rows:
+        if asset_type != "all" and row.asset_type != asset_type:
+            continue
+
+        if correction_status == "needs_fix":
+            serial = (row.n_property_sn or row.property_sn or row.n_item_sn or row.item_sn).strip()
+            if serial and not _contains_cjk(serial):
+                continue
+        elif correction_status != "all":
+            raise HTTPException(status_code=400, detail="invalid correction_status")
+
+        if normalized_keyword:
+            search_fields = [
+                row.n_property_sn,
+                row.property_sn,
+                row.n_item_sn,
+                row.item_sn,
+                row.name,
+                row.model,
+                row.location,
+                row.keeper,
+            ]
+            if not any((field or "").lower().find(normalized_keyword) >= 0 for field in search_fields):
+                continue
+
+        filtered_rows.append(row)
+
+    paged_items, total, total_pages = _paginate_rows(filtered_rows, page, page_size)
+    log_inventory_action(
+        action="read",
+        entity="inventory_item",
+        detail={"count": len(paged_items), "total": total, "page": page, "page_size": page_size, "mode": "list"},
+    )
+    return InventoryItemListResponse(items=paged_items, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
 @app.get("/api/items/{item_id}", response_model=InventoryItem, response_model_by_alias=False)
@@ -642,15 +740,39 @@ def delete_inventory_item_api(item_id: int):
     return {"success": True}
 
 
-@app.get("/api/issues", response_model=list[IssueRequest], response_model_by_alias=False)
-def list_issue_requests_api():
+@app.get("/api/issues", response_model=IssueRequestListResponse, response_model_by_alias=False)
+def list_issue_requests_api(
+    keyword: str = "",
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
     rows = list_issue_requests()
-    results = []
+    normalized_keyword = keyword.strip().lower()
+    results: list[IssueRequest] = []
     for row in rows:
         items = [row_to_issue_item(item) for item in list_issue_items(row["id"])]
-        results.append(issue_request_row_to_model(row, items))
-    log_inventory_action(action="read", entity="issue_request", detail={"count": len(results), "mode": "list"})
-    return results
+        model = issue_request_row_to_model(row, items)
+        if normalized_keyword:
+            item_matches = any((item.item_name or "").lower().find(normalized_keyword) >= 0 for item in model.items)
+            fields = [
+                model.requester or "",
+                model.department or "",
+                model.purpose or "",
+                model.memo or "",
+                str(model.request_date or ""),
+            ]
+            if not item_matches and not any(field.lower().find(normalized_keyword) >= 0 for field in fields):
+                continue
+        results.append(model)
+
+    paged_items, total, total_pages = _paginate_rows(results, page, page_size)
+    log_inventory_action(
+        action="read",
+        entity="issue_request",
+        detail={"count": len(paged_items), "total": total, "page": page, "page_size": page_size, "mode": "list"},
+    )
+    return IssueRequestListResponse(items=paged_items, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
 @app.get("/api/issues/{request_id}", response_model=IssueRequest, response_model_by_alias=False)
@@ -742,15 +864,42 @@ def delete_issue_request_api(request_id: int, background_tasks: BackgroundTasks)
     return {"success": True}
 
 
-@app.get("/api/borrows", response_model=list[BorrowRequest], response_model_by_alias=False)
-def list_borrow_requests_api():
+@app.get("/api/borrows", response_model=BorrowRequestListResponse, response_model_by_alias=False)
+def list_borrow_requests_api(
+    keyword: str = "",
+    status: str = "all",
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
     rows = list_borrow_requests()
-    results = []
+    normalized_keyword = keyword.strip().lower()
+    results: list[BorrowRequest] = []
     for row in rows:
         items = [row_to_borrow_item(item) for item in list_borrow_items(row["id"])]
-        results.append(borrow_request_row_to_model(row, items))
-    log_inventory_action(action="read", entity="borrow_request", detail={"count": len(results), "mode": "list"})
-    return results
+        model = borrow_request_row_to_model(row, items)
+        if status != "all" and model.status != status:
+            continue
+        if normalized_keyword:
+            item_matches = any((item.item_name or "").lower().find(normalized_keyword) >= 0 for item in model.items)
+            fields = [
+                model.borrower or "",
+                model.department or "",
+                model.purpose or "",
+                model.memo or "",
+                str(model.borrow_date or ""),
+            ]
+            if not item_matches and not any(field.lower().find(normalized_keyword) >= 0 for field in fields):
+                continue
+        results.append(model)
+
+    paged_items, total, total_pages = _paginate_rows(results, page, page_size)
+    log_inventory_action(
+        action="read",
+        entity="borrow_request",
+        detail={"count": len(paged_items), "total": total, "page": page, "page_size": page_size, "mode": "list"},
+    )
+    return BorrowRequestListResponse(items=paged_items, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
 @app.get("/api/borrows/{request_id}", response_model=BorrowRequest, response_model_by_alias=False)
@@ -842,15 +991,40 @@ def delete_borrow_request_api(request_id: int, background_tasks: BackgroundTasks
     return {"success": True}
 
 
-@app.get("/api/donations", response_model=list[DonationRequest], response_model_by_alias=False)
-def list_donation_requests_api():
+@app.get("/api/donations", response_model=DonationRequestListResponse, response_model_by_alias=False)
+def list_donation_requests_api(
+    keyword: str = "",
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
     rows = list_donation_requests()
-    results = []
+    normalized_keyword = keyword.strip().lower()
+    results: list[DonationRequest] = []
     for row in rows:
         items = [row_to_donation_item(item) for item in list_donation_items(row["id"])]
-        results.append(donation_request_row_to_model(row, items))
-    log_inventory_action(action="read", entity="donation_request", detail={"count": len(results), "mode": "list"})
-    return results
+        model = donation_request_row_to_model(row, items)
+        if normalized_keyword:
+            item_matches = any((item.item_name or "").lower().find(normalized_keyword) >= 0 for item in model.items)
+            fields = [
+                model.donor or "",
+                model.department or "",
+                model.recipient or "",
+                model.purpose or "",
+                model.memo or "",
+                str(model.donation_date or ""),
+            ]
+            if not item_matches and not any(field.lower().find(normalized_keyword) >= 0 for field in fields):
+                continue
+        results.append(model)
+
+    paged_items, total, total_pages = _paginate_rows(results, page, page_size)
+    log_inventory_action(
+        action="read",
+        entity="donation_request",
+        detail={"count": len(paged_items), "total": total, "page": page, "page_size": page_size, "mode": "list"},
+    )
+    return DonationRequestListResponse(items=paged_items, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
 @app.get("/api/donations/{request_id}", response_model=DonationRequest, response_model_by_alias=False)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -64,10 +64,24 @@ npm run lint     # ESLint 檢查
 - `/inventory`：財產清單
 - `/inventory/new`：新增財產
 - `/inventory/edit/:id`：編輯財產
+- `/issues`：領用清單
+- `/issues/new`：新增領用
+- `/issues/:id`：編輯領用單
+- `/borrows`：借用清單
+- `/borrows/new`：新增借用
+- `/borrows/:id`：編輯借用單
 - `/upload`：Excel 匯入
 - `/donations`：捐贈清單
 - `/donations/new`：新增捐贈
 - `/donations/:id`：編輯捐贈單
+
+## 側邊導覽分類
+
+- 總覽：Dashboard
+- 領用：領用清單、新增領用
+- 借用：借用清單、新增借用
+- 捐贈：捐贈清單、新增捐贈
+- 資產：財產清單、新增庫存、批次上傳
 
 ## 畫面與資料行為
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,16 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.2.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.553.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "sweetalert2": "^11.26.21",
+        "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.2.1"
       },
       "devDependencies": {
@@ -981,6 +987,85 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1642,7 +1727,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1652,7 +1737,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2150,6 +2235,27 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2203,7 +2309,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3129,6 +3235,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3506,6 +3621,16 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.2.1",
+        "@tanstack/react-router": "^1.168.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
@@ -1655,6 +1656,92 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/history": {
+      "version": "1.161.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
+      "integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.168.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.168.10.tgz",
+      "integrity": "sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.6",
+        "@tanstack/react-store": "^0.9.3",
+        "@tanstack/router-core": "1.168.9",
+        "isbot": "^5.1.22"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+      "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.168.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.9.tgz",
+      "integrity": "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.6",
+        "cookie-es": "^2.0.0",
+        "seroval": "^1.4.2",
+        "seroval-plugins": "^1.4.2"
+      },
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2290,6 +2377,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie-es": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
+      "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2844,6 +2937,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isbot": {
+      "version": "5.1.37",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.37.tgz",
+      "integrity": "sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/isexe": {
@@ -3555,6 +3657,27 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
+      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
+      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3778,6 +3901,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-separator": "^1.1.8",
     "@tailwindcss/vite": "^4.2.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.553.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "sweetalert2": "^11.26.21",
-    "tailwindcss": "^4.2.1"
+    "tailwindcss": "^4.2.1",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,17 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.2.1",
+    "@tanstack/react-router": "^1.168.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "sweetalert2": "^11.26.21",
-    "tailwindcss": "^4.2.1",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,112 +1,200 @@
-import { TopNav } from './components/TopNav'
-import { DashboardPage } from './components/pages/DashboardPage'
-import { BorrowPage } from './components/pages/BorrowPage'
+import { RouterProvider, createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
+import { AppShell } from './components/layout/AppShell'
 import { BorrowListPage } from './components/pages/BorrowListPage'
-import { DonationPage } from './components/pages/DonationPage'
+import { BorrowPage } from './components/pages/BorrowPage'
+import { DashboardPage } from './components/pages/DashboardPage'
 import { DonationListPage } from './components/pages/DonationListPage'
+import { DonationPage } from './components/pages/DonationPage'
 import { InventoryFormPage } from './components/pages/InventoryFormPage'
 import { InventoryListPage } from './components/pages/InventoryListPage'
 import { IssueListPage } from './components/pages/IssueListPage'
 import { IssuePage } from './components/pages/IssuePage'
 import { UploadPage } from './components/pages/UploadPage'
+import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card'
 
-function parseEditItemId(pathname: string): number | null {
-  const matchedParts = pathname.match(/^\/inventory\/edit\/(\d+)$/)
-  if (!matchedParts) {
-    return null
-  }
-
-  const parsedId = Number(matchedParts[1])
-  return Number.isInteger(parsedId) ? parsedId : null
+function parsePositiveId(value: string): number | null {
+  const parsedValue = Number(value)
+  return Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : null
 }
 
-function parseIssueRequestId(pathname: string): number | null {
-  const matchedParts = pathname.match(/^\/issues\/(\d+)$/)
-  if (!matchedParts) {
-    return null
-  }
-
-  const parsedId = Number(matchedParts[1])
-  return Number.isInteger(parsedId) ? parsedId : null
+function NotFoundPage() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>找不到頁面</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">請使用側邊導覽前往 Dashboard、財產、領用、借用、捐贈或上傳頁面。</p>
+      </CardContent>
+    </Card>
+  )
 }
 
-function parseBorrowRequestId(pathname: string): number | null {
-  const matchedParts = pathname.match(/^\/borrows\/(\d+)$/)
-  if (!matchedParts) {
-    return null
-  }
-
-  const parsedId = Number(matchedParts[1])
-  return Number.isInteger(parsedId) ? parsedId : null
+function InvalidRouteParameter() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>參數格式錯誤</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">網址中的資料編號無效，請回到清單頁重新操作。</p>
+      </CardContent>
+    </Card>
+  )
 }
 
-function parseDonationRequestId(pathname: string): number | null {
-  const matchedParts = pathname.match(/^\/donations\/(\d+)$/)
-  if (!matchedParts) {
-    return null
-  }
+const rootRoute = createRootRoute({
+  component: AppShell,
+  notFoundComponent: NotFoundPage,
+})
 
-  const parsedId = Number(matchedParts[1])
-  return Number.isInteger(parsedId) ? parsedId : null
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: DashboardPage,
+})
+
+const inventoryRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/inventory',
+  component: InventoryListPage,
+})
+
+const inventoryCreateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/inventory/new',
+  component: InventoryFormPage,
+})
+
+function InventoryEditRouteComponent() {
+  const { itemId } = inventoryEditRoute.useParams()
+  const parsedItemId = parsePositiveId(itemId)
+  if (!parsedItemId) {
+    return <InvalidRouteParameter />
+  }
+  return <InventoryFormPage itemId={parsedItemId} />
+}
+
+const inventoryEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/inventory/edit/$itemId',
+  component: InventoryEditRouteComponent,
+})
+
+const issueListRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/issues',
+  component: IssueListPage,
+})
+
+const issueCreateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/issues/new',
+  component: IssuePage,
+})
+
+function IssueEditRouteComponent() {
+  const { requestId } = issueEditRoute.useParams()
+  const parsedRequestId = parsePositiveId(requestId)
+  if (!parsedRequestId) {
+    return <InvalidRouteParameter />
+  }
+  return <IssuePage requestId={parsedRequestId} />
+}
+
+const issueEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/issues/$requestId',
+  component: IssueEditRouteComponent,
+})
+
+const borrowListRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/borrows',
+  component: BorrowListPage,
+})
+
+const borrowCreateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/borrows/new',
+  component: BorrowPage,
+})
+
+function BorrowEditRouteComponent() {
+  const { requestId } = borrowEditRoute.useParams()
+  const parsedRequestId = parsePositiveId(requestId)
+  if (!parsedRequestId) {
+    return <InvalidRouteParameter />
+  }
+  return <BorrowPage requestId={parsedRequestId} />
+}
+
+const borrowEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/borrows/$requestId',
+  component: BorrowEditRouteComponent,
+})
+
+const donationListRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/donations',
+  component: DonationListPage,
+})
+
+const donationCreateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/donations/new',
+  component: DonationPage,
+})
+
+function DonationEditRouteComponent() {
+  const { requestId } = donationEditRoute.useParams()
+  const parsedRequestId = parsePositiveId(requestId)
+  if (!parsedRequestId) {
+    return <InvalidRouteParameter />
+  }
+  return <DonationPage requestId={parsedRequestId} />
+}
+
+const donationEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/donations/$requestId',
+  component: DonationEditRouteComponent,
+})
+
+const uploadRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/upload',
+  component: UploadPage,
+})
+
+const routeTree = rootRoute.addChildren([
+  dashboardRoute,
+  inventoryRoute,
+  inventoryCreateRoute,
+  inventoryEditRoute,
+  issueListRoute,
+  issueCreateRoute,
+  issueEditRoute,
+  borrowListRoute,
+  borrowCreateRoute,
+  borrowEditRoute,
+  donationListRoute,
+  donationCreateRoute,
+  donationEditRoute,
+  uploadRoute,
+])
+
+const router = createRouter({ routeTree, defaultPreload: 'intent' })
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
 }
 
 function App() {
-  const pathname = window.location.pathname
-  const isUploadPage = pathname === '/upload'
-  const isDashboardPage = pathname === '/'
-  const isIssueListPage = pathname === '/issues'
-  const isIssueCreatePage = pathname === '/issues/new'
-  const isBorrowListPage = pathname === '/borrows'
-  const isBorrowCreatePage = pathname === '/borrows/new'
-  const isDonationListPage = pathname === '/donations'
-  const isDonationCreatePage = pathname === '/donations/new'
-  const isInventoryPage = pathname === '/inventory'
-  const isCreateInventoryPage = pathname === '/inventory/new'
-  const editItemId = parseEditItemId(pathname)
-  const editIssueRequestId = parseIssueRequestId(pathname)
-  const editBorrowRequestId = parseBorrowRequestId(pathname)
-  const editDonationRequestId = parseDonationRequestId(pathname)
-
-  return (
-    <main className="mx-auto grid max-h-screen w-full max-w-[980px] gap-5 px-4 pb-12 pt-8">
-      <TopNav pathname={pathname} />
-
-      {isDashboardPage ? <DashboardPage /> : null}
-      {isIssueListPage ? <IssueListPage /> : null}
-      {isIssueCreatePage ? <IssuePage /> : null}
-      {editIssueRequestId ? <IssuePage requestId={editIssueRequestId} /> : null}
-      {isBorrowListPage ? <BorrowListPage /> : null}
-      {isBorrowCreatePage ? <BorrowPage /> : null}
-      {editBorrowRequestId ? <BorrowPage requestId={editBorrowRequestId} /> : null}
-      {isDonationListPage ? <DonationListPage /> : null}
-      {isDonationCreatePage ? <DonationPage /> : null}
-      {editDonationRequestId ? <DonationPage requestId={editDonationRequestId} /> : null}
-      {isInventoryPage ? <InventoryListPage /> : null}
-      {isUploadPage ? <UploadPage /> : null}
-      {isCreateInventoryPage ? <InventoryFormPage /> : null}
-      {editItemId ? <InventoryFormPage itemId={editItemId} /> : null}
-
-      {!isDashboardPage &&
-      !isIssueListPage &&
-      !isIssueCreatePage &&
-      !isBorrowListPage &&
-      !isBorrowCreatePage &&
-      !isDonationListPage &&
-      !isDonationCreatePage &&
-      !editIssueRequestId &&
-      !editBorrowRequestId &&
-      !editDonationRequestId &&
-      !isUploadPage &&
-      !isInventoryPage &&
-      !isCreateInventoryPage &&
-      !editItemId ? (
-        <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-          <h1 className="mt-0">找不到頁面</h1>
-          <p className="mt-2 text-slate-500">請使用上方導覽前往 Dashboard、領用/借用/捐贈清單、財產清單、新增資料或上傳頁面。</p>
-        </section>
-      ) : null}
-    </main>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -2,8 +2,8 @@ type TopNavProps = {
   pathname: string
 }
 
-const navLinkClass = 'rounded-full bg-blue-100 px-3.5 py-2 text-sm font-bold text-blue-700 no-underline'
-const activeNavLinkClass = 'bg-blue-600 text-white'
+const navLinkClass = 'rounded-full bg-[hsl(var(--secondary))] px-3.5 py-2 text-sm font-bold text-[hsl(var(--secondary-foreground))] no-underline'
+const activeNavLinkClass = 'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]'
 
 export function TopNav({ pathname }: TopNavProps) {
   const isIssueEditPage = /^\/issues\/\d+$/.test(pathname)

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -23,8 +23,8 @@ const ASSET_TYPE_OPTIONS = {
 type AssetTypeValue = (typeof ASSET_TYPE_OPTIONS)[keyof typeof ASSET_TYPE_OPTIONS]
 const ASSET_TYPE_ENTRIES = Object.entries(ASSET_TYPE_OPTIONS) as Array<[string, AssetTypeValue]>
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 
 export function UploadPanel() {
   const [assetType, setAssetType] = useState(ASSET_TYPE_ENTRIES[0][1])
@@ -87,7 +87,7 @@ export function UploadPanel() {
   }
 
   return (
-    <section className="rounded-2xl bg-white p-8 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+    <section className="rounded-2xl bg-[hsl(var(--card))] p-8 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
       <h2 className="mt-0">資產資料上傳</h2>
       <p className="mt-2 text-slate-500">請選擇類別並上傳 Excel（.xlsx）檔案，系統會自動匯入資料。</p>
 
@@ -118,7 +118,7 @@ export function UploadPanel() {
       {errorMessage ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{errorMessage}</p> : null}
 
       {result ? (
-        <section className="mt-7 border-t border-slate-200 pt-5">
+        <section className="mt-7 border-t border-[hsl(var(--border))] pt-5">
           <h3 className="mt-0">匯入結果</h3>
           <ul className="mb-0 pl-5">
             <li>總筆數：{result.total}</li>
@@ -129,18 +129,18 @@ export function UploadPanel() {
           {hasErrors ? (
             <div className="mt-4">
               <h4 className="mt-0">錯誤明細</h4>
-              <table className="mt-2 w-full border-collapse bg-white">
+              <table className="mt-2 w-full border-collapse bg-[hsl(var(--card))]">
                 <thead>
                   <tr>
-                    <th className="whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left">列號</th>
-                    <th className="whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left">原因</th>
+                    <th className="whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left">列號</th>
+                    <th className="whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left">原因</th>
                   </tr>
                 </thead>
                 <tbody>
                   {result.errors.map((item) => (
                     <tr key={`${item.row}-${item.message}`}>
-                      <td className="whitespace-nowrap border border-slate-200 p-2 text-left">{item.row}</td>
-                      <td className="whitespace-nowrap border border-slate-200 p-2 text-left">{item.message}</td>
+                      <td className="whitespace-nowrap border border-[hsl(var(--border))] p-2 text-left">{item.row}</td>
+                      <td className="whitespace-nowrap border border-[hsl(var(--border))] p-2 text-left">{item.message}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,287 @@
+import { type ReactNode, useMemo, useState } from 'react'
+import { Link, Outlet, useLocation } from '@tanstack/react-router'
+import { Boxes, ChevronDown, ClipboardList, FilePlus2, HandCoins, Handshake, LayoutDashboard, Menu, Upload, X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+type NavigationLink = {
+  to: string
+  label: string
+  icon: ReactNode
+  exact?: boolean
+  isActive?: (pathname: string) => boolean
+}
+
+type NavigationSection = {
+  title: string
+  links: NavigationLink[]
+}
+
+const NAVIGATION_SECTIONS: NavigationSection[] = [
+  {
+    title: '總覽',
+    links: [{ to: '/', label: 'Dashboard', icon: <LayoutDashboard className="size-4" />, exact: true }],
+  },
+  {
+    title: '領用',
+    links: [
+      {
+        to: '/issues',
+        label: '領用清單',
+        icon: <HandCoins className="size-4" />,
+        isActive: (pathname) => pathname === '/issues' || /^\/issues\/\d+$/.test(pathname),
+      },
+      { to: '/issues/new', label: '新增領用', icon: <FilePlus2 className="size-4" />, exact: true },
+    ],
+  },
+  {
+    title: '借用',
+    links: [
+      {
+        to: '/borrows',
+        label: '借用清單',
+        icon: <Handshake className="size-4" />,
+        isActive: (pathname) => pathname === '/borrows' || /^\/borrows\/\d+$/.test(pathname),
+      },
+      { to: '/borrows/new', label: '新增借用', icon: <FilePlus2 className="size-4" />, exact: true },
+    ],
+  },
+  {
+    title: '捐贈',
+    links: [
+      {
+        to: '/donations',
+        label: '捐贈清單',
+        icon: <ClipboardList className="size-4" />,
+        isActive: (pathname) => pathname === '/donations' || /^\/donations\/\d+$/.test(pathname),
+      },
+      { to: '/donations/new', label: '新增捐贈', icon: <FilePlus2 className="size-4" />, exact: true },
+    ],
+  },
+  {
+    title: '資產',
+    links: [
+      {
+        to: '/inventory',
+        label: '財產清單',
+        icon: <Boxes className="size-4" />,
+        isActive: (pathname) => pathname === '/inventory' || /^\/inventory\/edit\/\d+$/.test(pathname),
+      },
+      { to: '/inventory/new', label: '新增庫存', icon: <ClipboardList className="size-4" />, exact: true },
+      { to: '/upload', label: '批次上傳', icon: <Upload className="size-4" />, exact: true },
+    ],
+  },
+]
+
+type PageMeta = {
+  title: string
+  description: string
+}
+
+function resolvePageMeta(pathname: string): PageMeta {
+  if (pathname === '/') {
+    return { title: 'Dashboard', description: '資產管理整體狀態與近期活動' }
+  }
+  if (pathname === '/inventory') {
+    return { title: '財產清單', description: '查詢、篩選與維護現有資產資料' }
+  }
+  if (pathname === '/inventory/new') {
+    return { title: '新增庫存', description: '建立新的資產資料' }
+  }
+  if (/^\/inventory\/edit\/\d+$/.test(pathname)) {
+    return { title: '編輯庫存', description: '更新既有資產資訊與狀態' }
+  }
+  if (pathname === '/issues') {
+    return { title: '領用清單', description: '查看與管理領用申請紀錄' }
+  }
+  if (pathname === '/issues/new') {
+    return { title: '新增領用', description: '建立新的領用申請單' }
+  }
+  if (/^\/issues\/\d+$/.test(pathname)) {
+    return { title: '編輯領用', description: '更新指定領用申請資料' }
+  }
+  if (pathname === '/borrows') {
+    return { title: '借用清單', description: '查看借用申請與歸還狀態' }
+  }
+  if (pathname === '/borrows/new') {
+    return { title: '新增借用', description: '建立新的借用申請單' }
+  }
+  if (/^\/borrows\/\d+$/.test(pathname)) {
+    return { title: '編輯借用', description: '更新借用單與歸還資訊' }
+  }
+  if (pathname === '/donations') {
+    return { title: '捐贈清單', description: '查詢對外捐贈申請與品項' }
+  }
+  if (pathname === '/donations/new') {
+    return { title: '新增捐贈', description: '建立新的捐贈申請單' }
+  }
+  if (/^\/donations\/\d+$/.test(pathname)) {
+    return { title: '編輯捐贈', description: '更新捐贈申請內容' }
+  }
+  if (pathname === '/upload') {
+    return { title: '批次上傳', description: '透過 xlsx 匯入資產資料' }
+  }
+
+  return { title: '頁面', description: '系統頁面' }
+}
+
+type SidebarContentProps = {
+  collapsible?: boolean
+  onSelect?: () => void
+}
+
+function SidebarContent({ collapsible = false, onSelect }: SidebarContentProps) {
+  const location = useLocation()
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() => {
+    const initialState: Record<string, boolean> = {}
+    for (const section of NAVIGATION_SECTIONS) {
+      initialState[section.title] = section.links.some((link) => {
+        if (link.isActive) {
+          return link.isActive(location.pathname)
+        }
+        if (link.exact) {
+          return location.pathname === link.to
+        }
+        return location.pathname === link.to || location.pathname.startsWith(`${link.to}/`)
+      })
+    }
+    return initialState
+  })
+
+  function toggleSection(title: string) {
+    setExpandedSections((previousState) => ({
+      ...previousState,
+      [title]: !previousState[title],
+    }))
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6 px-3 pb-5 pt-4">
+      <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))]/70 px-4 py-3">
+        <p className="m-0 text-xs font-semibold tracking-[0.16em] text-[hsl(var(--muted-foreground))] uppercase">Inventory Hub</p>
+        <p className="mt-1 mb-0 text-sm text-[hsl(var(--muted-foreground))]">Admin Console</p>
+      </div>
+
+      <div className="grid gap-5">
+        {NAVIGATION_SECTIONS.map((section) => (
+          <section key={section.title} className="grid gap-2">
+            {collapsible ? (
+              <button
+                type="button"
+                className="inline-flex w-full items-center justify-between rounded-lg px-2 py-1 text-xs font-semibold tracking-[0.16em] text-[hsl(var(--muted-foreground))] uppercase hover:bg-[hsl(var(--secondary))]"
+                onClick={() => toggleSection(section.title)}
+                aria-expanded={expandedSections[section.title] ? 'true' : 'false'}
+                aria-controls={`section-${section.title}`}
+              >
+                <span>{section.title}</span>
+                <ChevronDown className={cn('size-4 transition-transform', expandedSections[section.title] && 'rotate-180')} />
+              </button>
+            ) : (
+              <h2 className="px-2 text-xs font-semibold tracking-[0.16em] text-[hsl(var(--muted-foreground))] uppercase">{section.title}</h2>
+            )}
+            <div
+              id={collapsible ? `section-${section.title}` : undefined}
+              className={cn('grid gap-1', collapsible && !expandedSections[section.title] && 'hidden')}
+            >
+              {section.links.map((link) => {
+                const isActive = link.isActive
+                  ? link.isActive(location.pathname)
+                  : link.exact
+                    ? location.pathname === link.to
+                    : location.pathname === link.to || location.pathname.startsWith(`${link.to}/`)
+
+                return (
+                  <Link
+                    key={link.to}
+                    to={link.to}
+                    onClick={onSelect}
+                    className={cn(
+                      'group inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-[hsl(var(--muted-foreground))] no-underline transition-colors hover:bg-[hsl(var(--secondary))] hover:text-[hsl(var(--foreground))] focus-visible:bg-[hsl(var(--secondary))] focus-visible:text-[hsl(var(--foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--foreground))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--sidebar-background))]',
+                      isActive &&
+                        'bg-[hsl(var(--secondary))] text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))] hover:text-[hsl(var(--foreground))] focus-visible:bg-[hsl(var(--secondary))] focus-visible:text-[hsl(var(--foreground))] focus-visible:ring-[hsl(var(--foreground))]',
+                    )}
+                  >
+                    {link.icon}
+                    <span>{link.label}</span>
+                  </Link>
+                )
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function AppShell() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const location = useLocation()
+
+  const pageMeta = useMemo(() => resolvePageMeta(location.pathname), [location.pathname])
+
+  return (
+    <div className="relative min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))]">
+      <div className="grid min-h-screen w-full grid-cols-1 lg:grid-cols-[264px_minmax(0,1fr)]">
+        <aside className="hidden border-r border-[hsl(var(--border))] bg-[hsl(var(--sidebar-background))] lg:block">
+          <SidebarContent />
+        </aside>
+
+        <div className="grid min-h-screen grid-rows-[auto_minmax(0,1fr)]">
+          <header className="sticky top-0 z-20 border-b border-[hsl(var(--border))] bg-[hsl(var(--background))/0.88] px-4 py-3 backdrop-blur md:px-6">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 md:gap-3">
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center justify-center rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-2 text-[hsl(var(--foreground))] lg:hidden"
+                  onClick={() => setIsSidebarOpen(true)}
+                  aria-label="Open menu"
+                >
+                  <Menu className="size-4" />
+                </button>
+                <div>
+                  <h1 className="m-0 text-lg font-semibold md:text-xl">{pageMeta.title}</h1>
+                  <p className="m-0 text-xs text-[hsl(var(--muted-foreground))] md:text-sm">{pageMeta.description}</p>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <main className="overflow-y-auto px-4 pb-7 pt-5 md:px-6 md:pb-10">
+            <div className="grid w-full gap-5">
+              <Outlet />
+            </div>
+          </main>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          'fixed inset-0 z-30 bg-black/45 transition-opacity lg:hidden',
+          isSidebarOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+        )}
+        onClick={() => setIsSidebarOpen(false)}
+        aria-hidden="true"
+      />
+
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-40 w-[280px] border-r border-[hsl(var(--border))] bg-[hsl(var(--sidebar-background))] shadow-2xl transition-transform lg:hidden',
+          isSidebarOpen ? 'translate-x-0' : '-translate-x-full',
+        )}
+      >
+        <div className="flex items-center justify-between px-3 pb-1 pt-3">
+          <p className="m-0 text-xs font-semibold tracking-[0.16em] text-[hsl(var(--muted-foreground))] uppercase">Navigation</p>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-1.5"
+            onClick={() => setIsSidebarOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <SidebarContent collapsible onSelect={() => setIsSidebarOpen(false)} />
+      </aside>
+    </div>
+  )
+}

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
-import type { BorrowRequest } from './types'
+import { DataPagination } from '../ui/data-pagination'
+import type { BorrowRequest, PaginatedResponse } from './types'
 
 const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
 const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
@@ -9,30 +10,91 @@ const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-t
 const statusClassMap: Record<string, string> = {
   borrowed: 'bg-amber-100 text-amber-800',
   returned: 'bg-emerald-100 text-emerald-700',
-  overdue: 'bg-red-100 text-red-700'
+  overdue: 'bg-red-100 text-red-700',
 }
 
 const getStatusBadgeClass = (status: string) =>
   statusClassMap[status] ?? 'bg-slate-100 text-slate-700'
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return parsed
+}
+
+function readInitialState() {
+  const params = new URLSearchParams(window.location.search)
+  const statusParam = params.get('status')
+  const status: 'all' | 'borrowed' | 'returned' | 'overdue' = statusParam === 'borrowed' || statusParam === 'returned' || statusParam === 'overdue' ? statusParam : 'all'
+
+  return {
+    keyword: params.get('keyword') ?? '',
+    status,
+    page: parsePositiveInt(params.get('page'), 1),
+    pageSize: parsePositiveInt(params.get('page_size'), 10),
+  }
+}
+
 export function BorrowListPage() {
+  const initialState = readInitialState()
   const [requests, setRequests] = useState<BorrowRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
-  const [keyword, setKeyword] = useState('')
-  const [statusFilter, setStatusFilter] = useState<'all' | 'borrowed' | 'returned' | 'overdue'>('all')
+  const [keyword, setKeyword] = useState(initialState.keyword)
+  const [statusFilter, setStatusFilter] = useState<'all' | 'borrowed' | 'returned' | 'overdue'>(initialState.status)
+  const [page, setPage] = useState(initialState.page)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim())
+    }
+    if (statusFilter !== 'all') {
+      params.set('status', statusFilter)
+    }
+    if (page !== 1) {
+      params.set('page', String(page))
+    }
+    if (pageSize !== 10) {
+      params.set('page_size', String(pageSize))
+    }
+    const queryString = params.toString()
+    const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+    window.history.replaceState(null, '', url)
+  }, [keyword, statusFilter, page, pageSize])
 
   useEffect(() => {
     const loadRequests = async () => {
       setLoading(true)
       setLoadError('')
       try {
-        const response = await fetch(apiUrl('/api/borrows'))
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(pageSize),
+        })
+        if (keyword.trim()) {
+          params.set('keyword', keyword.trim())
+        }
+        if (statusFilter !== 'all') {
+          params.set('status', statusFilter)
+        }
+
+        const response = await fetch(apiUrl(`/api/borrows?${params.toString()}`))
         if (!response.ok) {
           throw new Error('無法載入借用清單')
         }
-        const payload = (await response.json()) as BorrowRequest[]
-        setRequests(payload)
+        const payload = (await response.json()) as PaginatedResponse<BorrowRequest>
+        setRequests(payload.items)
+        setTotal(payload.total)
+        setTotalPages(payload.total_pages)
       } catch {
         setLoadError('目前無法讀取借用清單，請稍後重試。')
       } finally {
@@ -41,28 +103,7 @@ export function BorrowListPage() {
     }
 
     void loadRequests()
-  }, [])
-
-  const filteredRequests = useMemo(() => {
-    const normalizedKeyword = keyword.trim().toLowerCase()
-    const normalize = (value: string | null | undefined) => (value ?? '').toLowerCase()
-
-    return requests.filter((request) => {
-      if (statusFilter !== 'all' && request.status !== statusFilter) {
-        return false
-      }
-
-      if (!normalizedKeyword) {
-        return true
-      }
-
-      const itemMatches = request.items.some((item) =>
-        normalize(item.item_name).includes(normalizedKeyword)
-      )
-      const fields = [request.borrower, request.department, request.purpose, request.memo, request.borrow_date]
-      return itemMatches || fields.some((field) => normalize(field).includes(normalizedKeyword))
-    })
-  }, [keyword, requests, statusFilter])
+  }, [keyword, statusFilter, page, pageSize])
 
   return (
     <>
@@ -77,7 +118,10 @@ export function BorrowListPage() {
             type="search"
             placeholder="輸入借用人、品項、用途..."
             value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
+            onChange={(event) => {
+              setKeyword(event.target.value)
+              setPage(1)
+            }}
           />
           <label htmlFor="borrow-status" className="font-bold">
             狀態篩選
@@ -86,75 +130,92 @@ export function BorrowListPage() {
             className={fieldClass}
             id="borrow-status"
             value={statusFilter}
-            onChange={(event) => setStatusFilter(event.target.value as 'all' | 'borrowed' | 'returned' | 'overdue')}
+            onChange={(event) => {
+              setStatusFilter(event.target.value as 'all' | 'borrowed' | 'returned' | 'overdue')
+              setPage(1)
+            }}
           >
             <option value="all">全部狀態</option>
             <option value="borrowed">借出中</option>
             <option value="returned">已歸還</option>
             <option value="overdue">逾期</option>
           </select>
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredRequests.length} 筆資料</p>
+          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
         </div>
 
         {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
         {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
-          <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-              <thead>
-                <tr>
-                  {['#', '借用日期', '借用人/單位', '用途', '歸還/狀態', '品項', '備註'].map((header) => (
-                    <th key={header} className={tableHeaderClass}>{header}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRequests.length === 0 ? (
+          <>
+            <div className="w-full overflow-x-auto">
+              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
+                <thead>
                   <tr>
-                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
-                      目前沒有符合條件的借用單。
-                    </td>
+                    {['#', '借用日期', '借用人/單位', '用途', '歸還/狀態', '品項', '備註'].map((header) => (
+                      <th key={header} className={tableHeaderClass}>{header}</th>
+                    ))}
                   </tr>
-                ) : (
-                  filteredRequests.map((request) => (
-                    <tr key={request.id}>
-                      <td className={tableCellClass}>
-                        <Link className="font-bold text-blue-700 no-underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
-                          {request.id}
-                        </Link>
+                </thead>
+                <tbody>
+                  {requests.length === 0 ? (
+                    <tr>
+                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
+                        目前沒有符合條件的借用單。
                       </td>
-                      <td className={tableCellClass}>{request.borrow_date || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="font-bold">{request.borrower || '--'}</div>
-                        <div className="text-sm text-slate-500">{request.department || ''}</div>
-                      </td>
-                      <td className={tableCellClass}>{request.purpose || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="text-sm">預計：{request.due_date || '--'}</div>
-                        <div className="text-sm">實際：{request.return_date || '--'}</div>
-                        <div
-                          className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-bold ${getStatusBadgeClass(request.status)}`}
-                        >
-                          {request.status}
-                        </div>
-                      </td>
-                      <td className={tableCellClass}>
-                        <div className="grid gap-1">
-                          {request.items.map((item) => (
-                            <div key={item.id} className="text-sm">
-                              {(item.item_name || `#${item.item_id}`)} x {item.quantity}
-                            </div>
-                          ))}
-                        </div>
-                      </td>
-                      <td className={tableCellClass}>{request.memo || '--'}</td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+                  ) : (
+                    requests.map((request) => (
+                      <tr key={request.id}>
+                        <td className={tableCellClass}>
+                          <Link className="font-bold text-blue-700 no-underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
+                            {request.id}
+                          </Link>
+                        </td>
+                        <td className={tableCellClass}>{request.borrow_date || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="font-bold">{request.borrower || '--'}</div>
+                          <div className="text-sm text-slate-500">{request.department || ''}</div>
+                        </td>
+                        <td className={tableCellClass}>{request.purpose || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="text-sm">預計：{request.due_date || '--'}</div>
+                          <div className="text-sm">實際：{request.return_date || '--'}</div>
+                          <div
+                            className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-bold ${getStatusBadgeClass(request.status)}`}
+                          >
+                            {request.status}
+                          </div>
+                        </td>
+                        <td className={tableCellClass}>
+                          <div className="grid gap-1">
+                            {request.items.map((item) => (
+                              <div key={item.id} className="text-sm">
+                                {(item.item_name || `#${item.item_id}`)} x {item.quantity}
+                              </div>
+                            ))}
+                          </div>
+                        </td>
+                        <td className={tableCellClass}>{request.memo || '--'}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <DataPagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              totalPages={totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize)
+                setPage(1)
+              }}
+            />
+          </>
         ) : null}
       </section>
     </>

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -1,20 +1,24 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { FilterBar } from '../ui/filter-bar'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import type { BorrowRequest, PaginatedResponse } from './types'
 
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
-const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
-const statusClassMap: Record<string, string> = {
-  borrowed: 'bg-amber-100 text-amber-800',
-  returned: 'bg-emerald-100 text-emerald-700',
-  overdue: 'bg-red-100 text-red-700',
+const statusLabelMap: Record<string, string> = {
+  borrowed: '借出中',
+  returned: '已歸還',
+  overdue: '逾期',
 }
-
-const getStatusBadgeClass = (status: string) =>
-  statusClassMap[status] ?? 'bg-slate-100 text-slate-700'
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
@@ -30,7 +34,8 @@ function parsePositiveInt(value: string | null, fallback: number): number {
 function readInitialState() {
   const params = new URLSearchParams(window.location.search)
   const statusParam = params.get('status')
-  const status: 'all' | 'borrowed' | 'returned' | 'overdue' = statusParam === 'borrowed' || statusParam === 'returned' || statusParam === 'overdue' ? statusParam : 'all'
+  const status: 'all' | 'borrowed' | 'returned' | 'overdue' =
+    statusParam === 'borrowed' || statusParam === 'returned' || statusParam === 'overdue' ? statusParam : 'all'
 
   return {
     keyword: params.get('keyword') ?? '',
@@ -107,101 +112,135 @@ export function BorrowListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <div className="mb-4 grid gap-2">
-          <label htmlFor="borrow-search" className="font-bold">
-            關鍵字搜尋
-          </label>
-          <input
-            className={fieldClass}
-            id="borrow-search"
-            type="search"
-            placeholder="輸入借用人、品項、用途..."
-            value={keyword}
-            onChange={(event) => {
-              setKeyword(event.target.value)
-              setPage(1)
-            }}
-          />
-          <label htmlFor="borrow-status" className="font-bold">
-            狀態篩選
-          </label>
-          <select
-            className={fieldClass}
-            id="borrow-status"
-            value={statusFilter}
-            onChange={(event) => {
-              setStatusFilter(event.target.value as 'all' | 'borrowed' | 'returned' | 'overdue')
-              setPage(1)
-            }}
-          >
-            <option value="all">全部狀態</option>
-            <option value="borrowed">借出中</option>
-            <option value="returned">已歸還</option>
-            <option value="overdue">逾期</option>
-          </select>
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
-        </div>
+      <PageHeader
+        title="借用清單"
+        description="追蹤借出、歸還與逾期狀態。"
+        actions={
+          <Link to="/borrows/new">
+            <Button>
+              <Plus className="size-4" />
+              新增借用
+            </Button>
+          </Link>
+        }
+      />
 
-        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
-        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+      <SectionCard>
+        <FilterBar className="xl:grid-cols-[2fr_1fr_1fr]">
+          <div className="grid gap-1.5">
+            <Label htmlFor="borrow-search">關鍵字搜尋</Label>
+            <Input
+              id="borrow-search"
+              type="search"
+              placeholder="輸入借用人、品項、用途..."
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value)
+                setPage(1)
+              }}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="borrow-status">狀態篩選</Label>
+            <Select
+              id="borrow-status"
+              value={statusFilter}
+              onChange={(event) => {
+                setStatusFilter(event.target.value as 'all' | 'borrowed' | 'returned' | 'overdue')
+                setPage(1)
+              }}
+            >
+              <option value="all">全部狀態</option>
+              <option value="borrowed">借出中</option>
+              <option value="returned">已歸還</option>
+              <option value="overdue">逾期</option>
+            </Select>
+          </div>
+          <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
+        </FilterBar>
+
+        {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+        {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
           <>
-            <div className="w-full overflow-x-auto">
-              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-                <thead>
-                  <tr>
-                    {['#', '借用日期', '借用人/單位', '用途', '歸還/狀態', '品項', '備註'].map((header) => (
-                      <th key={header} className={tableHeaderClass}>{header}</th>
+            <div className="hidden overflow-x-auto md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {['#', '借用日期', '借用人/單位', '用途', '歸還資訊', '品項', '備註'].map((header) => (
+                      <TableHead key={header}>{header}</TableHead>
                     ))}
-                  </tr>
-                </thead>
-                <tbody>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {requests.length === 0 ? (
-                    <tr>
-                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
+                    <TableRow>
+                      <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={7}>
                         目前沒有符合條件的借用單。
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ) : (
                     requests.map((request) => (
-                      <tr key={request.id}>
-                        <td className={tableCellClass}>
-                          <Link className="font-bold text-blue-700 no-underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
+                      <TableRow key={request.id}>
+                        <TableCell>
+                          <Link className="font-semibold text-blue-700 no-underline hover:underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
                             {request.id}
                           </Link>
-                        </td>
-                        <td className={tableCellClass}>{request.borrow_date || '--'}</td>
-                        <td className={tableCellClass}>
-                          <div className="font-bold">{request.borrower || '--'}</div>
-                          <div className="text-sm text-slate-500">{request.department || ''}</div>
-                        </td>
-                        <td className={tableCellClass}>{request.purpose || '--'}</td>
-                        <td className={tableCellClass}>
-                          <div className="text-sm">預計：{request.due_date || '--'}</div>
-                          <div className="text-sm">實際：{request.return_date || '--'}</div>
-                          <div
-                            className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-bold ${getStatusBadgeClass(request.status)}`}
-                          >
-                            {request.status}
-                          </div>
-                        </td>
-                        <td className={tableCellClass}>
+                        </TableCell>
+                        <TableCell>{request.borrow_date || '--'}</TableCell>
+                        <TableCell>
+                          <div className="font-semibold">{request.borrower || '--'}</div>
+                          <div className="text-xs text-[hsl(var(--muted-foreground))]">{request.department || ''}</div>
+                        </TableCell>
+                        <TableCell>{request.purpose || '--'}</TableCell>
+                        <TableCell>
+                          <div className="text-xs">預計：{request.due_date || '--'}</div>
+                          <div className="text-xs">實際：{request.return_date || '--'}</div>
+                          <Badge className="mt-1" variant="secondary">
+                            {statusLabelMap[request.status] || request.status || '--'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
                           <div className="grid gap-1">
                             {request.items.map((item) => (
-                              <div key={item.id} className="text-sm">
+                              <div key={item.id} className="text-xs">
                                 {(item.item_name || `#${item.item_id}`)} x {item.quantity}
                               </div>
                             ))}
                           </div>
-                        </td>
-                        <td className={tableCellClass}>{request.memo || '--'}</td>
-                      </tr>
+                        </TableCell>
+                        <TableCell>{request.memo || '--'}</TableCell>
+                      </TableRow>
                     ))
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="grid gap-3 md:hidden">
+              {requests.length === 0 ? (
+                <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                  目前沒有符合條件的借用單。
+                </p>
+              ) : (
+                requests.map((request) => (
+                  <article key={request.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                    <div className="flex items-center justify-between">
+                      <Link className="font-semibold text-blue-700 no-underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
+                        #{request.id}
+                      </Link>
+                      <Badge variant="secondary">{statusLabelMap[request.status] || request.status || '--'}</Badge>
+                    </div>
+                    <p className="mt-2 mb-0 text-sm font-semibold">{request.borrower || '--'}</p>
+                    <p className="mt-0.5 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{request.department || '--'}</p>
+                    <p className="mt-2 mb-0 text-sm">借用：{request.borrow_date || '--'} / 歸還：{request.return_date || '--'}</p>
+                    <p className="mt-2 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
+                      品項：{request.items.map((item) => `${item.item_name || `#${item.item_id}`} x ${item.quantity}`).join('，') || '--'}
+                    </p>
+                  </article>
+                ))
+              )}
             </div>
 
             <DataPagination
@@ -217,7 +256,7 @@ export function BorrowListPage() {
             />
           </>
         ) : null}
-      </section>
+      </SectionCard>
     </>
   )
 }

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
 import type { BorrowRequest } from './types'
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
-const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
+const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 const statusClassMap: Record<string, string> = {
   borrowed: 'bg-amber-100 text-amber-800',
   returned: 'bg-emerald-100 text-emerald-700',
@@ -65,12 +66,7 @@ export function BorrowListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">借用清單</h1>
-        <p className="mt-2 text-slate-500">可依借用人、品項、用途或狀態快速查詢。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <div className="mb-4 grid gap-2">
           <label htmlFor="borrow-search" className="font-bold">
             關鍵字搜尋
@@ -105,7 +101,7 @@ export function BorrowListPage() {
 
         {!loading && !loadError ? (
           <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
               <thead>
                 <tr>
                   {['#', '借用日期', '借用人/單位', '用途', '歸還/狀態', '品項', '備註'].map((header) => (
@@ -124,9 +120,9 @@ export function BorrowListPage() {
                   filteredRequests.map((request) => (
                     <tr key={request.id}>
                       <td className={tableCellClass}>
-                        <a className="font-bold text-blue-700 no-underline" href={`/borrows/${request.id}`}>
+                        <Link className="font-bold text-blue-700 no-underline" to="/borrows/$requestId" params={{ requestId: String(request.id) }}>
                           {request.id}
-                        </a>
+                        </Link>
                       </td>
                       <td className={tableCellClass}>{request.borrow_date || '--'}</td>
                       <td className={tableCellClass}>

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Textarea } from '../ui/textarea'
 import type { BorrowRequest, InventoryItem, PaginatedResponse } from './types'
 
 type BorrowLine = {
@@ -9,8 +16,6 @@ type BorrowLine = {
   note: string
 }
 
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): BorrowLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -87,7 +92,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
               quantity: item.quantity,
               note: item.note ?? '',
             }))
-            : [emptyLine()]
+            : [emptyLine()],
         )
       } catch {
         setLoadError('目前無法讀取借用單資料，請稍後重試。')
@@ -106,14 +111,6 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
   const handleLineChange = (index: number, patch: Partial<BorrowLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
-  }
-
-  const handleAddLine = () => {
-    setLines((prev) => [...prev, emptyLine()])
-  }
-
-  const handleRemoveLine = (index: number) => {
-    setLines((prev) => prev.filter((_, idx) => idx !== index))
   }
 
   const validateLines = () => {
@@ -183,65 +180,60 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯借用單' : '新增借用單'}</h2>
-        <div className="mt-4 grid gap-3">
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="grid gap-2 font-bold">
-              借用人
-              <input className={fieldClass} value={borrower} onChange={(event) => setBorrower(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              單位
-              <input className={fieldClass} value={department} onChange={(event) => setDepartment(event.target.value)} />
-            </label>
-          </div>
-          <label className="grid gap-2 font-bold">
-            用途
-            <input className={fieldClass} value={purpose} onChange={(event) => setPurpose(event.target.value)} />
-          </label>
-          <div className="grid gap-2 md:grid-cols-3">
-            <label className="grid gap-2 font-bold">
-              借用日期
-              <input className={fieldClass} type="date" value={borrowDate} onChange={(event) => setBorrowDate(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              預計歸還
-              <input className={fieldClass} type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              實際歸還
-              <input className={fieldClass} type="date" value={returnDate} onChange={(event) => setReturnDate(event.target.value)} />
-            </label>
-          </div>
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="grid gap-2 font-bold">
-              狀態
-              <select className={fieldClass} value={status} onChange={(event) => setStatus(event.target.value)}>
+      <PageHeader
+        title={isEditing ? '編輯借用單' : '新增借用單'}
+        description="建立借用紀錄並追蹤歸還狀態。"
+      />
+
+      <div className="grid gap-4">
+        <SectionCard title="基本資料">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid gap-1.5">
+              <Label>借用人</Label>
+              <Input value={borrower} onChange={(event) => setBorrower(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>單位</Label>
+              <Input value={department} onChange={(event) => setDepartment(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5 md:col-span-2">
+              <Label>用途</Label>
+              <Input value={purpose} onChange={(event) => setPurpose(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>借用日期</Label>
+              <Input type="date" value={borrowDate} onChange={(event) => setBorrowDate(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>預計歸還</Label>
+              <Input type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>實際歸還</Label>
+              <Input type="date" value={returnDate} onChange={(event) => setReturnDate(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>狀態</Label>
+              <Select value={status} onChange={(event) => setStatus(event.target.value)}>
                 <option value="borrowed">借出中</option>
                 <option value="returned">已歸還</option>
                 <option value="overdue">逾期</option>
-              </select>
-            </label>
-            <label className="grid gap-2 font-bold">
-              備註
-              <input className={fieldClass} value={memo} onChange={(event) => setMemo(event.target.value)} />
-            </label>
+              </Select>
+            </div>
+            <div className="grid gap-1.5 md:col-span-2">
+              <Label>備註</Label>
+              <Textarea rows={3} value={memo} onChange={(event) => setMemo(event.target.value)} />
+            </div>
           </div>
-        </div>
+        </SectionCard>
 
-        <div className="mt-6">
-          <div className="flex items-center justify-between">
-            <h3 className="m-0 text-base font-bold">借用品項</h3>
-          </div>
-
-          <div className="mt-3 grid gap-3">
+        <SectionCard title="借用品項">
+          <div className="grid gap-3">
             {lines.map((line, index) => (
-              <div key={`borrow-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
-                <label className="grid gap-2 font-bold">
-                  品項
-                  <select
-                    className={fieldClass}
+              <article key={`borrow-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+                <div className="grid gap-1.5">
+                  <Label>品項</Label>
+                  <Select
                     value={line.item_id}
                     onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
                   >
@@ -251,48 +243,41 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                         {option.label}
                       </option>
                     ))}
-                  </select>
-                </label>
-                <label className="grid gap-2 font-bold">
-                  數量
-                  <input
-                    className={fieldClass}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>數量</Label>
+                  <Input
                     type="number"
                     min={1}
                     value={line.quantity}
                     onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
                   />
-                </label>
-                <label className="grid gap-2 font-bold">
-                  備註
-                  <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
-                </label>
-                <div className="flex items-end">
-                  <button
-                    type="button"
-                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
-                    onClick={() => handleRemoveLine(index)}
-                    disabled={lines.length <= 1}
-                  >
-                    移除
-                  </button>
                 </div>
-              </div>
+                <div className="grid gap-1.5">
+                  <Label>備註</Label>
+                  <Input value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                </div>
+                <div className="flex items-end">
+                  <Button type="button" variant="secondary" onClick={() => setLines((prev) => prev.filter((_, idx) => idx !== index))} disabled={lines.length <= 1}>
+                    移除
+                  </Button>
+                </div>
+              </article>
             ))}
           </div>
 
-          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-xl px-4 py-3">
-            <button className={buttonClass} type="button" onClick={handleAddLine}>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <Button type="button" variant="secondary" onClick={() => setLines((prev) => [...prev, emptyLine()])}>
               新增品項
-            </button>
-            <button className={buttonClass} type="button" onClick={handleSubmit} disabled={submitting}>
+            </Button>
+            <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
               {submitting ? (isEditing ? '更新中...' : '建立中...') : (isEditing ? '更新借用單' : '建立借用單')}
-            </button>
-            {loadError ? <span className="text-sm text-red-600">{loadError}</span> : null}
+            </Button>
           </div>
-        </div>
-      </section>
-
+          {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
+        </SectionCard>
+      </div>
     </>
   )
 }

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
-import type { BorrowRequest, InventoryItem } from './types'
+import type { BorrowRequest, InventoryItem, PaginatedResponse } from './types'
 
 type BorrowLine = {
   item_id: number | ''
@@ -44,12 +44,12 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     const loadData = async () => {
       setLoadError('')
       try {
-        const itemsResponse = await fetch(apiUrl('/api/items'))
+        const itemsResponse = await fetch(apiUrl('/api/items?page=1&page_size=100000'))
         if (!itemsResponse.ok) {
           throw new Error('無法載入資料')
         }
-        const itemsPayload = (await itemsResponse.json()) as InventoryItem[]
-        setInventoryItems(itemsPayload)
+        const itemsPayload = (await itemsResponse.json()) as PaginatedResponse<InventoryItem>
+        setInventoryItems(itemsPayload.items)
       } catch {
         setLoadError('目前無法讀取借用資料，請稍後重試。')
       }

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -9,8 +9,8 @@ type BorrowLine = {
   note: string
 }
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): BorrowLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -183,12 +183,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">借用管理</h1>
-        <p className="mt-2 text-slate-500">建立借用單，並可一次選擇多個品項。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯借用單' : '新增借用單'}</h2>
         <div className="mt-4 grid gap-3">
           <div className="grid gap-2 md:grid-cols-2">
@@ -242,7 +237,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
           <div className="mt-3 grid gap-3">
             {lines.map((line, index) => (
-              <div key={`borrow-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
+              <div key={`borrow-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
                 <label className="grid gap-2 font-bold">
                   品項
                   <select
@@ -275,7 +270,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                 <div className="flex items-end">
                   <button
                     type="button"
-                    className="cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600"
+                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
                     onClick={() => handleRemoveLine(index)}
                     disabled={lines.length <= 1}
                   >

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
+import { Activity, AlertTriangle, Boxes, Server } from 'lucide-react'
 import { apiUrl } from '../../api'
 import type { DashboardPayload } from './types'
-
-const cardClass = 'rounded-2xl bg-white shadow-[0_12px_30px_rgba(31,41,55,0.12)]'
+import { Badge } from '../ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Separator } from '../ui/separator'
 
 export function DashboardPage() {
   const [dashboardData, setDashboardData] = useState<DashboardPayload | null>(null)
@@ -27,35 +29,78 @@ export function DashboardPage() {
 
   return (
     <>
-      <section className={`${cardClass} px-7 py-6`}>
-        <h1 className="mt-0">資產管理 Dashboard</h1>
-        <p className="mt-2 text-slate-500">此頁面僅顯示系統數據。</p>
+      <Card className="border-0 bg-gradient-to-r from-slate-900 to-slate-700 text-white shadow-lg">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <CardTitle className="text-2xl text-white">資產管理 Dashboard</CardTitle>
+              <CardDescription className="mt-2 text-slate-200">此頁面僅顯示系統數據。</CardDescription>
+            </div>
+            <Badge variant="secondary" className="bg-white/15 text-white">
+              <Activity className="size-3.5" />
+              系統摘要
+            </Badge>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <section className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-4">
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle>系統狀態</CardTitle>
+              <Server className="size-4 text-[hsl(var(--muted-foreground))]" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.status ?? '讀取中...'}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle>資產總數</CardTitle>
+              <Boxes className="size-4 text-[hsl(var(--muted-foreground))]" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.items ?? '--'}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle>待修改資料</CardTitle>
+              <AlertTriangle className="size-4 text-amber-500" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.pendingFix ?? '--'}</p>
+            <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">財產編號空值或包含中文</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle>後端訊息</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">{dashboardData?.data ?? '等待資料載入'}</p>
+          </CardContent>
+        </Card>
       </section>
 
-      <section className="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
-        <article className={`${cardClass} p-5`}>
-          <h2 className="mt-0">系統狀態</h2>
-          <p className="m-0 text-[1.75rem] font-bold text-blue-700">{dashboardData?.status ?? '讀取中...'}</p>
-        </article>
+      <Separator className="my-1" />
 
-        <article className={`${cardClass} p-5`}>
-          <h2 className="mt-0">資產總數</h2>
-          <p className="m-0 text-[1.75rem] font-bold text-blue-700">{dashboardData?.items ?? '--'}</p>
-        </article>
-
-        <article className={`${cardClass} p-5`}>
-          <h2 className="mt-0">待修改資料</h2>
-          <p className="m-0 text-[1.75rem] font-bold text-blue-700">{dashboardData?.pendingFix ?? '--'}</p>
-          <p className="mt-1.5 text-[0.92rem] text-slate-500">財產編號空值或包含中文</p>
-        </article>
-
-        <article className={`${cardClass} p-5`}>
-          <h2 className="mt-0">後端訊息</h2>
-          <p>{dashboardData?.data ?? '等待資料載入'}</p>
-        </article>
-      </section>
-
-      {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+      {loadError ? (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="p-4">
+            <p className="m-0 text-sm text-red-700">{loadError}</p>
+          </CardContent>
+        </Card>
+      ) : null}
     </>
   )
 }

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react'
 import { apiUrl } from '../../api'
 import { buildAssetStatusLabelMap, fetchAssetStatusOptions, toAssetStatusLabel } from './assetStatusLookup'
-import type { BorrowRequest, DashboardPayload, DonationRequest, InventoryItem, IssueRequest } from './types'
+import type { BorrowRequest, DashboardPayload, DonationRequest, InventoryItem, IssueRequest, PaginatedResponse } from './types'
 import { Badge } from '../ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
 
@@ -73,17 +73,17 @@ export function DashboardPage() {
       try {
         const [dashboardPayload, inventoryPayload, issuePayload, borrowPayload, donationPayload] = await Promise.all([
           fetchJson<DashboardPayload>('/api/data'),
-          fetchJson<InventoryItem[]>('/api/items?include_donated=true'),
-          fetchJson<IssueRequest[]>('/api/issues'),
-          fetchJson<BorrowRequest[]>('/api/borrows'),
-          fetchJson<DonationRequest[]>('/api/donations'),
+          fetchJson<PaginatedResponse<InventoryItem>>('/api/items?include_donated=true&page=1&page_size=100000'),
+          fetchJson<PaginatedResponse<IssueRequest>>('/api/issues?page=1&page_size=100000'),
+          fetchJson<PaginatedResponse<BorrowRequest>>('/api/borrows?page=1&page_size=100000'),
+          fetchJson<PaginatedResponse<DonationRequest>>('/api/donations?page=1&page_size=100000'),
         ])
 
         setDashboardData(dashboardPayload)
-        setItems(inventoryPayload)
-        setIssues(issuePayload)
-        setBorrows(borrowPayload)
-        setDonations(donationPayload)
+        setItems(inventoryPayload.items)
+        setIssues(issuePayload.items)
+        setBorrows(borrowPayload.items)
+        setDonations(donationPayload.items)
       } catch {
         setLoadError('目前無法完整讀取 Dashboard，請稍後再試。')
       } finally {

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -1,99 +1,212 @@
-import { useEffect, useState } from 'react'
-import { Activity, AlertTriangle, Boxes, Server } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  Boxes,
+  ChartNoAxesColumn,
+  ClipboardList,
+  HandCoins,
+  Handshake,
+  Server,
+} from 'lucide-react'
 import { apiUrl } from '../../api'
-import type { DashboardPayload } from './types'
+import { buildAssetStatusLabelMap, fetchAssetStatusOptions, toAssetStatusLabel } from './assetStatusLookup'
+import type { BorrowRequest, DashboardPayload, DonationRequest, InventoryItem, IssueRequest } from './types'
 import { Badge } from '../ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
-import { Separator } from '../ui/separator'
+
+type RecentActivity = {
+  key: string
+  type: '領用' | '借用' | '捐贈'
+  dateLabel: string
+  dateValue: number
+  actor: string
+  summary: string
+  requestId: string
+}
+
+type StatusDistribution = {
+  code: string
+  label: string
+  count: number
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(apiUrl(path))
+  if (!response.ok) {
+    throw new Error(`failed request for ${path}`)
+  }
+  return (await response.json()) as T
+}
+
+function parseDateValue(dateString: string | null | undefined): number {
+  if (!dateString) {
+    return 0
+  }
+  const parsedDate = Date.parse(dateString)
+  return Number.isNaN(parsedDate) ? 0 : parsedDate
+}
+
+function summarizeItems(itemCount: number): string {
+  return itemCount > 0 ? `${itemCount} 項品類` : '無品項資料'
+}
+
+function toDisplayDate(dateString: string | null | undefined): string {
+  return dateString?.trim() ? dateString : '--'
+}
 
 export function DashboardPage() {
   const [dashboardData, setDashboardData] = useState<DashboardPayload | null>(null)
+  const [items, setItems] = useState<InventoryItem[]>([])
+  const [issues, setIssues] = useState<IssueRequest[]>([])
+  const [borrows, setBorrows] = useState<BorrowRequest[]>([])
+  const [donations, setDonations] = useState<DonationRequest[]>([])
+  const [assetStatusLabelMap, setAssetStatusLabelMap] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
 
   useEffect(() => {
     const loadDashboard = async () => {
+      setLoading(true)
+      setLoadError('')
       try {
-        const response = await fetch(apiUrl('/api/data'))
-        if (!response.ok) {
-          throw new Error('無法載入儀表板資料')
-        }
-        const payload = (await response.json()) as DashboardPayload
-        setDashboardData(payload)
+        const [dashboardPayload, inventoryPayload, issuePayload, borrowPayload, donationPayload] = await Promise.all([
+          fetchJson<DashboardPayload>('/api/data'),
+          fetchJson<InventoryItem[]>('/api/items?include_donated=true'),
+          fetchJson<IssueRequest[]>('/api/issues'),
+          fetchJson<BorrowRequest[]>('/api/borrows'),
+          fetchJson<DonationRequest[]>('/api/donations'),
+        ])
+
+        setDashboardData(dashboardPayload)
+        setItems(inventoryPayload)
+        setIssues(issuePayload)
+        setBorrows(borrowPayload)
+        setDonations(donationPayload)
       } catch {
-        setLoadError('目前無法連線到後端，請稍後再試。')
+        setLoadError('目前無法完整讀取 Dashboard，請稍後再試。')
+      } finally {
+        setLoading(false)
       }
     }
 
     void loadDashboard()
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+    const loadAssetStatusLabels = async () => {
+      try {
+        const options = await fetchAssetStatusOptions()
+        if (!cancelled) {
+          setAssetStatusLabelMap(buildAssetStatusLabelMap(options))
+        }
+      } catch {
+        if (!cancelled) {
+          setAssetStatusLabelMap({})
+        }
+      }
+    }
+
+    void loadAssetStatusLabels()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const statusDistribution = useMemo<StatusDistribution[]>(() => {
+    const groupedCounts = new Map<string, number>()
+    for (const item of items) {
+      const statusCode = item.asset_status?.trim() || 'unknown'
+      groupedCounts.set(statusCode, (groupedCounts.get(statusCode) ?? 0) + 1)
+    }
+
+    return Array.from(groupedCounts.entries())
+      .map(([code, count]) => ({
+        code,
+        label: toAssetStatusLabel(code, assetStatusLabelMap),
+        count,
+      }))
+      .sort((left, right) => right.count - left.count)
+  }, [assetStatusLabelMap, items])
+
+  const recentActivities = useMemo<RecentActivity[]>(() => {
+    const issueActivities = issues.map<RecentActivity>((request) => ({
+      key: `issue-${request.id}`,
+      type: '領用',
+      dateLabel: toDisplayDate(request.request_date),
+      dateValue: parseDateValue(request.request_date),
+      actor: request.requester?.trim() || '未填寫',
+      summary: summarizeItems(request.items.length),
+      requestId: String(request.id),
+    }))
+
+    const borrowActivities = borrows.map<RecentActivity>((request) => ({
+      key: `borrow-${request.id}`,
+      type: '借用',
+      dateLabel: toDisplayDate(request.borrow_date),
+      dateValue: parseDateValue(request.borrow_date),
+      actor: request.borrower?.trim() || '未填寫',
+      summary: `${summarizeItems(request.items.length)} · ${request.status || '--'}`,
+      requestId: String(request.id),
+    }))
+
+    const donationActivities = donations.map<RecentActivity>((request) => ({
+      key: `donation-${request.id}`,
+      type: '捐贈',
+      dateLabel: toDisplayDate(request.donation_date),
+      dateValue: parseDateValue(request.donation_date),
+      actor: request.donor?.trim() || '未填寫',
+      summary: summarizeItems(request.items.length),
+      requestId: String(request.id),
+    }))
+
+    return [...issueActivities, ...borrowActivities, ...donationActivities]
+      .sort((left, right) => {
+        if (left.dateValue === right.dateValue) {
+          return right.key.localeCompare(left.key)
+        }
+        return right.dateValue - left.dateValue
+      })
+      .slice(0, 8)
+  }, [borrows, donations, issues])
+
+  const pendingFixCount = dashboardData?.pendingFix ?? 0
+  const totalRecords = issues.length + borrows.length + donations.length
+  const overdueBorrowCount = borrows.filter((request) => request.status === 'overdue').length
+  const donatedItemsCount = items.filter((item) => item.asset_status?.trim() === '3').length
+  const maxStatusCount = statusDistribution[0]?.count ?? 1
+
+  const kpiCards = [
+    {
+      label: '系統狀態',
+      value: dashboardData?.status ?? '--',
+      hint: '後端 API 回傳健康狀態',
+      icon: <Server className="size-4 text-[hsl(var(--muted-foreground))]" />,
+    },
+    {
+      label: '資產總數',
+      value: String(dashboardData?.items ?? items.length),
+      hint: '含現有與已捐贈資產',
+      icon: <Boxes className="size-4 text-[hsl(var(--muted-foreground))]" />,
+    },
+    {
+      label: '待修正資料',
+      value: String(pendingFixCount),
+      hint: '財產編號空值或包含中文',
+      icon: <AlertTriangle className="size-4 text-amber-500" />,
+    },
+    {
+      label: '交易總筆數',
+      value: String(totalRecords),
+      hint: '領用、借用、捐贈合計',
+      icon: <ClipboardList className="size-4 text-[hsl(var(--muted-foreground))]" />,
+    },
+  ]
+
   return (
     <>
-      <Card className="border-0 bg-gradient-to-r from-slate-900 to-slate-700 text-white shadow-lg">
-        <CardHeader>
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <CardTitle className="text-2xl text-white">資產管理 Dashboard</CardTitle>
-              <CardDescription className="mt-2 text-slate-200">此頁面僅顯示系統數據。</CardDescription>
-            </div>
-            <Badge variant="secondary" className="bg-white/15 text-white">
-              <Activity className="size-3.5" />
-              系統摘要
-            </Badge>
-          </div>
-        </CardHeader>
-      </Card>
-
-      <section className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-4">
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle>系統狀態</CardTitle>
-              <Server className="size-4 text-[hsl(var(--muted-foreground))]" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.status ?? '讀取中...'}</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle>資產總數</CardTitle>
-              <Boxes className="size-4 text-[hsl(var(--muted-foreground))]" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.items ?? '--'}</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle>待修改資料</CardTitle>
-              <AlertTriangle className="size-4 text-amber-500" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <p className="m-0 text-3xl font-semibold text-[hsl(var(--primary))]">{dashboardData?.pendingFix ?? '--'}</p>
-            <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">財產編號空值或包含中文</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>後端訊息</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">{dashboardData?.data ?? '等待資料載入'}</p>
-          </CardContent>
-        </Card>
-      </section>
-
-      <Separator className="my-1" />
-
       {loadError ? (
         <Card className="border-red-200 bg-red-50">
           <CardContent className="p-4">
@@ -101,6 +214,143 @@ export function DashboardPage() {
           </CardContent>
         </Card>
       ) : null}
+
+      <section className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-4">
+        {kpiCards.map((card) => (
+          <Card key={card.label} className="border-[hsl(var(--border))] bg-[hsl(var(--card))/0.9]">
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between">
+                <CardTitle>{card.label}</CardTitle>
+                {card.icon}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="m-0 text-3xl font-semibold text-[hsl(var(--foreground))]">{loading ? '...' : card.value}</p>
+              <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">{card.hint}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>資產狀態分布</CardTitle>
+                <CardDescription>依 `asset_status` 統計目前資產。</CardDescription>
+              </div>
+              <ChartNoAxesColumn className="size-4 text-[hsl(var(--muted-foreground))]" />
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-3">
+            {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
+            {!loading && statusDistribution.length === 0 ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有資產資料可統計。</p>
+            ) : null}
+            {!loading &&
+              statusDistribution.map((item) => {
+                const widthPercent = Math.max(8, Math.round((item.count / maxStatusCount) * 100))
+                return (
+                  <div key={item.code} className="grid gap-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="font-medium">{item.label}</span>
+                      <span className="text-[hsl(var(--muted-foreground))]">{item.count}</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-[hsl(var(--secondary))]">
+                      <div className="h-full rounded-full bg-[hsl(var(--primary))]" style={{ width: `${widthPercent}%` }} />
+                    </div>
+                  </div>
+                )
+              })}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>最近活動</CardTitle>
+                <CardDescription>最近 8 筆領用、借用、捐贈紀錄。</CardDescription>
+              </div>
+              <Badge variant="outline">{recentActivities.length}</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-2">
+            {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
+            {!loading && recentActivities.length === 0 ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有可顯示的活動紀錄。</p>
+            ) : null}
+            {!loading &&
+              recentActivities.map((activity) => (
+                <Link
+                  key={activity.key}
+                  to={
+                    activity.type === '領用'
+                      ? '/issues/$requestId'
+                      : activity.type === '借用'
+                        ? '/borrows/$requestId'
+                        : '/donations/$requestId'
+                  }
+                  params={{ requestId: activity.requestId }}
+                  className="group grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg border border-[hsl(var(--border))] px-3 py-2 no-underline transition-colors hover:bg-[hsl(var(--secondary))/0.75]"
+                >
+                  <span className="inline-flex rounded-md bg-[hsl(var(--secondary))] px-2 py-1 text-xs font-semibold text-[hsl(var(--secondary-foreground))]">
+                    {activity.type}
+                  </span>
+                  <div>
+                    <p className="m-0 text-sm font-medium text-[hsl(var(--foreground))]">{activity.actor}</p>
+                    <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">
+                      {activity.dateLabel} · {activity.summary}
+                    </p>
+                  </div>
+                  <ArrowRight className="size-4 text-[hsl(var(--muted-foreground))] transition-transform group-hover:translate-x-0.5" />
+                </Link>
+              ))}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <Card className="xl:col-span-2">
+          <CardHeader className="pb-3">
+            <CardTitle>異常提醒</CardTitle>
+            <CardDescription>優先處理可能造成資料錯誤或流程延遲的項目。</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2">
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              待修正資產資料：<strong>{pendingFixCount}</strong> 筆
+            </div>
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              逾期借用：<strong>{overdueBorrowCount}</strong> 筆
+            </div>
+            <div className="rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700">
+              已捐贈狀態資產：<strong>{donatedItemsCount}</strong> 筆
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle>快速入口</CardTitle>
+            <CardDescription>常用操作捷徑。</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2">
+            <Link to="/issues/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+              <HandCoins className="size-4" />
+              新增領用單
+            </Link>
+            <Link to="/borrows/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+              <Handshake className="size-4" />
+              新增借用單
+            </Link>
+            <Link to="/donations/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+              <ClipboardList className="size-4" />
+              新增捐贈單
+            </Link>
+          </CardContent>
+        </Card>
+      </section>
     </>
   )
 }

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -266,53 +266,76 @@ export function DashboardPage() {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <CardTitle>最近活動</CardTitle>
-                <CardDescription>最近 8 筆領用、借用、捐贈紀錄。</CardDescription>
+        <div className="grid gap-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle>快速入口</CardTitle>
+              <CardDescription>常用操作捷徑。</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-2">
+              <Link to="/issues/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+                <HandCoins className="size-4" />
+                新增領用單
+              </Link>
+              <Link to="/borrows/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+                <Handshake className="size-4" />
+                新增借用單
+              </Link>
+              <Link to="/donations/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
+                <ClipboardList className="size-4" />
+                新增捐贈單
+              </Link>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>最近活動</CardTitle>
+                  <CardDescription>最近 8 筆領用、借用、捐贈紀錄。</CardDescription>
+                </div>
+                <Badge variant="outline">{recentActivities.length}</Badge>
               </div>
-              <Badge variant="outline">{recentActivities.length}</Badge>
-            </div>
-          </CardHeader>
-          <CardContent className="grid gap-2">
-            {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
-            {!loading && recentActivities.length === 0 ? (
-              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有可顯示的活動紀錄。</p>
-            ) : null}
-            {!loading &&
-              recentActivities.map((activity) => (
-                <Link
-                  key={activity.key}
-                  to={
-                    activity.type === '領用'
-                      ? '/issues/$requestId'
-                      : activity.type === '借用'
-                        ? '/borrows/$requestId'
-                        : '/donations/$requestId'
-                  }
-                  params={{ requestId: activity.requestId }}
-                  className="group grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg border border-[hsl(var(--border))] px-3 py-2 no-underline transition-colors hover:bg-[hsl(var(--secondary))/0.75]"
-                >
-                  <span className="inline-flex rounded-md bg-[hsl(var(--secondary))] px-2 py-1 text-xs font-semibold text-[hsl(var(--secondary-foreground))]">
-                    {activity.type}
-                  </span>
-                  <div>
-                    <p className="m-0 text-sm font-medium text-[hsl(var(--foreground))]">{activity.actor}</p>
-                    <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">
-                      {activity.dateLabel} · {activity.summary}
-                    </p>
-                  </div>
-                  <ArrowRight className="size-4 text-[hsl(var(--muted-foreground))] transition-transform group-hover:translate-x-0.5" />
-                </Link>
-              ))}
-          </CardContent>
-        </Card>
+            </CardHeader>
+            <CardContent className="grid gap-2">
+              {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
+              {!loading && recentActivities.length === 0 ? (
+                <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有可顯示的活動紀錄。</p>
+              ) : null}
+              {!loading &&
+                recentActivities.map((activity) => (
+                  <Link
+                    key={activity.key}
+                    to={
+                      activity.type === '領用'
+                        ? '/issues/$requestId'
+                        : activity.type === '借用'
+                          ? '/borrows/$requestId'
+                          : '/donations/$requestId'
+                    }
+                    params={{ requestId: activity.requestId }}
+                    className="group grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg border border-[hsl(var(--border))] px-3 py-2 no-underline transition-colors hover:bg-[hsl(var(--secondary))/0.75]"
+                  >
+                    <span className="inline-flex rounded-md bg-[hsl(var(--secondary))] px-2 py-1 text-xs font-semibold text-[hsl(var(--secondary-foreground))]">
+                      {activity.type}
+                    </span>
+                    <div>
+                      <p className="m-0 text-sm font-medium text-[hsl(var(--foreground))]">{activity.actor}</p>
+                      <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">
+                        {activity.dateLabel} · {activity.summary}
+                      </p>
+                    </div>
+                    <ArrowRight className="size-4 text-[hsl(var(--muted-foreground))] transition-transform group-hover:translate-x-0.5" />
+                  </Link>
+                ))}
+            </CardContent>
+          </Card>
+        </div>
       </section>
 
-      <section className="grid gap-4 xl:grid-cols-3">
-        <Card className="xl:col-span-2">
+      <section className="grid gap-4">
+        <Card>
           <CardHeader className="pb-3">
             <CardTitle>異常提醒</CardTitle>
             <CardDescription>優先處理可能造成資料錯誤或流程延遲的項目。</CardDescription>
@@ -327,27 +350,6 @@ export function DashboardPage() {
             <div className="rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700">
               已捐贈狀態資產：<strong>{donatedItemsCount}</strong> 筆
             </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>快速入口</CardTitle>
-            <CardDescription>常用操作捷徑。</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-2">
-            <Link to="/issues/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
-              <HandCoins className="size-4" />
-              新增領用單
-            </Link>
-            <Link to="/borrows/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
-              <Handshake className="size-4" />
-              新增借用單
-            </Link>
-            <Link to="/donations/new" className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-3 py-2 text-sm font-semibold text-[hsl(var(--secondary-foreground))] no-underline hover:bg-[hsl(var(--secondary))/0.8]">
-              <ClipboardList className="size-4" />
-              新增捐贈單
-            </Link>
           </CardContent>
         </Card>
       </section>

--- a/frontend/src/components/pages/DonationListPage.tsx
+++ b/frontend/src/components/pages/DonationListPage.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
+import { Button } from '../ui/button'
+import { FilterBar } from '../ui/filter-bar'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import type { DonationRequest, PaginatedResponse } from './types'
-
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
-const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
@@ -88,76 +92,113 @@ export function DonationListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <div className="mb-4 grid gap-2">
-          <label htmlFor="donation-search" className="font-bold">
-            關鍵字搜尋
-          </label>
-          <input
-            className={fieldClass}
-            id="donation-search"
-            type="search"
-            placeholder="輸入捐贈人、受贈對象、品項..."
-            value={keyword}
-            onChange={(event) => {
-              setKeyword(event.target.value)
-              setPage(1)
-            }}
-          />
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
-        </div>
+      <PageHeader
+        title="捐贈清單"
+        description="查詢捐贈交易與受贈流向。"
+        actions={
+          <Link to="/donations/new">
+            <Button>
+              <Plus className="size-4" />
+              新增捐贈
+            </Button>
+          </Link>
+        }
+      />
 
-        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
-        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+      <SectionCard>
+        <FilterBar className="xl:grid-cols-[2fr_1fr]">
+          <div className="grid gap-1.5">
+            <Label htmlFor="donation-search">關鍵字搜尋</Label>
+            <Input
+              id="donation-search"
+              type="search"
+              placeholder="輸入捐贈人、受贈對象、品項..."
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value)
+                setPage(1)
+              }}
+            />
+          </div>
+          <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
+        </FilterBar>
+
+        {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+        {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
           <>
-            <div className="w-full overflow-x-auto">
-              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-                <thead>
-                  <tr>
+            <div className="hidden overflow-x-auto md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
                     {['#', '捐贈日期', '捐贈人/單位', '受贈對象', '用途', '品項', '備註'].map((header) => (
-                      <th key={header} className={tableHeaderClass}>{header}</th>
+                      <TableHead key={header}>{header}</TableHead>
                     ))}
-                  </tr>
-                </thead>
-                <tbody>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {requests.length === 0 ? (
-                    <tr>
-                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
+                    <TableRow>
+                      <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={7}>
                         目前沒有符合條件的捐贈單。
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ) : (
                     requests.map((request) => (
-                      <tr key={request.id}>
-                        <td className={tableCellClass}>
-                          <Link className="font-bold text-blue-700 no-underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
+                      <TableRow key={request.id}>
+                        <TableCell>
+                          <Link className="font-semibold text-blue-700 no-underline hover:underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
                             {request.id}
                           </Link>
-                        </td>
-                        <td className={tableCellClass}>{request.donation_date || '--'}</td>
-                        <td className={tableCellClass}>
-                          <div className="font-bold">{request.donor || '--'}</div>
-                          <div className="text-sm text-slate-500">{request.department || ''}</div>
-                        </td>
-                        <td className={tableCellClass}>{request.recipient || '--'}</td>
-                        <td className={tableCellClass}>{request.purpose || '--'}</td>
-                        <td className={tableCellClass}>
+                        </TableCell>
+                        <TableCell>{request.donation_date || '--'}</TableCell>
+                        <TableCell>
+                          <div className="font-semibold">{request.donor || '--'}</div>
+                          <div className="text-xs text-[hsl(var(--muted-foreground))]">{request.department || ''}</div>
+                        </TableCell>
+                        <TableCell>{request.recipient || '--'}</TableCell>
+                        <TableCell>{request.purpose || '--'}</TableCell>
+                        <TableCell>
                           <div className="grid gap-1">
                             {request.items.map((item) => (
-                              <div key={item.id} className="text-sm">
+                              <div key={item.id} className="text-xs">
                                 {(item.item_name || `#${item.item_id}`)} x {item.quantity}
                               </div>
                             ))}
                           </div>
-                        </td>
-                        <td className={tableCellClass}>{request.memo || '--'}</td>
-                      </tr>
+                        </TableCell>
+                        <TableCell>{request.memo || '--'}</TableCell>
+                      </TableRow>
                     ))
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="grid gap-3 md:hidden">
+              {requests.length === 0 ? (
+                <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                  目前沒有符合條件的捐贈單。
+                </p>
+              ) : (
+                requests.map((request) => (
+                  <article key={request.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                    <div className="flex items-center justify-between">
+                      <Link className="font-semibold text-blue-700 no-underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
+                        #{request.id}
+                      </Link>
+                      <span className="text-xs text-[hsl(var(--muted-foreground))]">{request.donation_date || '--'}</span>
+                    </div>
+                    <p className="mt-2 mb-0 text-sm font-semibold">{request.donor || '--'}</p>
+                    <p className="mt-0.5 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{request.department || '--'}</p>
+                    <p className="mt-2 mb-0 text-sm">受贈：{request.recipient || '--'}</p>
+                    <p className="mt-2 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
+                      品項：{request.items.map((item) => `${item.item_name || `#${item.item_id}`} x ${item.quantity}`).join('，') || '--'}
+                    </p>
+                  </article>
+                ))
+              )}
             </div>
 
             <DataPagination
@@ -173,7 +214,7 @@ export function DonationListPage() {
             />
           </>
         ) : null}
-      </section>
+      </SectionCard>
     </>
   )
 }

--- a/frontend/src/components/pages/DonationListPage.tsx
+++ b/frontend/src/components/pages/DonationListPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
 import type { DonationRequest } from './types'
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
-const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
+const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
 export function DonationListPage() {
   const [requests, setRequests] = useState<DonationRequest[]>([])
@@ -49,12 +50,7 @@ export function DonationListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">捐贈清單</h1>
-        <p className="mt-2 text-slate-500">可依捐贈人、受贈對象、用途、品項快速查詢。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <div className="mb-4 grid gap-2">
           <label htmlFor="donation-search" className="font-bold">
             關鍵字搜尋
@@ -75,7 +71,7 @@ export function DonationListPage() {
 
         {!loading && !loadError ? (
           <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
               <thead>
                 <tr>
                   {['#', '捐贈日期', '捐贈人/單位', '受贈對象', '用途', '品項', '備註'].map((header) => (
@@ -94,9 +90,9 @@ export function DonationListPage() {
                   filteredRequests.map((request) => (
                     <tr key={request.id}>
                       <td className={tableCellClass}>
-                        <a className="font-bold text-blue-700 no-underline" href={`/donations/${request.id}`}>
+                        <Link className="font-bold text-blue-700 no-underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
                           {request.id}
-                        </a>
+                        </Link>
                       </td>
                       <td className={tableCellClass}>{request.donation_date || '--'}</td>
                       <td className={tableCellClass}>

--- a/frontend/src/components/pages/DonationListPage.tsx
+++ b/frontend/src/components/pages/DonationListPage.tsx
@@ -1,29 +1,81 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
-import type { DonationRequest } from './types'
+import { DataPagination } from '../ui/data-pagination'
+import type { DonationRequest, PaginatedResponse } from './types'
 
 const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
 const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
 const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return parsed
+}
+
+function readInitialState() {
+  const params = new URLSearchParams(window.location.search)
+  return {
+    keyword: params.get('keyword') ?? '',
+    page: parsePositiveInt(params.get('page'), 1),
+    pageSize: parsePositiveInt(params.get('page_size'), 10),
+  }
+}
+
 export function DonationListPage() {
+  const initialState = readInitialState()
   const [requests, setRequests] = useState<DonationRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
-  const [keyword, setKeyword] = useState('')
+  const [keyword, setKeyword] = useState(initialState.keyword)
+  const [page, setPage] = useState(initialState.page)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim())
+    }
+    if (page !== 1) {
+      params.set('page', String(page))
+    }
+    if (pageSize !== 10) {
+      params.set('page_size', String(pageSize))
+    }
+    const queryString = params.toString()
+    const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+    window.history.replaceState(null, '', url)
+  }, [keyword, page, pageSize])
 
   useEffect(() => {
     const loadRequests = async () => {
       setLoading(true)
       setLoadError('')
       try {
-        const response = await fetch(apiUrl('/api/donations'))
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(pageSize),
+        })
+        if (keyword.trim()) {
+          params.set('keyword', keyword.trim())
+        }
+
+        const response = await fetch(apiUrl(`/api/donations?${params.toString()}`))
         if (!response.ok) {
           throw new Error('無法載入捐贈清單')
         }
-        const payload = (await response.json()) as DonationRequest[]
-        setRequests(payload)
+        const payload = (await response.json()) as PaginatedResponse<DonationRequest>
+        setRequests(payload.items)
+        setTotal(payload.total)
+        setTotalPages(payload.total_pages)
       } catch {
         setLoadError('目前無法讀取捐贈清單，請稍後重試。')
       } finally {
@@ -32,21 +84,7 @@ export function DonationListPage() {
     }
 
     void loadRequests()
-  }, [])
-
-  const filteredRequests = useMemo(() => {
-    const normalizedKeyword = keyword.trim().toLowerCase()
-    if (!normalizedKeyword) {
-      return requests
-    }
-
-    const normalize = (value: string | null | undefined) => (value ?? '').toLowerCase()
-    return requests.filter((request) => {
-      const itemMatches = request.items.some((item) => normalize(item.item_name).includes(normalizedKeyword))
-      const fields = [request.donor, request.department, request.recipient, request.purpose, request.memo, request.donation_date]
-      return itemMatches || fields.some((field) => normalize(field).includes(normalizedKeyword))
-    })
-  }, [keyword, requests])
+  }, [keyword, page, pageSize])
 
   return (
     <>
@@ -61,62 +99,79 @@ export function DonationListPage() {
             type="search"
             placeholder="輸入捐贈人、受贈對象、品項..."
             value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
+            onChange={(event) => {
+              setKeyword(event.target.value)
+              setPage(1)
+            }}
           />
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredRequests.length} 筆資料</p>
+          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
         </div>
 
         {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
         {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
-          <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-              <thead>
-                <tr>
-                  {['#', '捐贈日期', '捐贈人/單位', '受贈對象', '用途', '品項', '備註'].map((header) => (
-                    <th key={header} className={tableHeaderClass}>{header}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRequests.length === 0 ? (
+          <>
+            <div className="w-full overflow-x-auto">
+              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
+                <thead>
                   <tr>
-                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
-                      目前沒有符合條件的捐贈單。
-                    </td>
+                    {['#', '捐贈日期', '捐贈人/單位', '受贈對象', '用途', '品項', '備註'].map((header) => (
+                      <th key={header} className={tableHeaderClass}>{header}</th>
+                    ))}
                   </tr>
-                ) : (
-                  filteredRequests.map((request) => (
-                    <tr key={request.id}>
-                      <td className={tableCellClass}>
-                        <Link className="font-bold text-blue-700 no-underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
-                          {request.id}
-                        </Link>
+                </thead>
+                <tbody>
+                  {requests.length === 0 ? (
+                    <tr>
+                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={7}>
+                        目前沒有符合條件的捐贈單。
                       </td>
-                      <td className={tableCellClass}>{request.donation_date || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="font-bold">{request.donor || '--'}</div>
-                        <div className="text-sm text-slate-500">{request.department || ''}</div>
-                      </td>
-                      <td className={tableCellClass}>{request.recipient || '--'}</td>
-                      <td className={tableCellClass}>{request.purpose || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="grid gap-1">
-                          {request.items.map((item) => (
-                            <div key={item.id} className="text-sm">
-                              {(item.item_name || `#${item.item_id}`)} x {item.quantity}
-                            </div>
-                          ))}
-                        </div>
-                      </td>
-                      <td className={tableCellClass}>{request.memo || '--'}</td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+                  ) : (
+                    requests.map((request) => (
+                      <tr key={request.id}>
+                        <td className={tableCellClass}>
+                          <Link className="font-bold text-blue-700 no-underline" to="/donations/$requestId" params={{ requestId: String(request.id) }}>
+                            {request.id}
+                          </Link>
+                        </td>
+                        <td className={tableCellClass}>{request.donation_date || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="font-bold">{request.donor || '--'}</div>
+                          <div className="text-sm text-slate-500">{request.department || ''}</div>
+                        </td>
+                        <td className={tableCellClass}>{request.recipient || '--'}</td>
+                        <td className={tableCellClass}>{request.purpose || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="grid gap-1">
+                            {request.items.map((item) => (
+                              <div key={item.id} className="text-sm">
+                                {(item.item_name || `#${item.item_id}`)} x {item.quantity}
+                              </div>
+                            ))}
+                          </div>
+                        </td>
+                        <td className={tableCellClass}>{request.memo || '--'}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <DataPagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              totalPages={totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize)
+                setPage(1)
+              }}
+            />
+          </>
         ) : null}
       </section>
     </>

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -11,8 +11,8 @@ type DonationLine = {
 
 const FIXED_DONOR = '固定捐贈人'
 const FIXED_DEPARTMENT = '固定單位'
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -192,12 +192,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">捐贈管理</h1>
-        <p className="mt-2 text-slate-500">建立捐贈單，並可一次選擇多個品項。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯捐贈單' : '新增捐贈單'}</h2>
         <div className="mt-4 grid gap-3">
           <div className="grid gap-2 md:grid-cols-2">
@@ -230,7 +225,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
           <div className="mt-3 grid gap-3">
             {lines.map((line, index) => (
-              <div key={`donation-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
+              <div key={`donation-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
                 <label className="grid gap-2 font-bold">
                   品項
                   <select
@@ -263,7 +258,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
                 <div className="flex items-end">
                   <button
                     type="button"
-                    className="cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600"
+                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
                     onClick={() => handleRemoveLine(index)}
                     disabled={lines.length <= 1}
                   >

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
-import type { DonationRequest, InventoryItem } from './types'
+import type { DonationRequest, InventoryItem, PaginatedResponse } from './types'
 
 type DonationLine = {
   item_id: number | ''
@@ -43,12 +43,12 @@ export function DonationPage({ requestId }: DonationPageProps) {
   const loadInventoryItems = useCallback(async () => {
     setLoadError('')
     try {
-      const itemsResponse = await fetch(apiUrl('/api/items?include_donated=true'))
+      const itemsResponse = await fetch(apiUrl('/api/items?include_donated=true&page=1&page_size=100000'))
       if (!itemsResponse.ok) {
         throw new Error('無法載入資料')
       }
-      const itemsPayload = (await itemsResponse.json()) as InventoryItem[]
-      setInventoryItems(itemsPayload)
+      const itemsPayload = (await itemsResponse.json()) as PaginatedResponse<InventoryItem>
+      setInventoryItems(itemsPayload.items)
     } catch {
       setLoadError('目前無法讀取捐贈資料，請稍後重試。')
     }

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Textarea } from '../ui/textarea'
 import type { DonationRequest, InventoryItem, PaginatedResponse } from './types'
 
 type DonationLine = {
@@ -11,8 +18,6 @@ type DonationLine = {
 
 const FIXED_DONOR = '固定捐贈人'
 const FIXED_DEPARTMENT = '固定單位'
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -85,7 +90,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
               quantity: item.quantity,
               note: item.note ?? '',
             }))
-            : [emptyLine()]
+            : [emptyLine()],
         )
       } catch {
         setLoadError('目前無法讀取捐贈單資料，請稍後重試。')
@@ -110,14 +115,6 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
   const handleLineChange = (index: number, patch: Partial<DonationLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
-  }
-
-  const handleAddLine = () => {
-    setLines((prev) => [...prev, emptyLine()])
-  }
-
-  const handleRemoveLine = (index: number) => {
-    setLines((prev) => prev.filter((_, idx) => idx !== index))
   }
 
   const validateLines = () => {
@@ -192,44 +189,48 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯捐贈單' : '新增捐贈單'}</h2>
-        <div className="mt-4 grid gap-3">
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="grid gap-2 font-bold">
-              <span className="inline-flex items-center gap-1">
-                受贈對象
-                <span className="text-red-600">*</span>
-              </span>
-              <input className={fieldClass} value={recipient} onChange={(event) => setRecipient(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              捐贈日期
-              <input className={fieldClass} type="date" value={donationDate} onChange={(event) => setDonationDate(event.target.value)} />
-            </label>
-          </div>
-          <label className="grid gap-2 font-bold">
-            用途
-            <input className={fieldClass} value={purpose} onChange={(event) => setPurpose(event.target.value)} />
-          </label>
-          <label className="grid gap-2 font-bold">
-            備註
-            <input className={fieldClass} value={memo} onChange={(event) => setMemo(event.target.value)} />
-          </label>
-        </div>
+      <PageHeader
+        title={isEditing ? '編輯捐贈單' : '新增捐贈單'}
+        description="建立捐贈交易並標記對應庫存。"
+      />
 
-        <div className="mt-6">
-          <div className="flex items-center justify-between">
-            <h3 className="m-0 text-base font-bold">捐贈品項</h3>
+      <div className="grid gap-4">
+        <SectionCard title="基本資料">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid gap-1.5">
+              <Label>捐贈人</Label>
+              <Input value={donor} onChange={(event) => setDonor(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>單位</Label>
+              <Input value={department} onChange={(event) => setDepartment(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>受贈對象</Label>
+              <Input value={recipient} onChange={(event) => setRecipient(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>捐贈日期</Label>
+              <Input type="date" value={donationDate} onChange={(event) => setDonationDate(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5 md:col-span-2">
+              <Label>用途</Label>
+              <Input value={purpose} onChange={(event) => setPurpose(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5 md:col-span-2">
+              <Label>備註</Label>
+              <Textarea rows={3} value={memo} onChange={(event) => setMemo(event.target.value)} />
+            </div>
           </div>
+        </SectionCard>
 
-          <div className="mt-3 grid gap-3">
+        <SectionCard title="捐贈品項">
+          <div className="grid gap-3">
             {lines.map((line, index) => (
-              <div key={`donation-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
-                <label className="grid gap-2 font-bold">
-                  品項
-                  <select
-                    className={fieldClass}
+              <article key={`donation-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+                <div className="grid gap-1.5">
+                  <Label>品項</Label>
+                  <Select
                     value={line.item_id}
                     onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
                   >
@@ -239,48 +240,41 @@ export function DonationPage({ requestId }: DonationPageProps) {
                         {`${item.name || '未命名'} ${item.model ? `(${item.model})` : ''} ${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn ? `｜${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn}` : ''}`.trim()}
                       </option>
                     ))}
-                  </select>
-                </label>
-                <label className="grid gap-2 font-bold">
-                  數量
-                  <input
-                    className={fieldClass}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>數量</Label>
+                  <Input
                     type="number"
                     min={1}
                     value={line.quantity}
                     onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
                   />
-                </label>
-                <label className="grid gap-2 font-bold">
-                  備註
-                  <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
-                </label>
-                <div className="flex items-end">
-                  <button
-                    type="button"
-                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
-                    onClick={() => handleRemoveLine(index)}
-                    disabled={lines.length <= 1}
-                  >
-                    移除
-                  </button>
                 </div>
-              </div>
+                <div className="grid gap-1.5">
+                  <Label>備註</Label>
+                  <Input value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                </div>
+                <div className="flex items-end">
+                  <Button type="button" variant="secondary" onClick={() => setLines((prev) => prev.filter((_, idx) => idx !== index))} disabled={lines.length <= 1}>
+                    移除
+                  </Button>
+                </div>
+              </article>
             ))}
           </div>
 
-          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-xl px-4 py-3">
-            <button className={buttonClass} type="button" onClick={handleAddLine}>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <Button type="button" variant="secondary" onClick={() => setLines((prev) => [...prev, emptyLine()])}>
               新增品項
-            </button>
-            <button className={buttonClass} type="button" onClick={() => void handleSubmit()} disabled={submitting}>
+            </Button>
+            <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
               {submitting ? (isEditing ? '更新中...' : '建立中...') : (isEditing ? '更新捐贈單' : '建立捐贈單')}
-            </button>
+            </Button>
           </div>
-        </div>
-      </section>
-
-      {loadError ? <p className="rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+          {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
+        </SectionCard>
+      </div>
     </>
   )
 }

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import { apiUrl } from '../../api'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
+import { Textarea } from '../ui/textarea'
 import { fetchAssetStatusOptions } from './assetStatusLookup'
 import type { InventoryItem } from './types'
 
@@ -60,10 +68,6 @@ const DEFAULT_FORM_DATA: InventoryFormData = {
   memo2: '',
   keeper: '',
 }
-
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const labelClass = 'grid gap-1.5 font-semibold'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 
 function normalizeDateForInput(value: string | null): string {
   if (!value) {
@@ -248,155 +252,179 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
-        {errorMessage ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{errorMessage}</p> : null}
-        {successMessage ? <p className="mt-0.5 rounded-[10px] bg-emerald-50 px-3.5 py-3 text-emerald-700">{successMessage}</p> : null}
+      <PageHeader
+        title={isEditMode ? '編輯庫存' : '新增庫存'}
+        description="以分頁分區方式維護資產資料。"
+      />
 
-        {!loading ? (
-          <form className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-x-4 gap-y-3.5" onSubmit={(event) => void handleSubmit(event)}>
-            <label className={labelClass}>
-              資產類型
-              <select className={fieldClass} value={formData.asset_type} onChange={(event) => handleInputChange('asset_type', event.target.value)}>
-                {ASSET_TYPE_OPTIONS.map((assetTypeOption) => (
-                  <option key={assetTypeOption.value} value={assetTypeOption.value}>
-                    {assetTypeOption.label}
-                  </option>
-                ))}
-                {!ASSET_TYPE_OPTIONS.some((assetTypeOption) => assetTypeOption.value === formData.asset_type) && formData.asset_type ? (
-                  <option value={formData.asset_type}>{formData.asset_type}</option>
-                ) : null}
-              </select>
-            </label>
+      {loading ? <p className="mt-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+      {errorMessage ? <p className="mt-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{errorMessage}</p> : null}
+      {successMessage ? <p className="mt-0 rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{successMessage}</p> : null}
 
-            <label className={labelClass}>
-              資產狀態
-              <select className={fieldClass} value={formData.asset_status} onChange={(event) => handleInputChange('asset_status', event.target.value)}>
-                {assetStatusOptions.map((statusOption) => (
-                  <option key={statusOption.value} value={statusOption.value}>
-                    {statusOption.label}
-                  </option>
-                ))}
-                {!assetStatusOptions.some((statusOption) => statusOption.value === formData.asset_status) && formData.asset_status ? (
-                  <option value={formData.asset_status}>{formData.asset_status}</option>
-                ) : null}
-              </select>
-            </label>
+      {!loading ? (
+        <form className="grid gap-4" onSubmit={(event) => void handleSubmit(event)}>
+          <Tabs defaultValue="basic">
+            <TabsList>
+              <TabsTrigger value="basic">基本資料</TabsTrigger>
+              <TabsTrigger value="details">補充欄位</TabsTrigger>
+              <TabsTrigger value="meta">異動紀錄</TabsTrigger>
+            </TabsList>
 
-            <label className={labelClass}>
-              Key
-              <input className={fieldClass} type="text" value={formData.key} onChange={(event) => handleInputChange('key', event.target.value)} />
-            </label>
+            <TabsContent value="basic">
+              <SectionCard>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-1.5">
+                    <Label>資產類型</Label>
+                    <Select value={formData.asset_type} onChange={(event) => handleInputChange('asset_type', event.target.value)}>
+                      {ASSET_TYPE_OPTIONS.map((assetTypeOption) => (
+                        <option key={assetTypeOption.value} value={assetTypeOption.value}>
+                          {assetTypeOption.label}
+                        </option>
+                      ))}
+                      {!ASSET_TYPE_OPTIONS.some((assetTypeOption) => assetTypeOption.value === formData.asset_type) && formData.asset_type ? (
+                        <option value={formData.asset_type}>{formData.asset_type}</option>
+                      ) : null}
+                    </Select>
+                  </div>
 
-            <label className={labelClass}>
-              n_property_sn
-              <input className={fieldClass} type="text" value={formData.n_property_sn} onChange={(event) => handleInputChange('n_property_sn', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>資產狀態</Label>
+                    <Select value={formData.asset_status} onChange={(event) => handleInputChange('asset_status', event.target.value)}>
+                      {assetStatusOptions.map((statusOption) => (
+                        <option key={statusOption.value} value={statusOption.value}>
+                          {statusOption.label}
+                        </option>
+                      ))}
+                      {!assetStatusOptions.some((statusOption) => statusOption.value === formData.asset_status) && formData.asset_status ? (
+                        <option value={formData.asset_status}>{formData.asset_status}</option>
+                      ) : null}
+                    </Select>
+                  </div>
 
-            <label className={labelClass}>
-              property_sn
-              <input className={fieldClass} type="text" value={formData.property_sn} onChange={(event) => handleInputChange('property_sn', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>Key</Label>
+                    <Input value={formData.key} onChange={(event) => handleInputChange('key', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              n_item_sn
-              <input className={fieldClass} type="text" value={formData.n_item_sn} onChange={(event) => handleInputChange('n_item_sn', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>n_property_sn</Label>
+                    <Input value={formData.n_property_sn} onChange={(event) => handleInputChange('n_property_sn', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              item_sn
-              <input className={fieldClass} type="text" value={formData.item_sn} onChange={(event) => handleInputChange('item_sn', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>property_sn</Label>
+                    <Input value={formData.property_sn} onChange={(event) => handleInputChange('property_sn', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              品名
-              <input className={fieldClass} type="text" value={formData.name} onChange={(event) => handleInputChange('name', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>n_item_sn</Label>
+                    <Input value={formData.n_item_sn} onChange={(event) => handleInputChange('n_item_sn', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              name_code
-              <input className={fieldClass} type="text" value={formData.name_code} onChange={(event) => handleInputChange('name_code', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>item_sn</Label>
+                    <Input value={formData.item_sn} onChange={(event) => handleInputChange('item_sn', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              name_code2
-              <input className={fieldClass} type="text" value={formData.name_code2} onChange={(event) => handleInputChange('name_code2', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>品名</Label>
+                    <Input value={formData.name} onChange={(event) => handleInputChange('name', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              型號
-              <input className={fieldClass} type="text" value={formData.model} onChange={(event) => handleInputChange('model', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>型號</Label>
+                    <Input value={formData.model} onChange={(event) => handleInputChange('model', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              規格
-              <input className={fieldClass} type="text" value={formData.specification} onChange={(event) => handleInputChange('specification', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>規格</Label>
+                    <Input value={formData.specification} onChange={(event) => handleInputChange('specification', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              單位
-              <input className={fieldClass} type="text" value={formData.unit} onChange={(event) => handleInputChange('unit', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>單位</Label>
+                    <Input value={formData.unit} onChange={(event) => handleInputChange('unit', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              數量
-              <input className={fieldClass} type="number" min={1} value={formData.count} onChange={(event) => handleCountChange(event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>數量</Label>
+                    <Input type="number" min={1} value={formData.count} onChange={(event) => handleCountChange(event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              購置日期
-              <input className={fieldClass} type="date" value={formData.purchase_date} onChange={(event) => handleInputChange('purchase_date', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>購置日期</Label>
+                    <Input type="date" value={formData.purchase_date} onChange={(event) => handleInputChange('purchase_date', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              到期日
-              <input className={fieldClass} type="date" value={formData.due_date} onChange={(event) => handleInputChange('due_date', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>到期日</Label>
+                    <Input type="date" value={formData.due_date} onChange={(event) => handleInputChange('due_date', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              歸還日
-              <input className={fieldClass} type="date" value={formData.return_date} onChange={(event) => handleInputChange('return_date', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>歸還日</Label>
+                    <Input type="date" value={formData.return_date} onChange={(event) => handleInputChange('return_date', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              放置地點
-              <input className={fieldClass} type="text" value={formData.location} onChange={(event) => handleInputChange('location', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>放置地點</Label>
+                    <Input value={formData.location} onChange={(event) => handleInputChange('location', event.target.value)} />
+                  </div>
 
-            <label className={labelClass}>
-              保管人
-              <input className={fieldClass} type="text" value={formData.keeper} onChange={(event) => handleInputChange('keeper', event.target.value)} />
-            </label>
+                  <div className="grid gap-1.5">
+                    <Label>保管人</Label>
+                    <Input value={formData.keeper} onChange={(event) => handleInputChange('keeper', event.target.value)} />
+                  </div>
+                </div>
+              </SectionCard>
+            </TabsContent>
 
-            <label className={`${labelClass} col-[1/-1]`}>
-              memo
-              <textarea className={`${fieldClass} resize-y`} value={formData.memo} onChange={(event) => handleInputChange('memo', event.target.value)} rows={3} />
-            </label>
+            <TabsContent value="details">
+              <SectionCard>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="grid gap-1.5">
+                    <Label>name_code</Label>
+                    <Input value={formData.name_code} onChange={(event) => handleInputChange('name_code', event.target.value)} />
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label>name_code2</Label>
+                    <Input value={formData.name_code2} onChange={(event) => handleInputChange('name_code2', event.target.value)} />
+                  </div>
+                  <div className="grid gap-1.5 md:col-span-2">
+                    <Label>memo</Label>
+                    <Textarea rows={4} value={formData.memo} onChange={(event) => handleInputChange('memo', event.target.value)} />
+                  </div>
+                  <div className="grid gap-1.5 md:col-span-2">
+                    <Label>memo2</Label>
+                    <Textarea rows={4} value={formData.memo2} onChange={(event) => handleInputChange('memo2', event.target.value)} />
+                  </div>
+                </div>
+              </SectionCard>
+            </TabsContent>
 
-            <label className={`${labelClass} col-[1/-1]`}>
-              memo2
-              <textarea className={`${fieldClass} resize-y`} value={formData.memo2} onChange={(event) => handleInputChange('memo2', event.target.value)} rows={3} />
-            </label>
+            <TabsContent value="meta">
+              <SectionCard>
+                {loadedItem ? (
+                  <div className="grid gap-2 rounded-md bg-[hsl(var(--card-soft))] p-3 text-sm text-[hsl(var(--muted-foreground))] md:grid-cols-2">
+                    <div>建立時間：{formatDateTime(loadedItem.created_at)}</div>
+                    <div>建立者：{loadedItem.created_by || '--'}</div>
+                    <div>更新時間：{formatDateTime(loadedItem.updated_at)}</div>
+                    <div>更新者：{loadedItem.updated_by || '--'}</div>
+                    <div>刪除時間：{formatDateTime(loadedItem.deleted_at)}</div>
+                    <div>刪除者：{loadedItem.deleted_by || '--'}</div>
+                  </div>
+                ) : (
+                  <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">新增模式尚無異動紀錄。</p>
+                )}
+              </SectionCard>
+            </TabsContent>
+          </Tabs>
 
-            {loadedItem ? (
-              <div className="col-[1/-1] grid gap-2 rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-4 text-sm text-slate-700 md:grid-cols-2">
-                <div>建立時間：{formatDateTime(loadedItem.created_at)}</div>
-                <div>建立者：{loadedItem.created_by || '--'}</div>
-                <div>更新時間：{formatDateTime(loadedItem.updated_at)}</div>
-                <div>更新者：{loadedItem.updated_by || '--'}</div>
-                <div>刪除時間：{formatDateTime(loadedItem.deleted_at)}</div>
-                <div>刪除者：{loadedItem.deleted_by || '--'}</div>
-              </div>
-            ) : null}
-
-            <div className="col-[1/-1] flex justify-end">
-              <button className={buttonClass} type="submit" disabled={submitting}>
-                {submitButtonLabel}
-              </button>
-            </div>
-          </form>
-        ) : null}
-      </section>
+          <div className="sticky bottom-0 z-10 flex justify-end rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))]/95 p-3 backdrop-blur">
+            <Button type="submit" disabled={submitting}>{submitButtonLabel}</Button>
+          </div>
+        </form>
+      ) : null}
     </>
   )
 }

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -61,9 +61,9 @@ const DEFAULT_FORM_DATA: InventoryFormData = {
   keeper: '',
 }
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
 const labelClass = 'grid gap-1.5 font-semibold'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 
 function normalizeDateForInput(value: string | null): string {
   if (!value) {
@@ -248,12 +248,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">{isEditMode ? '修改財產資料' : '新增庫存資料'}</h1>
-        <p className="mt-2 text-slate-500">{isEditMode ? '可編輯現有財產資訊並儲存。' : '填寫下列欄位建立新的庫存資料。'}</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
         {errorMessage ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{errorMessage}</p> : null}
         {successMessage ? <p className="mt-0.5 rounded-[10px] bg-emerald-50 px-3.5 py-3 text-emerald-700">{successMessage}</p> : null}
@@ -384,7 +379,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
             </label>
 
             {loadedItem ? (
-              <div className="col-[1/-1] grid gap-2 rounded-[10px] border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 md:grid-cols-2">
+              <div className="col-[1/-1] grid gap-2 rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-4 text-sm text-slate-700 md:grid-cols-2">
                 <div>建立時間：{formatDateTime(loadedItem.created_at)}</div>
                 <div>建立者：{loadedItem.created_by || '--'}</div>
                 <div>更新時間：{formatDateTime(loadedItem.updated_at)}</div>

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { MoreHorizontal, Plus } from 'lucide-react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
+import { Button } from '../ui/button'
+import { Dialog } from '../ui/dialog'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu'
+import { FilterBar } from '../ui/filter-bar'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import { buildAssetStatusLabelMap, fetchAssetStatusOptions, toAssetStatusLabel } from './assetStatusLookup'
 import type { InventoryItem, PaginatedResponse } from './types'
 
@@ -13,9 +24,6 @@ const ASSET_TYPE_LABEL_MAP: Record<string, string> = {
 }
 
 const CHINESE_CHARACTER_REGEX = /[\u4e00-\u9fff]/
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
-const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 const SCAN_MAX_KEY_INTERVAL_MS = 45
 const SCAN_MIN_LENGTH = 4
 
@@ -85,6 +93,7 @@ export function InventoryListPage() {
   const [total, setTotal] = useState(0)
   const [totalPages, setTotalPages] = useState(1)
   const [deletingItemId, setDeletingItemId] = useState<number | null>(null)
+  const [confirmDeleteItem, setConfirmDeleteItem] = useState<InventoryItem | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const scanBufferRef = useRef<ScanBuffer>({ value: '', lastTs: 0 })
@@ -225,6 +234,9 @@ export function InventoryListPage() {
     return item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn || ''
   }
 
+  const confirmDeleteLabel =
+    confirmDeleteItem ? confirmDeleteItem.name || getPrimarySerial(confirmDeleteItem) || String(confirmDeleteItem.id) : ''
+
   const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const now = Date.now()
     const buffer = scanBufferRef.current
@@ -257,19 +269,6 @@ export function InventoryListPage() {
       return
     }
 
-    const result = await Swal.fire({
-      title: '確認刪除',
-      text: `確定要刪除財產「${item.name || getPrimarySerial(item) || item.id}」嗎？`,
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonText: '刪除',
-      cancelButtonText: '取消',
-    })
-
-    if (!result.isConfirmed) {
-      return
-    }
-
     setLoadError('')
     setActionMessage('')
     setDeletingItemId(item.id)
@@ -285,6 +284,7 @@ export function InventoryListPage() {
 
       setActionMessage('財產資料已刪除。')
       setReloadKey((previous) => previous + 1)
+      setConfirmDeleteItem(null)
     } catch {
       setLoadError('刪除財產資料失敗，請稍後再試。')
     } finally {
@@ -305,146 +305,188 @@ export function InventoryListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <div className="mb-4 grid grid-cols-1 gap-2">
-          <label htmlFor="search-input" className="font-bold">
-            關鍵字搜尋
-          </label>
-          <input
-            className={fieldClass}
-            id="search-input"
-            ref={searchInputRef}
-            type="search"
-            placeholder="可輸入/掃描財產編號、品名、型號..."
-            value={keyword}
-            onKeyDown={handleSearchKeyDown}
-            onChange={(event) => {
-              if (lastInputSourceRef.current !== 'scan') {
-                lastInputSourceRef.current = 'manual'
-              }
-              setKeyword(event.target.value)
-              setPage(1)
-            }}
-          />
+      <PageHeader
+        title="財產清單"
+        description="管理資產資料，支援條件過濾、掃碼查詢與刪除。"
+        actions={
+          <Link to="/inventory/new">
+            <Button>
+              <Plus className="size-4" />
+              新增庫存
+            </Button>
+          </Link>
+        }
+      />
 
-          <label htmlFor="asset-type-filter" className="font-bold">
-            資產類型篩選
-          </label>
-          <select
-            className={fieldClass}
-            id="asset-type-filter"
-            value={selectedAssetType}
-            onChange={(event) => {
-              setSelectedAssetType(event.target.value)
-              setPage(1)
-            }}
-          >
-            {assetTypeOptions.map((assetTypeValue) => (
-              <option key={assetTypeValue} value={assetTypeValue}>
-                {assetTypeValue === 'all' ? '全部類別' : toAssetTypeLabel(assetTypeValue)}
-              </option>
-            ))}
-          </select>
-
-          <label htmlFor="correction-filter" className="font-bold">
-            待修正篩選
-          </label>
-          <select
-            className={fieldClass}
-            id="correction-filter"
-            value={selectedCorrectionStatus}
-            onChange={(event) => {
-              setSelectedCorrectionStatus(event.target.value as 'all' | 'needs_fix')
-              setPage(1)
-            }}
-          >
-            <option value="all">全部資料</option>
-            <option value="needs_fix">僅顯示待修正資料</option>
-          </select>
-
-          <label className="mt-1 inline-flex items-center gap-2 font-bold">
-            <input
-              type="checkbox"
-              checked={showDonated}
+      <SectionCard>
+        <FilterBar className="xl:grid-cols-[2fr_1fr_1fr_1fr]">
+          <div className="grid gap-1.5 xl:col-span-2">
+            <Label htmlFor="search-input">關鍵字搜尋</Label>
+            <Input
+              id="search-input"
+              ref={searchInputRef}
+              type="search"
+              placeholder="可輸入/掃描財產編號、品名、型號..."
+              value={keyword}
+              onKeyDown={handleSearchKeyDown}
               onChange={(event) => {
-                setShowDonated(event.target.checked)
+                if (lastInputSourceRef.current !== 'scan') {
+                  lastInputSourceRef.current = 'manual'
+                }
+                setKeyword(event.target.value)
                 setPage(1)
               }}
             />
-            顯示已捐贈資料
-          </label>
+          </div>
 
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
-          {correctionSummary !== null ? <p className="mt-1 text-[0.95rem] text-slate-600">本頁待修正：{correctionSummary} 筆</p> : null}
-        </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="asset-type-filter">資產類型篩選</Label>
+            <Select
+              id="asset-type-filter"
+              value={selectedAssetType}
+              onChange={(event) => {
+                setSelectedAssetType(event.target.value)
+                setPage(1)
+              }}
+            >
+              {assetTypeOptions.map((assetTypeValue) => (
+                <option key={assetTypeValue} value={assetTypeValue}>
+                  {assetTypeValue === 'all' ? '全部類別' : toAssetTypeLabel(assetTypeValue)}
+                </option>
+              ))}
+            </Select>
+          </div>
 
-        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
-        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
-        {actionMessage ? <p className="mt-0.5 rounded-[10px] bg-emerald-50 px-3.5 py-3 text-emerald-700">{actionMessage}</p> : null}
+          <div className="grid gap-1.5">
+            <Label htmlFor="correction-filter">待修正篩選</Label>
+            <Select
+              id="correction-filter"
+              value={selectedCorrectionStatus}
+              onChange={(event) => {
+                setSelectedCorrectionStatus(event.target.value as 'all' | 'needs_fix')
+                setPage(1)
+              }}
+            >
+              <option value="all">全部資料</option>
+              <option value="needs_fix">僅顯示待修正資料</option>
+            </Select>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-2 xl:col-span-4">
+            <Label className="inline-flex cursor-pointer items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={showDonated}
+                onChange={(event) => {
+                  setShowDonated(event.target.checked)
+                  setPage(1)
+                }}
+              />
+              顯示已捐贈資料
+            </Label>
+            <div className="text-sm text-[hsl(var(--muted-foreground))]">
+              共 {total} 筆資料{correctionSummary !== null ? `，本頁待修正 ${correctionSummary} 筆` : ''}
+            </div>
+          </div>
+        </FilterBar>
+
+        {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+        {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
+        {actionMessage ? <p className="m-0 rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{actionMessage}</p> : null}
 
         {!loading && !loadError ? (
           <>
-            <div className="w-full overflow-x-auto">
-              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-                <thead>
-                  <tr>
-                    {['#', '資產類型', '財產序號', '品名', '型號', '規格', '單位', '購置日期', '放置地點', '保管人', '資產狀態', '操作'].map((header) => (
-                      <th key={header} className={tableHeaderClass}>{header}</th>
+            <div className="hidden overflow-x-auto md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {['#', '資產類型', '財產序號', '品名', '型號', '放置地點', '保管人', '資產狀態', '操作'].map((header) => (
+                      <TableHead key={header}>{header}</TableHead>
                     ))}
-                  </tr>
-                </thead>
-                <tbody>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {items.length === 0 ? (
-                    <tr>
-                      <td colSpan={12} className="border border-[hsl(var(--border))] p-2 text-center text-slate-500">
-                        查無符合條件的財產資料
-                      </td>
-                    </tr>
+                    <TableRow>
+                      <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={9}>
+                        查無符合條件的財產資料。
+                      </TableCell>
+                    </TableRow>
                   ) : (
                     items.map((item) => (
-                      <tr key={item.id}>
-                        <td className={`${tableCellClass} whitespace-nowrap`}>
+                      <TableRow key={item.id}>
+                        <TableCell>
                           {item.id ? (
-                            <Link
-                              className="font-bold text-blue-700 no-underline hover:underline"
-                              to="/inventory/edit/$itemId"
-                              params={{ itemId: String(item.id) }}
-                            >
+                            <Link className="font-semibold text-blue-700 no-underline hover:underline" to="/inventory/edit/$itemId" params={{ itemId: String(item.id) }}>
                               {item.id}
                             </Link>
                           ) : (
                             '--'
                           )}
-                        </td>
-                        <td className={tableCellClass}>{toAssetTypeLabel(item.asset_type)}</td>
-                        <td className={tableCellClass}>{getPrimarySerial(item) || '--'}</td>
-                        <td className={tableCellClass}>{item.name || '--'}</td>
-                        <td className={tableCellClass}>{item.model || '--'}</td>
-                        <td className={tableCellClass}>{item.specification || '--'}</td>
-                        <td className={tableCellClass}>{item.unit || '--'}</td>
-                        <td className={`${tableCellClass} whitespace-nowrap`}>{item.purchase_date ?? '--'}</td>
-                        <td className={tableCellClass}>{item.location || '--'}</td>
-                        <td className={tableCellClass}>{item.keeper || '--'}</td>
-                        <td className={`${tableCellClass} whitespace-nowrap`}>
-                          <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-bold text-slate-700">
-                            {toAssetStatusLabel(item.asset_status, assetStatusLabelMap)}
-                          </span>
-                        </td>
-                        <td className={`${tableCellClass} whitespace-nowrap`}>
-                          <button
-                            type="button"
-                            className="cursor-pointer rounded-[10px] border-none bg-red-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-red-300"
-                            onClick={() => void handleDeleteItem(item)}
-                            disabled={deletingItemId === item.id}
-                          >
-                            {deletingItemId === item.id ? '刪除中...' : '刪除'}
-                          </button>
-                        </td>
-                      </tr>
+                        </TableCell>
+                        <TableCell>{toAssetTypeLabel(item.asset_type)}</TableCell>
+                        <TableCell>{getPrimarySerial(item) || '--'}</TableCell>
+                        <TableCell>
+                          <div className="font-semibold">{item.name || '--'}</div>
+                          <div className="text-xs text-[hsl(var(--muted-foreground))]">{item.model || '--'}</div>
+                        </TableCell>
+                        <TableCell>{item.specification || '--'}</TableCell>
+                        <TableCell>{item.location || '--'}</TableCell>
+                        <TableCell>{item.keeper || '--'}</TableCell>
+                        <TableCell>{toAssetStatusLabel(item.asset_status, assetStatusLabelMap)}</TableCell>
+                        <TableCell>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger>
+                              <MoreHorizontal className="size-4" />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent>
+                              <Link
+                                className="flex items-center rounded-sm px-2 py-1.5 text-sm text-[hsl(var(--foreground))] no-underline hover:bg-[hsl(var(--secondary))]"
+                                to="/inventory/edit/$itemId"
+                                params={{ itemId: String(item.id) }}
+                              >
+                                編輯
+                              </Link>
+                              <DropdownMenuItem className="text-red-600" onClick={() => setConfirmDeleteItem(item)}>
+                                刪除
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </TableCell>
+                      </TableRow>
                     ))
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="grid gap-3 md:hidden">
+              {items.length === 0 ? (
+                <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                  查無符合條件的財產資料。
+                </p>
+              ) : (
+                items.map((item) => (
+                  <article key={item.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                    <div className="flex items-center justify-between">
+                      <p className="m-0 text-sm font-semibold">{item.name || '--'}</p>
+                      <span className="text-xs text-[hsl(var(--muted-foreground))]">#{item.id}</span>
+                    </div>
+                    <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{getPrimarySerial(item) || '--'}</p>
+                    <p className="mt-2 mb-0 text-sm">類型：{toAssetTypeLabel(item.asset_type)}</p>
+                    <p className="mt-1 mb-0 text-sm">地點：{item.location || '--'}</p>
+                    <p className="mt-1 mb-0 text-sm">狀態：{toAssetStatusLabel(item.asset_status, assetStatusLabelMap)}</p>
+                    <div className="mt-3 flex gap-2">
+                      <Link className="flex-1" to="/inventory/edit/$itemId" params={{ itemId: String(item.id) }}>
+                        <Button className="w-full" size="sm" variant="secondary">編輯</Button>
+                      </Link>
+                      <Button size="sm" variant="destructive" onClick={() => setConfirmDeleteItem(item)}>
+                        刪除
+                      </Button>
+                    </div>
+                  </article>
+                ))
+              )}
             </div>
 
             <DataPagination
@@ -460,7 +502,32 @@ export function InventoryListPage() {
             />
           </>
         ) : null}
-      </section>
+      </SectionCard>
+
+      <Dialog
+        open={Boolean(confirmDeleteItem)}
+        onClose={() => setConfirmDeleteItem(null)}
+        title="確認刪除"
+        description={`確定要刪除財產「${confirmDeleteLabel}」嗎？`}
+        actions={
+          <>
+            <Button variant="secondary" onClick={() => setConfirmDeleteItem(null)}>
+              取消
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (confirmDeleteItem) {
+                  void handleDeleteItem(confirmDeleteItem)
+                }
+              }}
+              disabled={deletingItemId === confirmDeleteItem?.id}
+            >
+              {deletingItemId === confirmDeleteItem?.id ? '刪除中...' : '刪除'}
+            </Button>
+          </>
+        }
+      />
     </>
   )
 }

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
+import { DataPagination } from '../ui/data-pagination'
 import { buildAssetStatusLabelMap, fetchAssetStatusOptions, toAssetStatusLabel } from './assetStatusLookup'
-import type { InventoryItem } from './types'
+import type { InventoryItem, PaginatedResponse } from './types'
 
 const ASSET_TYPE_LABEL_MAP: Record<string, string> = {
   '11': '財產',
@@ -11,10 +12,8 @@ const ASSET_TYPE_LABEL_MAP: Record<string, string> = {
   A2: '其他',
 }
 
-const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
 const CHINESE_CHARACTER_REGEX = /[\u4e00-\u9fff]/
 const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
 const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 const SCAN_MAX_KEY_INTERVAL_MS = 45
@@ -33,36 +32,115 @@ type ScanBuffer = {
   lastTs: number
 }
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return parsed
+}
+
+function parseBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === 'true') {
+    return true
+  }
+  if (value === 'false') {
+    return false
+  }
+  return fallback
+}
+
+function readInitialState() {
+  const params = new URLSearchParams(window.location.search)
+  const correctionParam = params.get('correction_status')
+  const correctionStatus = correctionParam === 'needs_fix' ? correctionParam : 'all'
+
+  return {
+    keyword: params.get('keyword') ?? '',
+    selectedAssetType: params.get('asset_type') ?? 'all',
+    selectedCorrectionStatus: correctionStatus as 'all' | 'needs_fix',
+    showDonated: parseBoolean(params.get('include_donated'), false),
+    page: parsePositiveInt(params.get('page'), 1),
+    pageSize: parsePositiveInt(params.get('page_size'), 10),
+  }
+}
+
 export function InventoryListPage() {
+  const initialState = readInitialState()
   const [items, setItems] = useState<InventoryItem[]>([])
+  const [assetTypeOptions, setAssetTypeOptions] = useState<string[]>(['all'])
   const [assetStatusLabelMap, setAssetStatusLabelMap] = useState<Record<string, string>>({})
   const [loadError, setLoadError] = useState('')
   const [actionMessage, setActionMessage] = useState('')
   const [loading, setLoading] = useState(true)
-  const [keyword, setKeyword] = useState('')
-  const [selectedAssetType, setSelectedAssetType] = useState('all')
-  const [selectedCorrectionStatus, setSelectedCorrectionStatus] = useState<'all' | 'needs_fix'>('all')
-  const [showDonated, setShowDonated] = useState(false)
-  const [pageSize, setPageSize] = useState(10)
-  const [customPageSize, setCustomPageSize] = useState('10')
-  const [currentPage, setCurrentPage] = useState(1)
+  const [keyword, setKeyword] = useState(initialState.keyword)
+  const [selectedAssetType, setSelectedAssetType] = useState(initialState.selectedAssetType)
+  const [selectedCorrectionStatus, setSelectedCorrectionStatus] = useState<'all' | 'needs_fix'>(initialState.selectedCorrectionStatus)
+  const [showDonated, setShowDonated] = useState(initialState.showDonated)
+  const [page, setPage] = useState(initialState.page)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
   const [deletingItemId, setDeletingItemId] = useState<number | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const scanBufferRef = useRef<ScanBuffer>({ value: '', lastTs: 0 })
   const lastInputSourceRef = useRef<'manual' | 'scan'>('manual')
   const lastNotifiedScanKeywordRef = useRef('')
 
   useEffect(() => {
+    const params = new URLSearchParams()
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim())
+    }
+    if (selectedAssetType !== 'all') {
+      params.set('asset_type', selectedAssetType)
+    }
+    if (selectedCorrectionStatus !== 'all') {
+      params.set('correction_status', selectedCorrectionStatus)
+    }
+    if (showDonated) {
+      params.set('include_donated', 'true')
+    }
+    if (page !== 1) {
+      params.set('page', String(page))
+    }
+    if (pageSize !== 10) {
+      params.set('page_size', String(pageSize))
+    }
+    const queryString = params.toString()
+    const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+    window.history.replaceState(null, '', url)
+  }, [keyword, selectedAssetType, selectedCorrectionStatus, showDonated, page, pageSize])
+
+  useEffect(() => {
     const loadItems = async () => {
       setLoading(true)
       setLoadError('')
       try {
-        const response = await fetch(apiUrl(showDonated ? '/api/items?include_donated=true' : '/api/items'))
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(pageSize),
+          include_donated: String(showDonated),
+          correction_status: selectedCorrectionStatus,
+        })
+        if (keyword.trim()) {
+          params.set('keyword', keyword.trim())
+        }
+        if (selectedAssetType !== 'all') {
+          params.set('asset_type', selectedAssetType)
+        }
+        const response = await fetch(apiUrl(`/api/items?${params.toString()}`))
         if (!response.ok) {
           throw new Error('無法載入財產清單')
         }
-        const payload = (await response.json()) as InventoryItem[]
-        setItems(payload)
+        const payload = (await response.json()) as PaginatedResponse<InventoryItem>
+        setItems(payload.items)
+        setTotal(payload.total)
+        setTotalPages(payload.total_pages)
       } catch {
         setLoadError('目前無法讀取財產清單，請稍後重試。')
       } finally {
@@ -71,7 +149,30 @@ export function InventoryListPage() {
     }
 
     void loadItems()
-  }, [showDonated])
+  }, [keyword, selectedAssetType, selectedCorrectionStatus, showDonated, page, pageSize, reloadKey])
+
+  useEffect(() => {
+    const loadAssetTypes = async () => {
+      try {
+        const params = new URLSearchParams({
+          page: '1',
+          page_size: '100000',
+          include_donated: String(showDonated),
+        })
+        const response = await fetch(apiUrl(`/api/items?${params.toString()}`))
+        if (!response.ok) {
+          throw new Error('無法載入資產類型')
+        }
+        const payload = (await response.json()) as PaginatedResponse<InventoryItem>
+        const uniqueAssetTypes = new Set(payload.items.map((item) => item.asset_type).filter((assetType): assetType is string => Boolean(assetType?.trim())))
+        setAssetTypeOptions(['all', ...Array.from(uniqueAssetTypes)])
+      } catch {
+        setAssetTypeOptions(['all'])
+      }
+    }
+
+    void loadAssetTypes()
+  }, [showDonated, reloadKey])
 
   useEffect(() => {
     let cancelled = false
@@ -100,6 +201,18 @@ export function InventoryListPage() {
     searchInputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    if (lastInputSourceRef.current !== 'scan') {
+      return
+    }
+    const normalizedKeyword = keyword.trim()
+    if (!normalizedKeyword || total > 0 || lastNotifiedScanKeywordRef.current === normalizedKeyword) {
+      return
+    }
+    lastNotifiedScanKeywordRef.current = normalizedKeyword
+    void toast.fire({ icon: 'error', title: '查無此財產編號。' })
+  }, [keyword, total])
+
   const toAssetTypeLabel = (assetType: string) => {
     if (!assetType) {
       return '--'
@@ -111,67 +224,6 @@ export function InventoryListPage() {
   const getPrimarySerial = (item: InventoryItem) => {
     return item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn || ''
   }
-
-  const assetTypeOptions = useMemo(() => {
-    const uniqueAssetTypes = new Set(items.map((item) => item.asset_type).filter((assetType): assetType is string => Boolean(assetType?.trim())))
-    return ['all', ...Array.from(uniqueAssetTypes)]
-  }, [items])
-
-  const filteredItems = useMemo(() => {
-    const normalizedKeyword = keyword.trim().toLowerCase()
-    const normalizeSearchValue = (value: unknown) => (typeof value === 'string' ? value : '').toLowerCase()
-    const isNeedsFix = (item: InventoryItem) => {
-      const serial = getPrimarySerial(item).trim()
-      return serial.length === 0 || CHINESE_CHARACTER_REGEX.test(serial)
-    }
-
-    return items.filter((item) => {
-      const passesAssetTypeFilter = selectedAssetType === 'all' || item.asset_type === selectedAssetType
-      if (!passesAssetTypeFilter) {
-        return false
-      }
-
-      const passesCorrectionStatusFilter = selectedCorrectionStatus === 'all' || isNeedsFix(item)
-      if (!passesCorrectionStatusFilter) {
-        return false
-      }
-
-      if (!normalizedKeyword) {
-        return true
-      }
-
-      const searchFields = [item.n_property_sn, item.property_sn, item.n_item_sn, item.item_sn, item.name, item.model, item.location, item.keeper]
-      return searchFields.some((field) => normalizeSearchValue(field).includes(normalizedKeyword))
-    })
-  }, [items, keyword, selectedAssetType, selectedCorrectionStatus])
-
-  const totalPages = Math.max(1, Math.ceil(filteredItems.length / pageSize))
-  const paginatedItems = useMemo(() => {
-    const startIndex = (currentPage - 1) * pageSize
-    return filteredItems.slice(startIndex, startIndex + pageSize)
-  }, [filteredItems, currentPage, pageSize])
-
-  useEffect(() => {
-    setCurrentPage(1)
-  }, [keyword, selectedAssetType, selectedCorrectionStatus, pageSize])
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(totalPages)
-    }
-  }, [currentPage, totalPages])
-
-  useEffect(() => {
-    if (lastInputSourceRef.current !== 'scan') {
-      return
-    }
-    const normalizedKeyword = keyword.trim()
-    if (!normalizedKeyword || filteredItems.length > 0 || lastNotifiedScanKeywordRef.current === normalizedKeyword) {
-      return
-    }
-    lastNotifiedScanKeywordRef.current = normalizedKeyword
-    void toast.fire({ icon: 'error', title: '查無此財產編號。' })
-  }, [filteredItems.length, keyword])
 
   const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const now = Date.now()
@@ -198,20 +250,6 @@ export function InventoryListPage() {
       buffer.value += key
     }
     buffer.lastTs = now
-  }
-
-  const handlePresetPageSize = (size: number) => {
-    setPageSize(size)
-    setCustomPageSize(String(size))
-  }
-
-  const handleCustomPageSize = () => {
-    const nextSize = Number(customPageSize)
-    if (!Number.isInteger(nextSize) || nextSize <= 0) {
-      return
-    }
-
-    setPageSize(nextSize)
   }
 
   const handleDeleteItem = async (item: InventoryItem) => {
@@ -245,14 +283,25 @@ export function InventoryListPage() {
         throw new Error('刪除失敗')
       }
 
-      setItems((previousItems) => previousItems.filter((existingItem) => existingItem.id !== item.id))
       setActionMessage('財產資料已刪除。')
+      setReloadKey((previous) => previous + 1)
     } catch {
       setLoadError('刪除財產資料失敗，請稍後再試。')
     } finally {
       setDeletingItemId(null)
     }
   }
+
+  const correctionSummary = useMemo(() => {
+    if (selectedCorrectionStatus !== 'needs_fix') {
+      return null
+    }
+    const count = items.filter((item) => {
+      const serial = getPrimarySerial(item).trim()
+      return serial.length === 0 || CHINESE_CHARACTER_REGEX.test(serial)
+    }).length
+    return count
+  }, [items, selectedCorrectionStatus])
 
   return (
     <>
@@ -274,13 +323,22 @@ export function InventoryListPage() {
                 lastInputSourceRef.current = 'manual'
               }
               setKeyword(event.target.value)
+              setPage(1)
             }}
           />
 
           <label htmlFor="asset-type-filter" className="font-bold">
             資產類型篩選
           </label>
-          <select className={fieldClass} id="asset-type-filter" value={selectedAssetType} onChange={(event) => setSelectedAssetType(event.target.value)}>
+          <select
+            className={fieldClass}
+            id="asset-type-filter"
+            value={selectedAssetType}
+            onChange={(event) => {
+              setSelectedAssetType(event.target.value)
+              setPage(1)
+            }}
+          >
             {assetTypeOptions.map((assetTypeValue) => (
               <option key={assetTypeValue} value={assetTypeValue}>
                 {assetTypeValue === 'all' ? '全部類別' : toAssetTypeLabel(assetTypeValue)}
@@ -295,7 +353,10 @@ export function InventoryListPage() {
             className={fieldClass}
             id="correction-filter"
             value={selectedCorrectionStatus}
-            onChange={(event) => setSelectedCorrectionStatus(event.target.value as 'all' | 'needs_fix')}
+            onChange={(event) => {
+              setSelectedCorrectionStatus(event.target.value as 'all' | 'needs_fix')
+              setPage(1)
+            }}
           >
             <option value="all">全部資料</option>
             <option value="needs_fix">僅顯示待修正資料</option>
@@ -305,43 +366,16 @@ export function InventoryListPage() {
             <input
               type="checkbox"
               checked={showDonated}
-              onChange={(event) => setShowDonated(event.target.checked)}
+              onChange={(event) => {
+                setShowDonated(event.target.checked)
+                setPage(1)
+              }}
             />
             顯示已捐贈資料
           </label>
 
-          <div className="grid gap-2">
-            <span className="font-bold">每頁筆數</span>
-            <div className="flex flex-wrap gap-2">
-              {DEFAULT_PAGE_SIZE_OPTIONS.map((size) => (
-                <button
-                  key={size}
-                  type="button"
-                  className={`cursor-pointer rounded-[10px] border px-3 py-2 font-bold ${size === pageSize ? 'border-[hsl(var(--primary))] bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]' : 'border-[hsl(var(--border))] bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))]'}`}
-                  onClick={() => handlePresetPageSize(size)}
-                >
-                  {size}
-                </button>
-              ))}
-            </div>
-            <div className="flex items-center gap-2">
-              <input
-                className={`${fieldClass} w-26`}
-                type="number"
-                min={1}
-                value={customPageSize}
-                onChange={(event) => setCustomPageSize(event.target.value)}
-              />
-              <button className={buttonClass} type="button" onClick={handleCustomPageSize}>
-                套用
-              </button>
-            </div>
-          </div>
-
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredItems.length} 筆資料</p>
-          <p className="mt-1 text-[0.95rem] text-slate-600">
-            第 {currentPage} / {totalPages} 頁
-          </p>
+          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
+          {correctionSummary !== null ? <p className="mt-1 text-[0.95rem] text-slate-600">本頁待修正：{correctionSummary} 筆</p> : null}
         </div>
 
         {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
@@ -360,14 +394,14 @@ export function InventoryListPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {paginatedItems.length === 0 ? (
+                  {items.length === 0 ? (
                     <tr>
                       <td colSpan={12} className="border border-[hsl(var(--border))] p-2 text-center text-slate-500">
                         查無符合條件的財產資料
                       </td>
                     </tr>
                   ) : (
-                    paginatedItems.map((item) => (
+                    items.map((item) => (
                       <tr key={item.id}>
                         <td className={`${tableCellClass} whitespace-nowrap`}>
                           {item.id ? (
@@ -413,29 +447,17 @@ export function InventoryListPage() {
               </table>
             </div>
 
-            {filteredItems.length > 0 ? (
-              <div className="mt-3.5 flex items-center justify-end gap-3">
-                <button
-                  className={buttonClass}
-                  type="button"
-                  onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
-                  disabled={currentPage === 1}
-                >
-                  上一頁
-                </button>
-                <span>
-                  目前第 {currentPage} 頁，共 {totalPages} 頁
-                </span>
-                <button
-                  className={buttonClass}
-                  type="button"
-                  onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-                  disabled={currentPage === totalPages}
-                >
-                  下一頁
-                </button>
-              </div>
-            ) : null}
+            <DataPagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              totalPages={totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize)
+                setPage(1)
+              }}
+            />
           </>
         ) : null}
       </section>

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { buildAssetStatusLabelMap, fetchAssetStatusOptions, toAssetStatusLabel } from './assetStatusLookup'
@@ -12,10 +13,10 @@ const ASSET_TYPE_LABEL_MAP: Record<string, string> = {
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
 const CHINESE_CHARACTER_REGEX = /[\u4e00-\u9fff]/
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
-const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
-const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
+const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
+const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 const SCAN_MAX_KEY_INTERVAL_MS = 45
 const SCAN_MIN_LENGTH = 4
 
@@ -255,12 +256,7 @@ export function InventoryListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">財產清單</h1>
-        <p className="mt-2 text-slate-500">可依財產編號、品名、型號、放置地點或保管人快速查詢（支援掃描槍）。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <div className="mb-4 grid grid-cols-1 gap-2">
           <label htmlFor="search-input" className="font-bold">
             關鍵字搜尋
@@ -321,7 +317,7 @@ export function InventoryListPage() {
                 <button
                   key={size}
                   type="button"
-                  className={`cursor-pointer rounded-[10px] border px-3 py-2 font-bold ${size === pageSize ? 'border-blue-600 bg-blue-600 text-white' : 'border-blue-300 bg-blue-100 text-blue-700'}`}
+                  className={`cursor-pointer rounded-[10px] border px-3 py-2 font-bold ${size === pageSize ? 'border-[hsl(var(--primary))] bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]' : 'border-[hsl(var(--border))] bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))]'}`}
                   onClick={() => handlePresetPageSize(size)}
                 >
                   {size}
@@ -355,7 +351,7 @@ export function InventoryListPage() {
         {!loading && !loadError ? (
           <>
             <div className="w-full overflow-x-auto">
-              <table className="mt-2 w-full table-fixed border-collapse bg-white">
+              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
                 <thead>
                   <tr>
                     {['#', '資產類型', '財產序號', '品名', '型號', '規格', '單位', '購置日期', '放置地點', '保管人', '資產狀態', '操作'].map((header) => (
@@ -366,7 +362,7 @@ export function InventoryListPage() {
                 <tbody>
                   {paginatedItems.length === 0 ? (
                     <tr>
-                      <td colSpan={12} className="border border-slate-200 p-2 text-center text-slate-500">
+                      <td colSpan={12} className="border border-[hsl(var(--border))] p-2 text-center text-slate-500">
                         查無符合條件的財產資料
                       </td>
                     </tr>
@@ -374,7 +370,17 @@ export function InventoryListPage() {
                     paginatedItems.map((item) => (
                       <tr key={item.id}>
                         <td className={`${tableCellClass} whitespace-nowrap`}>
-                          {item.id ? <a className="font-bold text-blue-700 no-underline hover:underline" href={`/inventory/edit/${item.id}`}>{item.id}</a> : '--'}
+                          {item.id ? (
+                            <Link
+                              className="font-bold text-blue-700 no-underline hover:underline"
+                              to="/inventory/edit/$itemId"
+                              params={{ itemId: String(item.id) }}
+                            >
+                              {item.id}
+                            </Link>
+                          ) : (
+                            '--'
+                          )}
                         </td>
                         <td className={tableCellClass}>{toAssetTypeLabel(item.asset_type)}</td>
                         <td className={tableCellClass}>{getPrimarySerial(item) || '--'}</td>

--- a/frontend/src/components/pages/IssueListPage.tsx
+++ b/frontend/src/components/pages/IssueListPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
 import type { IssueRequest } from './types'
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-slate-200 bg-slate-50 p-2 text-left'
-const tableCellClass = 'border border-slate-200 p-2 text-left align-top break-words'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
+const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
 export function IssueListPage() {
   const [requests, setRequests] = useState<IssueRequest[]>([])
@@ -51,12 +52,7 @@ export function IssueListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">領用清單</h1>
-        <p className="mt-2 text-slate-500">可依領用人、單位、用途、品項快速查詢。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <div className="mb-4 grid gap-2">
           <label htmlFor="issue-search" className="font-bold">
             關鍵字搜尋
@@ -77,7 +73,7 @@ export function IssueListPage() {
 
         {!loading && !loadError ? (
           <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-white">
+            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
               <thead>
                 <tr>
                   {['#', '領用日期', '領用人/單位', '用途', '品項', '備註'].map((header) => (
@@ -96,9 +92,9 @@ export function IssueListPage() {
                   filteredRequests.map((request) => (
                     <tr key={request.id}>
                       <td className={tableCellClass}>
-                        <a className="font-bold text-blue-700 no-underline" href={`/issues/${request.id}`}>
+                        <Link className="font-bold text-blue-700 no-underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
                           {request.id}
-                        </a>
+                        </Link>
                       </td>
                       <td className={tableCellClass}>{request.request_date || '--'}</td>
                       <td className={tableCellClass}>

--- a/frontend/src/components/pages/IssueListPage.tsx
+++ b/frontend/src/components/pages/IssueListPage.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
+import { Button } from '../ui/button'
+import { FilterBar } from '../ui/filter-bar'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import type { IssueRequest, PaginatedResponse } from './types'
-
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
-const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
@@ -88,75 +92,112 @@ export function IssueListPage() {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <div className="mb-4 grid gap-2">
-          <label htmlFor="issue-search" className="font-bold">
-            關鍵字搜尋
-          </label>
-          <input
-            className={fieldClass}
-            id="issue-search"
-            type="search"
-            placeholder="輸入領用人、品項、用途..."
-            value={keyword}
-            onChange={(event) => {
-              setKeyword(event.target.value)
-              setPage(1)
-            }}
-          />
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
-        </div>
+      <PageHeader
+        title="領用清單"
+        description="檢視、搜尋與維護領用申請資料。"
+        actions={
+          <Link to="/issues/new">
+            <Button>
+              <Plus className="size-4" />
+              新增領用
+            </Button>
+          </Link>
+        }
+      />
 
-        {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
-        {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
+      <SectionCard>
+        <FilterBar className="xl:grid-cols-[2fr_1fr]">
+          <div className="grid gap-1.5">
+            <Label htmlFor="issue-search">關鍵字搜尋</Label>
+            <Input
+              id="issue-search"
+              type="search"
+              placeholder="輸入領用人、品項、用途..."
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value)
+                setPage(1)
+              }}
+            />
+          </div>
+          <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
+        </FilterBar>
+
+        {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+        {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
           <>
-            <div className="w-full overflow-x-auto">
-              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-                <thead>
-                  <tr>
+            <div className="hidden overflow-x-auto md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
                     {['#', '領用日期', '領用人/單位', '用途', '品項', '備註'].map((header) => (
-                      <th key={header} className={tableHeaderClass}>{header}</th>
+                      <TableHead key={header}>{header}</TableHead>
                     ))}
-                  </tr>
-                </thead>
-                <tbody>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {requests.length === 0 ? (
-                    <tr>
-                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={6}>
+                    <TableRow>
+                      <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={6}>
                         目前沒有符合條件的領用單。
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ) : (
                     requests.map((request) => (
-                      <tr key={request.id}>
-                        <td className={tableCellClass}>
-                          <Link className="font-bold text-blue-700 no-underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
+                      <TableRow key={request.id}>
+                        <TableCell>
+                          <Link className="font-semibold text-blue-700 no-underline hover:underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
                             {request.id}
                           </Link>
-                        </td>
-                        <td className={tableCellClass}>{request.request_date || '--'}</td>
-                        <td className={tableCellClass}>
-                          <div className="font-bold">{request.requester || '--'}</div>
-                          <div className="text-sm text-slate-500">{request.department || ''}</div>
-                        </td>
-                        <td className={tableCellClass}>{request.purpose || '--'}</td>
-                        <td className={tableCellClass}>
+                        </TableCell>
+                        <TableCell>{request.request_date || '--'}</TableCell>
+                        <TableCell>
+                          <div className="font-semibold">{request.requester || '--'}</div>
+                          <div className="text-xs text-[hsl(var(--muted-foreground))]">{request.department || ''}</div>
+                        </TableCell>
+                        <TableCell>{request.purpose || '--'}</TableCell>
+                        <TableCell>
                           <div className="grid gap-1">
                             {request.items.map((item) => (
-                              <div key={item.id} className="text-sm">
+                              <div key={item.id} className="text-xs">
                                 {(item.item_name || `#${item.item_id}`)} x {item.quantity}
                               </div>
                             ))}
                           </div>
-                        </td>
-                        <td className={tableCellClass}>{request.memo || '--'}</td>
-                      </tr>
+                        </TableCell>
+                        <TableCell>{request.memo || '--'}</TableCell>
+                      </TableRow>
                     ))
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="grid gap-3 md:hidden">
+              {requests.length === 0 ? (
+                <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                  目前沒有符合條件的領用單。
+                </p>
+              ) : (
+                requests.map((request) => (
+                  <article key={request.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                    <div className="flex items-center justify-between">
+                      <Link className="font-semibold text-blue-700 no-underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
+                        #{request.id}
+                      </Link>
+                      <span className="text-xs text-[hsl(var(--muted-foreground))]">{request.request_date || '--'}</span>
+                    </div>
+                    <p className="mt-2 mb-0 text-sm font-semibold">{request.requester || '--'}</p>
+                    <p className="mt-0.5 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{request.department || '--'}</p>
+                    <p className="mt-2 mb-0 text-sm">用途：{request.purpose || '--'}</p>
+                    <p className="mt-2 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
+                      品項：{request.items.map((item) => `${item.item_name || `#${item.item_id}`} x ${item.quantity}`).join('，') || '--'}
+                    </p>
+                  </article>
+                ))
+              )}
             </div>
 
             <DataPagination
@@ -172,7 +213,7 @@ export function IssueListPage() {
             />
           </>
         ) : null}
-      </section>
+      </SectionCard>
     </>
   )
 }

--- a/frontend/src/components/pages/IssueListPage.tsx
+++ b/frontend/src/components/pages/IssueListPage.tsx
@@ -1,29 +1,81 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { apiUrl } from '../../api'
-import type { IssueRequest } from './types'
+import { DataPagination } from '../ui/data-pagination'
+import type { IssueRequest, PaginatedResponse } from './types'
 
 const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
 const tableHeaderClass = 'whitespace-nowrap border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] p-2 text-left'
 const tableCellClass = 'border border-[hsl(var(--border))] p-2 text-left align-top break-words'
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return parsed
+}
+
+function readInitialState() {
+  const params = new URLSearchParams(window.location.search)
+  return {
+    keyword: params.get('keyword') ?? '',
+    page: parsePositiveInt(params.get('page'), 1),
+    pageSize: parsePositiveInt(params.get('page_size'), 10),
+  }
+}
+
 export function IssueListPage() {
+  const initialState = readInitialState()
   const [requests, setRequests] = useState<IssueRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
-  const [keyword, setKeyword] = useState('')
+  const [keyword, setKeyword] = useState(initialState.keyword)
+  const [page, setPage] = useState(initialState.page)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim())
+    }
+    if (page !== 1) {
+      params.set('page', String(page))
+    }
+    if (pageSize !== 10) {
+      params.set('page_size', String(pageSize))
+    }
+    const queryString = params.toString()
+    const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+    window.history.replaceState(null, '', url)
+  }, [keyword, page, pageSize])
 
   useEffect(() => {
     const loadRequests = async () => {
       setLoading(true)
       setLoadError('')
       try {
-        const response = await fetch(apiUrl('/api/issues'))
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(pageSize),
+        })
+        if (keyword.trim()) {
+          params.set('keyword', keyword.trim())
+        }
+
+        const response = await fetch(apiUrl(`/api/issues?${params.toString()}`))
         if (!response.ok) {
           throw new Error('無法載入領用清單')
         }
-        const payload = (await response.json()) as IssueRequest[]
-        setRequests(payload)
+        const payload = (await response.json()) as PaginatedResponse<IssueRequest>
+        setRequests(payload.items)
+        setTotal(payload.total)
+        setTotalPages(payload.total_pages)
       } catch {
         setLoadError('目前無法讀取領用清單，請稍後重試。')
       } finally {
@@ -32,23 +84,7 @@ export function IssueListPage() {
     }
 
     void loadRequests()
-  }, [])
-
-  const filteredRequests = useMemo(() => {
-    const normalizedKeyword = keyword.trim().toLowerCase()
-    if (!normalizedKeyword) {
-      return requests
-    }
-
-    const normalize = (value: string | null | undefined) => (value ?? '').toLowerCase()
-    return requests.filter((request) => {
-      const itemMatches = request.items.some((item) =>
-        normalize(item.item_name).includes(normalizedKeyword)
-      )
-      const fields = [request.requester, request.department, request.purpose, request.memo, request.request_date]
-      return itemMatches || fields.some((field) => normalize(field).includes(normalizedKeyword))
-    })
-  }, [keyword, requests])
+  }, [keyword, page, pageSize])
 
   return (
     <>
@@ -63,61 +99,78 @@ export function IssueListPage() {
             type="search"
             placeholder="輸入領用人、品項、用途..."
             value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
+            onChange={(event) => {
+              setKeyword(event.target.value)
+              setPage(1)
+            }}
           />
-          <p className="mt-1 text-[0.95rem] text-slate-600">共 {filteredRequests.length} 筆資料</p>
+          <p className="mt-1 text-[0.95rem] text-slate-600">共 {total} 筆資料</p>
         </div>
 
         {loading ? <p className="mt-0.5 rounded-[10px] px-3.5 py-3">資料載入中...</p> : null}
         {loadError ? <p className="mt-0.5 rounded-[10px] bg-red-50 px-3.5 py-3 text-red-700">{loadError}</p> : null}
 
         {!loading && !loadError ? (
-          <div className="w-full overflow-x-auto">
-            <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
-              <thead>
-                <tr>
-                  {['#', '領用日期', '領用人/單位', '用途', '品項', '備註'].map((header) => (
-                    <th key={header} className={tableHeaderClass}>{header}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRequests.length === 0 ? (
+          <>
+            <div className="w-full overflow-x-auto">
+              <table className="mt-2 w-full table-fixed border-collapse bg-[hsl(var(--card))]">
+                <thead>
                   <tr>
-                    <td className={`${tableCellClass} text-center text-slate-500`} colSpan={6}>
-                      目前沒有符合條件的領用單。
-                    </td>
+                    {['#', '領用日期', '領用人/單位', '用途', '品項', '備註'].map((header) => (
+                      <th key={header} className={tableHeaderClass}>{header}</th>
+                    ))}
                   </tr>
-                ) : (
-                  filteredRequests.map((request) => (
-                    <tr key={request.id}>
-                      <td className={tableCellClass}>
-                        <Link className="font-bold text-blue-700 no-underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
-                          {request.id}
-                        </Link>
+                </thead>
+                <tbody>
+                  {requests.length === 0 ? (
+                    <tr>
+                      <td className={`${tableCellClass} text-center text-slate-500`} colSpan={6}>
+                        目前沒有符合條件的領用單。
                       </td>
-                      <td className={tableCellClass}>{request.request_date || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="font-bold">{request.requester || '--'}</div>
-                        <div className="text-sm text-slate-500">{request.department || ''}</div>
-                      </td>
-                      <td className={tableCellClass}>{request.purpose || '--'}</td>
-                      <td className={tableCellClass}>
-                        <div className="grid gap-1">
-                          {request.items.map((item) => (
-                            <div key={item.id} className="text-sm">
-                              {(item.item_name || `#${item.item_id}`)} x {item.quantity}
-                            </div>
-                          ))}
-                        </div>
-                      </td>
-                      <td className={tableCellClass}>{request.memo || '--'}</td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+                  ) : (
+                    requests.map((request) => (
+                      <tr key={request.id}>
+                        <td className={tableCellClass}>
+                          <Link className="font-bold text-blue-700 no-underline" to="/issues/$requestId" params={{ requestId: String(request.id) }}>
+                            {request.id}
+                          </Link>
+                        </td>
+                        <td className={tableCellClass}>{request.request_date || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="font-bold">{request.requester || '--'}</div>
+                          <div className="text-sm text-slate-500">{request.department || ''}</div>
+                        </td>
+                        <td className={tableCellClass}>{request.purpose || '--'}</td>
+                        <td className={tableCellClass}>
+                          <div className="grid gap-1">
+                            {request.items.map((item) => (
+                              <div key={item.id} className="text-sm">
+                                {(item.item_name || `#${item.item_id}`)} x {item.quantity}
+                              </div>
+                            ))}
+                          </div>
+                        </td>
+                        <td className={tableCellClass}>{request.memo || '--'}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <DataPagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              totalPages={totalPages}
+              onPageChange={setPage}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize)
+                setPage(1)
+              }}
+            />
+          </>
         ) : null}
       </section>
     </>

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
-import type { InventoryItem, IssueRequest } from './types'
+import type { InventoryItem, IssueRequest, PaginatedResponse } from './types'
 
 type IssueLine = {
   item_id: number | ''
@@ -41,12 +41,12 @@ export function IssuePage({ requestId }: IssuePageProps) {
     const loadData = async () => {
       setLoadError('')
       try {
-        const itemsResponse = await fetch(apiUrl('/api/items'))
+        const itemsResponse = await fetch(apiUrl('/api/items?page=1&page_size=100000'))
         if (!itemsResponse.ok) {
           throw new Error('無法載入資料')
         }
-        const itemsPayload = (await itemsResponse.json()) as InventoryItem[]
-        setInventoryItems(itemsPayload)
+        const itemsPayload = (await itemsResponse.json()) as PaginatedResponse<InventoryItem>
+        setInventoryItems(itemsPayload.items)
       } catch {
         setLoadError('目前無法讀取領用資料，請稍後重試。')
       }

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -9,8 +9,8 @@ type IssueLine = {
   note: string
 }
 
-const fieldClass = 'rounded-[10px] border border-slate-300 bg-white px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-blue-600 px-3 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:bg-blue-300'
+const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
+const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): IssueLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -169,12 +169,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">領用管理</h1>
-        <p className="mt-2 text-slate-500">建立領用單，並可一次選擇多個品項。</p>
-      </section>
-
-      <section className="rounded-2xl bg-white p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
+      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
         <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯領用單' : '新增領用單'}</h2>
         <div className="mt-4 grid gap-3">
           <div className="grid gap-2 md:grid-cols-2">
@@ -210,7 +205,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
 
           <div className="mt-3 grid gap-3">
             {lines.map((line, index) => (
-              <div key={`issue-line-${index}`} className="grid gap-2 rounded-xl border border-slate-200 p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
+              <div key={`issue-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
                 <label className="grid gap-2 font-bold">
                   品項
                   <select
@@ -243,7 +238,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
                 <div className="flex items-end">
                   <button
                     type="button"
-                    className="cursor-pointer rounded-[10px] border border-slate-300 px-3 py-2.5 text-sm font-bold text-slate-600"
+                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
                     onClick={() => handleRemoveLine(index)}
                     disabled={lines.length <= 1}
                   >

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { PageHeader } from '../ui/page-header'
+import { SectionCard } from '../ui/section-card'
+import { Select } from '../ui/select'
+import { Textarea } from '../ui/textarea'
 import type { InventoryItem, IssueRequest, PaginatedResponse } from './types'
 
 type IssueLine = {
@@ -9,8 +16,6 @@ type IssueLine = {
   note: string
 }
 
-const fieldClass = 'rounded-[10px] border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5'
-const buttonClass = 'cursor-pointer rounded-[10px] border-none bg-[hsl(var(--primary))] px-3 py-2.5 font-bold text-[hsl(var(--primary-foreground))] disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-disabled))] disabled:text-[hsl(var(--primary-foreground))]'
 const emptyLine = (): IssueLine => ({ item_id: '', quantity: 1, note: '' })
 const toast = Swal.mixin({
   toast: true,
@@ -81,7 +86,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
               quantity: item.quantity,
               note: item.note ?? '',
             }))
-            : [emptyLine()]
+            : [emptyLine()],
         )
       } catch {
         setLoadError('目前無法讀取領用單資料，請稍後重試。')
@@ -100,14 +105,6 @@ export function IssuePage({ requestId }: IssuePageProps) {
 
   const handleLineChange = (index: number, patch: Partial<IssueLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
-  }
-
-  const handleAddLine = () => {
-    setLines((prev) => [...prev, emptyLine()])
-  }
-
-  const handleRemoveLine = (index: number) => {
-    setLines((prev) => prev.filter((_, idx) => idx !== index))
   }
 
   const validateLines = () => {
@@ -169,47 +166,44 @@ export function IssuePage({ requestId }: IssuePageProps) {
 
   return (
     <>
-      <section className="rounded-2xl bg-[hsl(var(--card))] p-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h2 className="mt-0 text-lg font-bold">{isEditing ? '編輯領用單' : '新增領用單'}</h2>
-        <div className="mt-4 grid gap-3">
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="grid gap-2 font-bold">
-              領用人
-              <input className={fieldClass} value={requester} onChange={(event) => setRequester(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              單位
-              <input className={fieldClass} value={department} onChange={(event) => setDepartment(event.target.value)} />
-            </label>
-          </div>
-          <label className="grid gap-2 font-bold">
-            用途
-            <input className={fieldClass} value={purpose} onChange={(event) => setPurpose(event.target.value)} />
-          </label>
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="grid gap-2 font-bold">
-              領用日期
-              <input className={fieldClass} type="date" value={requestDate} onChange={(event) => setRequestDate(event.target.value)} />
-            </label>
-            <label className="grid gap-2 font-bold">
-              備註
-              <input className={fieldClass} value={memo} onChange={(event) => setMemo(event.target.value)} />
-            </label>
-          </div>
-        </div>
+      <PageHeader
+        title={isEditing ? '編輯領用單' : '新增領用單'}
+        description="填寫領用人與品項資訊，建立領用交易。"
+      />
 
-        <div className="mt-6">
-          <div className="flex items-center justify-between">
-            <h3 className="m-0 text-base font-bold">領用品項</h3>
+      <div className="grid gap-4">
+        <SectionCard title="基本資料">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid gap-1.5">
+              <Label>領用人</Label>
+              <Input value={requester} onChange={(event) => setRequester(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>單位</Label>
+              <Input value={department} onChange={(event) => setDepartment(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5 md:col-span-2">
+              <Label>用途</Label>
+              <Input value={purpose} onChange={(event) => setPurpose(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>領用日期</Label>
+              <Input type="date" value={requestDate} onChange={(event) => setRequestDate(event.target.value)} />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>備註</Label>
+              <Textarea rows={3} value={memo} onChange={(event) => setMemo(event.target.value)} />
+            </div>
           </div>
+        </SectionCard>
 
-          <div className="mt-3 grid gap-3">
+        <SectionCard title="領用品項">
+          <div className="grid gap-3">
             {lines.map((line, index) => (
-              <div key={`issue-line-${index}`} className="grid gap-2 rounded-xl border border-[hsl(var(--border))] p-4 md:grid-cols-[2fr,1fr,2fr,auto]">
-                <label className="grid gap-2 font-bold">
-                  品項
-                  <select
-                    className={fieldClass}
+              <article key={`issue-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+                <div className="grid gap-1.5">
+                  <Label>品項</Label>
+                  <Select
                     value={line.item_id}
                     onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
                   >
@@ -219,48 +213,41 @@ export function IssuePage({ requestId }: IssuePageProps) {
                         {option.label}
                       </option>
                     ))}
-                  </select>
-                </label>
-                <label className="grid gap-2 font-bold">
-                  數量
-                  <input
-                    className={fieldClass}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>數量</Label>
+                  <Input
                     type="number"
                     min={1}
                     value={line.quantity}
                     onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
                   />
-                </label>
-                <label className="grid gap-2 font-bold">
-                  備註
-                  <input className={fieldClass} value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
-                </label>
-                <div className="flex items-end">
-                  <button
-                    type="button"
-                    className="cursor-pointer rounded-[10px] border border-[hsl(var(--border))] px-3 py-2.5 text-sm font-bold text-slate-600"
-                    onClick={() => handleRemoveLine(index)}
-                    disabled={lines.length <= 1}
-                  >
-                    移除
-                  </button>
                 </div>
-              </div>
+                <div className="grid gap-1.5">
+                  <Label>備註</Label>
+                  <Input value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                </div>
+                <div className="flex items-end">
+                  <Button type="button" variant="secondary" onClick={() => setLines((prev) => prev.filter((_, idx) => idx !== index))} disabled={lines.length <= 1}>
+                    移除
+                  </Button>
+                </div>
+              </article>
             ))}
           </div>
 
-          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-xl px-4 py-3">
-            <button className={buttonClass} type="button" onClick={handleAddLine}>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <Button type="button" variant="secondary" onClick={() => setLines((prev) => [...prev, emptyLine()])}>
               新增品項
-            </button>
-            <button className={buttonClass} type="button" onClick={handleSubmit} disabled={submitting}>
+            </Button>
+            <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
               {submitting ? (isEditing ? '更新中...' : '建立中...') : (isEditing ? '更新領用單' : '建立領用單')}
-            </button>
-            {loadError ? <span className="text-sm text-red-600">{loadError}</span> : null}
+            </Button>
           </div>
-        </div>
-      </section>
-
+          {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
+        </SectionCard>
+      </div>
     </>
   )
 }

--- a/frontend/src/components/pages/UploadPage.tsx
+++ b/frontend/src/components/pages/UploadPage.tsx
@@ -3,10 +3,6 @@ import { UploadPanel } from '../UploadPanel'
 export function UploadPage() {
   return (
     <>
-      <section className="rounded-2xl bg-white px-7 py-6 shadow-[0_12px_30px_rgba(31,41,55,0.12)]">
-        <h1 className="mt-0">資產匯入</h1>
-        <p className="mt-2 text-slate-500">上傳畫面為獨立頁面，請在此進行 Excel 批次匯入。</p>
-      </section>
       <UploadPanel />
     </>
   )

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -5,6 +5,14 @@ export type DashboardPayload = {
   pendingFix: number
 }
 
+export type PaginatedResponse<T> = {
+  items: T[]
+  page: number
+  page_size: number
+  total: number
+  total_pages: number
+}
+
 export type InventoryItem = {
   id: number
   asset_type: string

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '../../lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap [&>svg]:size-3 gap-1',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]',
+        secondary: 'border-transparent bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))]',
+        outline: 'border-[hsl(var(--border))] text-[hsl(var(--foreground))]',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+function Badge({ className, variant, ...props }: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+  return <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] hover:bg-[hsl(var(--primary-hover))]',
+        secondary:
+          'border border-[hsl(var(--border-strong))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))]',
+        destructive: 'bg-[hsl(var(--destructive))] text-[hsl(var(--destructive-foreground))] hover:bg-[hsl(var(--destructive-hover))]',
+        ghost: 'text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--secondary))] hover:text-[hsl(var(--foreground))]',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-8 px-3 text-xs',
+        lg: 'h-11 px-5',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+export function Button({ className, variant, size, ...props }: React.ComponentProps<'button'> & VariantProps<typeof buttonVariants>) {
+  return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+function Card({ className, ...props }: React.ComponentProps<'section'>) {
+  return (
+    <section
+      data-slot="card"
+      className={cn(
+        'rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-header" className={cn('flex flex-col gap-1.5 p-6', className)} {...props} />
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'h2'>) {
+  return (
+    <h2 data-slot="card-title" className={cn('text-base leading-none font-semibold tracking-tight', className)} {...props} />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return <p data-slot="card-description" className={cn('text-sm text-[hsl(var(--muted-foreground))]', className)} {...props} />
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('p-6 pt-0', className)} {...props} />
+}
+
+export { Card, CardContent, CardDescription, CardHeader, CardTitle }

--- a/frontend/src/components/ui/data-pagination.tsx
+++ b/frontend/src/components/ui/data-pagination.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
+
+type PageToken = number | 'ellipsis'
+
+type DataPaginationProps = {
+  page: number
+  pageSize: number
+  total: number
+  totalPages: number
+  pageSizeOptions?: number[]
+  allowCustomPageSize?: boolean
+  onPageChange: (page: number) => void
+  onPageSizeChange: (nextPageSize: number) => void
+}
+
+const defaultPageSizeOptions = [10, 20, 50, 100]
+
+function buildPageTokens(currentPage: number, totalPages: number): PageToken[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const left = Math.max(2, currentPage - 1)
+  const right = Math.min(totalPages - 1, currentPage + 1)
+  const pages = new Set<number>([1, totalPages, left, currentPage, right])
+  const sorted = Array.from(pages).sort((a, b) => a - b)
+
+  const tokens: PageToken[] = []
+  for (let index = 0; index < sorted.length; index += 1) {
+    const value = sorted[index]
+    const previousValue = sorted[index - 1]
+    if (index > 0 && previousValue + 1 < value) {
+      tokens.push('ellipsis')
+    }
+    tokens.push(value)
+  }
+  return tokens
+}
+
+const iconButtonClass =
+  'inline-flex h-9 min-w-9 items-center justify-center rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 text-sm font-semibold text-[hsl(var(--foreground))] transition-colors hover:bg-[hsl(var(--secondary))] disabled:cursor-not-allowed disabled:opacity-50'
+
+const numberButtonClass =
+  'inline-flex h-9 min-w-9 items-center justify-center rounded-md border border-[hsl(var(--border))] px-2 text-sm font-semibold transition-colors'
+
+export function DataPagination({
+  page,
+  pageSize,
+  total,
+  totalPages,
+  pageSizeOptions = defaultPageSizeOptions,
+  allowCustomPageSize = true,
+  onPageChange,
+  onPageSizeChange,
+}: DataPaginationProps) {
+  const [customSize, setCustomSize] = useState(String(pageSize))
+  const pageTokens = useMemo(() => buildPageTokens(page, totalPages), [page, totalPages])
+
+  useEffect(() => {
+    setCustomSize(String(pageSize))
+  }, [pageSize])
+
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1
+  const end = total === 0 ? 0 : Math.min(total, page * pageSize)
+
+  return (
+    <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-[hsl(var(--muted-foreground))]">每頁</span>
+        <div className="flex flex-wrap items-center gap-1">
+          {pageSizeOptions.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={`${numberButtonClass} ${option === pageSize ? 'border-[hsl(var(--primary))] bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]' : 'bg-[hsl(var(--card))] text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))]'}`}
+              onClick={() => {
+                setCustomSize(String(option))
+                onPageSizeChange(option)
+              }}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+        {allowCustomPageSize ? (
+          <div className="ml-1 flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              value={customSize}
+              onChange={(event) => setCustomSize(event.target.value)}
+              className="h-9 w-20 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 text-sm"
+            />
+            <button
+              type="button"
+              className={iconButtonClass}
+              onClick={() => {
+                const next = Number(customSize)
+                if (!Number.isInteger(next) || next <= 0) {
+                  return
+                }
+                onPageSizeChange(next)
+              }}
+            >
+              套用
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-[hsl(var(--muted-foreground))]">
+          {start}-{end} / {total}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className={iconButtonClass}
+            onClick={() => onPageChange(Math.max(1, page - 1))}
+            disabled={page <= 1}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+
+          {pageTokens.map((token, index) =>
+            token === 'ellipsis' ? (
+              <span key={`ellipsis-${index}`} className="inline-flex h-9 min-w-9 items-center justify-center text-[hsl(var(--muted-foreground))]">
+                <MoreHorizontal className="size-4" />
+              </span>
+            ) : (
+              <button
+                key={token}
+                type="button"
+                className={`${numberButtonClass} ${token === page ? 'border-[hsl(var(--primary))] bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]' : 'bg-[hsl(var(--card))] text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))]'}`}
+                onClick={() => onPageChange(token)}
+              >
+                {token}
+              </button>
+            ),
+          )}
+
+          <button
+            type="button"
+            className={iconButtonClass}
+            onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+            disabled={page >= totalPages}
+            aria-label="Next page"
+          >
+            <ChevronRight className="size-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,35 @@
+import { createPortal } from 'react-dom'
+
+import { cn } from '../../lib/utils'
+
+type DialogProps = {
+  open: boolean
+  onClose: () => void
+  title: string
+  description?: string
+  children?: React.ReactNode
+  actions?: React.ReactNode
+}
+
+export function Dialog({ open, onClose, title, description, children, actions }: DialogProps) {
+  if (!open) {
+    return null
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="presentation" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn('w-full max-w-md rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-xl')}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 className="m-0 text-base font-semibold text-[hsl(var(--foreground))]">{title}</h3>
+        {description ? <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">{description}</p> : null}
+        {children ? <div className="mt-4">{children}</div> : null}
+        {actions ? <div className="mt-5 flex justify-end gap-2">{actions}</div> : null}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function DropdownMenu({ className, ...props }: React.ComponentProps<'details'>) {
+  return <details className={cn('relative', className)} {...props} />
+}
+
+export function DropdownMenuTrigger({ className, ...props }: React.ComponentProps<'summary'>) {
+  return (
+    <summary
+      className={cn(
+        'inline-flex h-9 cursor-pointer list-none items-center justify-center rounded-md border border-[hsl(var(--border-strong))] bg-[hsl(var(--card))] px-3 text-sm font-medium text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))]',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function DropdownMenuContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'absolute right-0 z-10 mt-2 min-w-32 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-1 shadow-lg',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function DropdownMenuItem({ className, ...props }: React.ComponentProps<'button'>) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex w-full items-center rounded-sm px-2 py-1.5 text-left text-sm text-[hsl(var(--foreground))] hover:bg-[hsl(var(--secondary))]',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/ui/filter-bar.tsx
+++ b/frontend/src/components/ui/filter-bar.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '../../lib/utils'
+
+type FilterBarProps = {
+  children: ReactNode
+  className?: string
+}
+
+export function FilterBar({ children, className }: FilterBarProps) {
+  return (
+    <div className={cn('mb-4 grid gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] p-3 md:grid-cols-2 xl:grid-cols-4', className)}>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function Input({ className, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      className={cn(
+        'flex h-10 w-full rounded-md border border-[hsl(var(--border-strong))] bg-[hsl(var(--input))] px-3 py-2 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function Label({ className, ...props }: React.ComponentProps<'label'>) {
+  return <label className={cn('text-sm font-medium text-[hsl(var(--foreground))]', className)} {...props} />
+}

--- a/frontend/src/components/ui/page-header.tsx
+++ b/frontend/src/components/ui/page-header.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '../../lib/utils'
+
+type PageHeaderProps = {
+  title: string
+  description: string
+  actions?: ReactNode
+  className?: string
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <header className={cn('mb-4 flex flex-wrap items-start justify-between gap-3', className)}>
+      <div>
+        <h2 className="m-0 text-xl font-semibold tracking-tight text-[hsl(var(--foreground))]">{title}</h2>
+        <p className="mt-1 mb-0 text-sm text-[hsl(var(--muted-foreground))]">{description}</p>
+      </div>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </header>
+  )
+}

--- a/frontend/src/components/ui/section-card.tsx
+++ b/frontend/src/components/ui/section-card.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '../../lib/utils'
+
+type SectionCardProps = {
+  title?: string
+  description?: string
+  children: ReactNode
+  className?: string
+}
+
+export function SectionCard({ title, description, children, className }: SectionCardProps) {
+  return (
+    <section className={cn('rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4 shadow-sm md:p-5', className)}>
+      {title ? (
+        <div className="mb-4">
+          <h3 className="m-0 text-sm font-semibold text-[hsl(var(--foreground))]">{title}</h3>
+          {description ? <p className="mt-1 mb-0 text-sm text-[hsl(var(--muted-foreground))]">{description}</p> : null}
+        </div>
+      ) : null}
+      {children}
+    </section>
+  )
+}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function Select({ className, ...props }: React.ComponentProps<'select'>) {
+  return (
+    <select
+      className={cn(
+        'flex h-10 w-full rounded-md border border-[hsl(var(--border-strong))] bg-[hsl(var(--input))] px-3 py-2 text-sm text-[hsl(var(--foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as SeparatorPrimitive from '@radix-ui/react-separator'
+
+import { cn } from '../../lib/utils'
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator-root"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-[hsl(var(--border))] data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return <table className={cn('w-full caption-bottom text-sm', className)} {...props} />
+}
+
+export function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead className={cn('[&_tr]:border-b', className)} {...props} />
+}
+
+export function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+}
+
+export function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return <tr className={cn('border-b border-[hsl(var(--border))] transition-colors hover:bg-[hsl(var(--secondary))]/50', className)} {...props} />
+}
+
+export function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return <th className={cn('h-10 px-3 text-left align-middle font-semibold text-[hsl(var(--muted-foreground))]', className)} {...props} />
+}
+
+export function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return <td className={cn('px-3 py-2 align-middle', className)} {...props} />
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode, createContext, useContext, useMemo, useState } from 'react'
+
+import { cn } from '../../lib/utils'
+
+type TabsContextType = {
+  activeValue: string
+  setActiveValue: (value: string) => void
+}
+
+const TabsContext = createContext<TabsContextType | null>(null)
+
+function useTabsContext() {
+  const context = useContext(TabsContext)
+  if (!context) {
+    throw new Error('Tabs components must be used within Tabs')
+  }
+  return context
+}
+
+type TabsProps = {
+  defaultValue: string
+  children: ReactNode
+  className?: string
+}
+
+export function Tabs({ defaultValue, children, className }: TabsProps) {
+  const [activeValue, setActiveValue] = useState(defaultValue)
+  const value = useMemo(() => ({ activeValue, setActiveValue }), [activeValue])
+
+  return (
+    <TabsContext.Provider value={value}>
+      <div className={cn('grid gap-4', className)}>{children}</div>
+    </TabsContext.Provider>
+  )
+}
+
+export function TabsList({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('inline-flex w-fit items-center rounded-md bg-[hsl(var(--secondary))] p-1', className)} {...props} />
+}
+
+type TabsTriggerProps = React.ComponentProps<'button'> & {
+  value: string
+}
+
+export function TabsTrigger({ value, className, ...props }: TabsTriggerProps) {
+  const { activeValue, setActiveValue } = useTabsContext()
+  const isActive = activeValue === value
+
+  return (
+    <button
+      type="button"
+      onClick={() => setActiveValue(value)}
+      className={cn(
+        'inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm font-medium transition-colors',
+        isActive
+          ? 'bg-[hsl(var(--card))] text-[hsl(var(--foreground))] shadow-sm'
+          : 'text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+type TabsContentProps = React.ComponentProps<'div'> & {
+  value: string
+}
+
+export function TabsContent({ value, className, ...props }: TabsContentProps) {
+  const { activeValue } = useTabsContext()
+  if (activeValue !== value) {
+    return null
+  }
+
+  return <div className={cn('grid gap-4', className)} {...props} />
+}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+export function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-20 w-full rounded-md border border-[hsl(var(--border-strong))] bg-[hsl(var(--input))] px-3 py-2 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,16 @@
   :root {
     font-family: 'Noto Sans TC', 'Segoe UI', Arial, sans-serif;
     color: #1f2937;
+    --background: 210 40% 98%;
+    --foreground: 222.2 47.4% 11.2%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 47.4% 11.2%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --border: 214.3 31.8% 91.4%;
   }
 
   * {
@@ -11,6 +21,6 @@
   }
 
   body {
-    @apply m-0 min-h-screen bg-gradient-to-b from-[#f0f7ff] to-slate-50;
+    @apply m-0 min-h-screen bg-gradient-to-b from-[#f0f7ff] to-slate-50 text-[hsl(var(--foreground))];
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,18 +3,26 @@
 @layer base {
   :root {
     font-family: "Manrope", "Noto Sans TC", "Segoe UI", sans-serif;
-    --background: 213 42% 97%;
-    --foreground: 223 24% 15%;
+    --background: 215 39% 96%;
+    --foreground: 224 24% 15%;
     --card: 0 0% 100%;
-    --card-foreground: 223 24% 15%;
-    --primary: 216 89% 57%;
+    --card-soft: 216 35% 97%;
+    --card-foreground: 224 24% 15%;
+    --primary: 217 91% 60%;
+    --primary-hover: 217 91% 54%;
     --primary-foreground: 0 0% 100%;
-    --primary-disabled: 216 74% 78%;
-    --secondary: 214 36% 93%;
-    --secondary-foreground: 223 26% 22%;
-    --muted-foreground: 218 16% 43%;
-    --border: 214 27% 87%;
-    --sidebar-background: 214 35% 95%;
+    --primary-disabled: 216 67% 76%;
+    --secondary: 214 32% 92%;
+    --secondary-foreground: 224 22% 22%;
+    --muted-foreground: 219 14% 40%;
+    --border: 215 23% 84%;
+    --border-strong: 215 20% 74%;
+    --input: 0 0% 100%;
+    --ring: 217 91% 60%;
+    --destructive: 0 78% 56%;
+    --destructive-hover: 0 72% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --sidebar-background: 214 34% 95%;
   }
 
   * {
@@ -24,8 +32,8 @@
   body {
     @apply m-0 min-h-screen text-[hsl(var(--foreground))];
     background:
-      radial-gradient(circle at 8% 14%, rgba(59, 130, 246, 0.14), transparent 34%),
-      radial-gradient(circle at 91% 5%, rgba(14, 165, 233, 0.1), transparent 28%),
+      radial-gradient(circle at 10% 15%, rgba(37, 99, 235, 0.14), transparent 32%),
+      radial-gradient(circle at 90% 8%, rgba(2, 132, 199, 0.1), transparent 30%),
       hsl(var(--background));
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,18 +2,19 @@
 
 @layer base {
   :root {
-    font-family: 'Noto Sans TC', 'Segoe UI', Arial, sans-serif;
-    color: #1f2937;
-    --background: 210 40% 98%;
-    --foreground: 222.2 47.4% 11.2%;
+    font-family: "Manrope", "Noto Sans TC", "Segoe UI", sans-serif;
+    --background: 213 42% 97%;
+    --foreground: 223 24% 15%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 47.4% 11.2%;
-    --primary: 217.2 91.2% 59.8%;
+    --card-foreground: 223 24% 15%;
+    --primary: 216 89% 57%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --border: 214.3 31.8% 91.4%;
+    --primary-disabled: 216 74% 78%;
+    --secondary: 214 36% 93%;
+    --secondary-foreground: 223 26% 22%;
+    --muted-foreground: 218 16% 43%;
+    --border: 214 27% 87%;
+    --sidebar-background: 214 35% 95%;
   }
 
   * {
@@ -21,6 +22,10 @@
   }
 
   body {
-    @apply m-0 min-h-screen bg-gradient-to-b from-[#f0f7ff] to-slate-50 text-[hsl(var(--foreground))];
+    @apply m-0 min-h-screen text-[hsl(var(--foreground))];
+    background:
+      radial-gradient(circle at 8% 14%, rgba(59, 130, 246, 0.14), transparent 34%),
+      radial-gradient(circle at 91% 5%, rgba(14, 165, 233, 0.1), transparent 28%),
+      hsl(var(--background));
   }
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- adopt shadcn-style admin layout shell and refresh page structure
- introduce reusable shadcn-style UI primitives and shared tokens
- update dashboard and CRUD/list pages with improved pagination and table presentation
- include related frontend dependency updates and README notes

## Scope
- frontend layout and page refactor for dashboard, inventory, issue, borrow, donation, and upload-related screens
- supporting backend adjustments in `backend/main.py` for compatibility with the refreshed frontend flows

## Testing
- not run in this PR flow