### PR TITLE
feat(backend): transaction consistency for issue/borrow/donation flows (closes #11)

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1039,12 +1039,74 @@ def validate_item_ids_available(
     return True, None
 
 
+def _sum_item_quantities(items: list[dict[str, Any]]) -> dict[int, int]:
+    quantity_map: dict[int, int] = {}
+    for item in items:
+        item_id = _to_int(item.get("item_id"))
+        quantity = _to_int(item.get("quantity"))
+        if item_id <= 0:
+            raise ValueError(f"item_id {item_id} not found")
+        if quantity <= 0:
+            raise ValueError("quantity must be greater than 0")
+        quantity_map[item_id] = quantity_map.get(item_id, 0) + quantity
+    return quantity_map
+
+
+def _active_inventory_rows_map(inventory_rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    return {
+        _to_int(row.get("id")): row
+        for row in inventory_rows
+        if _is_blank(row.get("deleted_at"))
+    }
+
+
+def _set_inventory_status_from_count(row: dict[str, Any], *, depleted_status: str) -> None:
+    count = _to_int(row.get("count"), default=0)
+    row["asset_status"] = depleted_status if count <= 0 else "0"
+    row["updated_at"] = _now_str()
+    row["updated_by"] = "system"
+
+
+def _apply_inventory_request_delta(
+    *,
+    inventory_rows: list[dict[str, Any]],
+    old_quantity_map: dict[int, int],
+    new_quantity_map: dict[int, int],
+    depleted_status: str,
+) -> None:
+    inventory_map = _active_inventory_rows_map(inventory_rows)
+    target_ids = set(old_quantity_map) | set(new_quantity_map)
+    for item_id in target_ids:
+        row = inventory_map.get(item_id)
+        if row is None:
+            raise ValueError(f"item_id {item_id} not found")
+        if _to_str(row.get("asset_status")) == "3" and old_quantity_map.get(item_id, 0) <= 0:
+            raise ValueError(f"item_id {item_id} is already donated")
+
+        current_count = _to_int(row.get("count"), default=0)
+        restored_count = current_count + old_quantity_map.get(item_id, 0)
+        next_count = restored_count - new_quantity_map.get(item_id, 0)
+        if restored_count < 0 or next_count < 0:
+            raise ValueError(f"item_id {item_id} quantity is insufficient")
+
+        row["count"] = str(next_count)
+        _set_inventory_status_from_count(row, depleted_status=depleted_status)
+
 def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
     with _locked_workbook() as wb:
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
+        quantity_map = _sum_item_quantities(items)
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map={},
+            new_quantity_map=quantity_map,
+            depleted_status="1",
+        )
         request_id = _next_id(request_rows)
         request_rows.append(
             {
@@ -1070,6 +1132,7 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
             )
         _write_rows(request_ws, SHEETS["issue_requests"], request_rows)
         _write_rows(item_ws, SHEETS["issue_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -1124,8 +1187,10 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
     with _locked_workbook() as wb:
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
         updated = False
         for row in request_rows:
             if _to_int(row.get("id")) == request_id:
@@ -1143,6 +1208,16 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
         if not updated:
             return False
 
+        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_quantity_map = _sum_item_quantities(old_items)
+        new_quantity_map = _sum_item_quantities(items)
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=old_quantity_map,
+            new_quantity_map=new_quantity_map,
+            depleted_status="1",
+        )
+
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
         for index, item in enumerate(items):
@@ -1157,6 +1232,7 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
             )
         _write_rows(request_ws, SHEETS["issue_requests"], request_rows)
         _write_rows(item_ws, SHEETS["issue_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1165,15 +1241,26 @@ def delete_issue_request(request_id: int) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
         deleted = len(remaining_requests) != len(request_rows)
         if not deleted:
             return False
+        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_quantity_map = _sum_item_quantities(old_items)
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=old_quantity_map,
+            new_quantity_map={},
+            depleted_status="1",
+        )
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["issue_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["issue_items"], remaining_items)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1187,17 +1274,22 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
 
-        selected_item_ids = [_to_int(item.get("item_id")) for item in items]
-        if len(selected_item_ids) != len(set(selected_item_ids)):
+        quantity_map = _sum_item_quantities(items)
+        if len(quantity_map) != len(items):
             raise ValueError("item_id cannot be duplicated")
 
-        inventory_map = {_to_int(row.get("id")): row for row in inventory_rows if _is_blank(row.get("deleted_at"))}
-        for item_id in selected_item_ids:
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        for item_id, requested_quantity in quantity_map.items():
             row = inventory_map.get(item_id)
             if row is None:
                 raise ValueError(f"item_id {item_id} not found")
             if _to_str(row.get("asset_status")) == "3":
                 raise ValueError(f"item_id {item_id} is already donated")
+            current_count = _to_int(row.get("count"), default=0)
+            if current_count <= 0:
+                raise ValueError(f"item_id {item_id} quantity is insufficient")
+            if requested_quantity != current_count:
+                raise ValueError(f"item_id {item_id} donation quantity must equal available count")
 
         request_id = _next_id(request_rows)
         request_rows.append(
@@ -1225,13 +1317,12 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
                 }
             )
 
-        marked_item_ids = set(selected_item_ids)
-        now = _now_str()
-        for row in inventory_rows:
-            if _to_int(row.get("id")) in marked_item_ids and _is_blank(row.get("deleted_at")):
-                row["asset_status"] = "3"
-                row["updated_at"] = now
-                row["updated_by"] = "system"
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map={},
+            new_quantity_map=quantity_map,
+            depleted_status="3",
+        )
 
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
@@ -1303,37 +1394,29 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
         if request_row is None:
             return False
 
-        selected_item_ids = [_to_int(item.get("item_id")) for item in items]
-        if len(selected_item_ids) != len(set(selected_item_ids)):
+        new_quantity_map = _sum_item_quantities(items)
+        if len(new_quantity_map) != len(items):
             raise ValueError("item_id cannot be duplicated")
+        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_quantity_map = _sum_item_quantities(old_items)
 
-        inventory_map = {_to_int(row.get("id")): row for row in inventory_rows if _is_blank(row.get("deleted_at"))}
-        for item_id in selected_item_ids:
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        donation_request_map = {
+            _to_int(row.get("item_id")): _to_int(row.get("request_id"))
+            for row in item_rows
+        }
+        for item_id, requested_quantity in new_quantity_map.items():
             row = inventory_map.get(item_id)
             if row is None:
                 raise ValueError(f"item_id {item_id} not found")
-            donation_request_id = 0
-            for donation_row in item_rows:
-                if _to_int(donation_row.get("item_id")) == item_id:
-                    donation_request_id = _to_int(donation_row.get("request_id"))
-                    break
-            if _to_str(row.get("asset_status")) != "3" and donation_request_id == 0:
-                continue
-            if donation_request_id != request_id:
+            donated_request_id = donation_request_map.get(item_id, 0)
+            if donated_request_id not in (0, request_id):
                 raise ValueError(f"item_id {item_id} is already donated")
-
-        old_item_ids = {
-            _to_int(row.get("item_id"))
-            for row in item_rows
-            if _to_int(row.get("request_id")) == request_id
-        }
-        for row in inventory_rows:
-            item_id = _to_int(row.get("id"))
-            if item_id not in old_item_ids or not _is_blank(row.get("deleted_at")):
-                continue
-            row["asset_status"] = "0"
-            row["updated_at"] = _now_str()
-            row["updated_by"] = "system"
+            restored_count = _to_int(row.get("count"), default=0) + old_quantity_map.get(item_id, 0)
+            if restored_count <= 0:
+                raise ValueError(f"item_id {item_id} quantity is insufficient")
+            if requested_quantity != restored_count:
+                raise ValueError(f"item_id {item_id} donation quantity must equal available count")
 
         request_row.update(
             {
@@ -1359,13 +1442,12 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
                 }
             )
 
-        now = _now_str()
-        marked_item_ids = set(selected_item_ids)
-        for row in inventory_rows:
-            if _to_int(row.get("id")) in marked_item_ids and _is_blank(row.get("deleted_at")):
-                row["asset_status"] = "3"
-                row["updated_at"] = now
-                row["updated_by"] = "system"
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=old_quantity_map,
+            new_quantity_map=new_quantity_map,
+            depleted_status="3",
+        )
 
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
@@ -1388,19 +1470,15 @@ def delete_donation_request(request_id: int) -> bool:
         if not deleted:
             return False
 
-        removed_item_ids = {
-            _to_int(row.get("item_id"))
-            for row in item_rows
-            if _to_int(row.get("request_id")) == request_id
-        }
+        removed_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        removed_quantity_map = _sum_item_quantities(removed_items)
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
-
-        for row in inventory_rows:
-            if _to_int(row.get("id")) not in removed_item_ids:
-                continue
-            row["asset_status"] = "0"
-            row["updated_at"] = _now_str()
-            row["updated_by"] = "system"
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=removed_quantity_map,
+            new_quantity_map={},
+            depleted_status="3",
+        )
 
         _write_rows(request_ws, SHEETS["donation_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["donation_items"], remaining_items)
@@ -1409,12 +1487,26 @@ def delete_donation_request(request_id: int) -> bool:
         return True
 
 
+def _borrow_status_uses_inventory(status: Any) -> bool:
+    normalized = _to_str(status).strip().lower()
+    return normalized in {"borrowed", "overdue"}
+
+
 def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
+        new_quantity_map = _sum_item_quantities(items) if _borrow_status_uses_inventory(request_data.get("status")) else {}
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map={},
+            new_quantity_map=new_quantity_map,
+            depleted_status="2",
+        )
         request_id = _next_id(request_rows)
         request_rows.append(
             {
@@ -1443,6 +1535,7 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
             )
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
         _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -1497,11 +1590,15 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
         updated = False
+        previous_status = ""
         for row in request_rows:
             if _to_int(row.get("id")) == request_id:
+                previous_status = _to_str(row.get("status"))
                 row.update(
                     {
                         "borrower": request_data["borrower"],
@@ -1519,6 +1616,16 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
         if not updated:
             return False
 
+        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_quantity_map = _sum_item_quantities(old_items) if _borrow_status_uses_inventory(previous_status) else {}
+        new_quantity_map = _sum_item_quantities(items) if _borrow_status_uses_inventory(request_data.get("status")) else {}
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=old_quantity_map,
+            new_quantity_map=new_quantity_map,
+            depleted_status="2",
+        )
+
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
         for index, item in enumerate(items):
@@ -1533,6 +1640,7 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
             )
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
         _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1541,15 +1649,31 @@ def delete_borrow_request(request_id: int) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
+        inventory_ws = wb["inventory_items"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        inventory_rows = _read_rows(inventory_ws)
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
         deleted = len(remaining_requests) != len(request_rows)
         if not deleted:
             return False
+        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_quantity_map = (
+            _sum_item_quantities(old_items)
+            if request_row is not None and _borrow_status_uses_inventory(request_row.get("status"))
+            else {}
+        )
+        _apply_inventory_request_delta(
+            inventory_rows=inventory_rows,
+            old_quantity_map=old_quantity_map,
+            new_quantity_map={},
+            depleted_status="2",
+        )
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["borrow_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["borrow_items"], remaining_items)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         wb.save(DB_PATH)
         return True
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -330,9 +330,7 @@ def _to_inventory_create_row(new_id: int, item_data: dict[str, Any], property_nu
     serial_for_key = _inventory_property_number(row_for_key)
     name_code, name_code2 = _normalize_name_codes(item_data.get("name_code"), item_data.get("name_code2"))
     now = _now_str()
-    count = _to_int(item_data.get("count"), default=1)
-    if count <= 0:
-        count = 1
+    count = 1
     row = {
         "id": new_id,
         "asset_type": asset_type,
@@ -871,9 +869,7 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
                 item_sn = _to_str(item_data.get("item_sn")).strip()
                 property_number = n_property_sn or property_sn or n_item_sn or item_sn
                 name_code, name_code2 = _normalize_name_codes(item_data.get("name_code"), item_data.get("name_code2"))
-                count = _to_int(item_data.get("count"), default=1)
-                if count <= 0:
-                    count = 1
+                count = 1
                 next_key = _to_str(item_data.get("key")).strip()
                 if not next_key:
                     tmp_row = {
@@ -1039,17 +1035,21 @@ def validate_item_ids_available(
     return True, None
 
 
-def _sum_item_quantities(items: list[dict[str, Any]]) -> dict[int, int]:
-    quantity_map: dict[int, int] = {}
+def _normalize_request_item_ids(items: list[dict[str, Any]]) -> list[int]:
+    item_ids: list[int] = []
+    seen: set[int] = set()
     for item in items:
         item_id = _to_int(item.get("item_id"))
         quantity = _to_int(item.get("quantity"))
         if item_id <= 0:
             raise ValueError(f"item_id {item_id} not found")
-        if quantity <= 0:
-            raise ValueError("quantity must be greater than 0")
-        quantity_map[item_id] = quantity_map.get(item_id, 0) + quantity
-    return quantity_map
+        if quantity != 1:
+            raise ValueError("quantity must be 1 in single-item mode")
+        if item_id in seen:
+            raise ValueError("item_id cannot be duplicated")
+        seen.add(item_id)
+        item_ids.append(item_id)
+    return item_ids
 
 
 def _active_inventory_rows_map(inventory_rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
@@ -1060,37 +1060,25 @@ def _active_inventory_rows_map(inventory_rows: list[dict[str, Any]]) -> dict[int
     }
 
 
-def _set_inventory_status_from_count(row: dict[str, Any], *, depleted_status: str) -> None:
-    count = _to_int(row.get("count"), default=0)
-    row["asset_status"] = depleted_status if count <= 0 else "0"
+def _set_inventory_status(row: dict[str, Any], status: str) -> None:
+    row["asset_status"] = status
     row["updated_at"] = _now_str()
     row["updated_by"] = "system"
 
 
-def _apply_inventory_request_delta(
+def _validate_item_status(
     *,
-    inventory_rows: list[dict[str, Any]],
-    old_quantity_map: dict[int, int],
-    new_quantity_map: dict[int, int],
-    depleted_status: str,
-) -> None:
-    inventory_map = _active_inventory_rows_map(inventory_rows)
-    target_ids = set(old_quantity_map) | set(new_quantity_map)
-    for item_id in target_ids:
-        row = inventory_map.get(item_id)
-        if row is None:
-            raise ValueError(f"item_id {item_id} not found")
-        if _to_str(row.get("asset_status")) == "3" and old_quantity_map.get(item_id, 0) <= 0:
-            raise ValueError(f"item_id {item_id} is already donated")
-
-        current_count = _to_int(row.get("count"), default=0)
-        restored_count = current_count + old_quantity_map.get(item_id, 0)
-        next_count = restored_count - new_quantity_map.get(item_id, 0)
-        if restored_count < 0 or next_count < 0:
-            raise ValueError(f"item_id {item_id} quantity is insufficient")
-
-        row["count"] = str(next_count)
-        _set_inventory_status_from_count(row, depleted_status=depleted_status)
+    inventory_map: dict[int, dict[str, Any]],
+    item_id: int,
+    allowed_statuses: set[str],
+) -> dict[str, Any]:
+    row = inventory_map.get(item_id)
+    if row is None:
+        raise ValueError(f"item_id {item_id} not found")
+    status = _to_str(row.get("asset_status")).strip()
+    if status not in allowed_statuses:
+        raise ValueError(f"item_id {item_id} is unavailable")
+    return row
 
 def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
     with _locked_workbook() as wb:
@@ -1100,13 +1088,11 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
-        quantity_map = _sum_item_quantities(items)
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map={},
-            new_quantity_map=quantity_map,
-            depleted_status="1",
-        )
+        selected_item_ids = _normalize_request_item_ids(items)
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        for item_id in selected_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            _set_inventory_status(row, "1")
         request_id = _next_id(request_rows)
         request_rows.append(
             {
@@ -1126,7 +1112,7 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
@@ -1209,14 +1195,19 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
             return False
 
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_quantity_map = _sum_item_quantities(old_items)
-        new_quantity_map = _sum_item_quantities(items)
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=old_quantity_map,
-            new_quantity_map=new_quantity_map,
-            depleted_status="1",
-        )
+        old_item_ids = {_to_int(row.get("item_id")) for row in old_items}
+        new_item_ids = set(_normalize_request_item_ids(items))
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+
+        for item_id in new_item_ids - old_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            _set_inventory_status(row, "1")
+        for item_id in new_item_ids & old_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0", "1"})
+            _set_inventory_status(row, "1")
+        for item_id in old_item_ids - new_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"1"})
+            _set_inventory_status(row, "0")
 
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
@@ -1226,7 +1217,7 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
@@ -1250,13 +1241,11 @@ def delete_issue_request(request_id: int) -> bool:
         if not deleted:
             return False
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_quantity_map = _sum_item_quantities(old_items)
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=old_quantity_map,
-            new_quantity_map={},
-            depleted_status="1",
-        )
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        for old_item in old_items:
+            item_id = _to_int(old_item.get("item_id"))
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"1"})
+            _set_inventory_status(row, "0")
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["issue_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["issue_items"], remaining_items)
@@ -1274,22 +1263,11 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
 
-        quantity_map = _sum_item_quantities(items)
-        if len(quantity_map) != len(items):
-            raise ValueError("item_id cannot be duplicated")
-
+        selected_item_ids = _normalize_request_item_ids(items)
         inventory_map = _active_inventory_rows_map(inventory_rows)
-        for item_id, requested_quantity in quantity_map.items():
-            row = inventory_map.get(item_id)
-            if row is None:
-                raise ValueError(f"item_id {item_id} not found")
-            if _to_str(row.get("asset_status")) == "3":
-                raise ValueError(f"item_id {item_id} is already donated")
-            current_count = _to_int(row.get("count"), default=0)
-            if current_count <= 0:
-                raise ValueError(f"item_id {item_id} quantity is insufficient")
-            if requested_quantity != current_count:
-                raise ValueError(f"item_id {item_id} donation quantity must equal available count")
+        for item_id in selected_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            _set_inventory_status(row, "3")
 
         request_id = _next_id(request_rows)
         request_rows.append(
@@ -1312,17 +1290,10 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
-
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map={},
-            new_quantity_map=quantity_map,
-            depleted_status="3",
-        )
 
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
@@ -1394,29 +1365,20 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
         if request_row is None:
             return False
 
-        new_quantity_map = _sum_item_quantities(items)
-        if len(new_quantity_map) != len(items):
-            raise ValueError("item_id cannot be duplicated")
+        new_item_ids = set(_normalize_request_item_ids(items))
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_quantity_map = _sum_item_quantities(old_items)
+        old_item_ids = {_to_int(row.get("item_id")) for row in old_items}
 
         inventory_map = _active_inventory_rows_map(inventory_rows)
-        donation_request_map = {
-            _to_int(row.get("item_id")): _to_int(row.get("request_id"))
-            for row in item_rows
-        }
-        for item_id, requested_quantity in new_quantity_map.items():
-            row = inventory_map.get(item_id)
-            if row is None:
-                raise ValueError(f"item_id {item_id} not found")
-            donated_request_id = donation_request_map.get(item_id, 0)
-            if donated_request_id not in (0, request_id):
-                raise ValueError(f"item_id {item_id} is already donated")
-            restored_count = _to_int(row.get("count"), default=0) + old_quantity_map.get(item_id, 0)
-            if restored_count <= 0:
-                raise ValueError(f"item_id {item_id} quantity is insufficient")
-            if requested_quantity != restored_count:
-                raise ValueError(f"item_id {item_id} donation quantity must equal available count")
+        for item_id in new_item_ids - old_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            _set_inventory_status(row, "3")
+        for item_id in new_item_ids & old_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0", "3"})
+            _set_inventory_status(row, "3")
+        for item_id in old_item_ids - new_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"3"})
+            _set_inventory_status(row, "0")
 
         request_row.update(
             {
@@ -1437,17 +1399,10 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
-
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=old_quantity_map,
-            new_quantity_map=new_quantity_map,
-            depleted_status="3",
-        )
 
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
@@ -1471,14 +1426,12 @@ def delete_donation_request(request_id: int) -> bool:
             return False
 
         removed_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        removed_quantity_map = _sum_item_quantities(removed_items)
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=removed_quantity_map,
-            new_quantity_map={},
-            depleted_status="3",
-        )
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        for removed_item in removed_items:
+            item_id = _to_int(removed_item.get("item_id"))
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"3"})
+            _set_inventory_status(row, "0")
 
         _write_rows(request_ws, SHEETS["donation_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["donation_items"], remaining_items)
@@ -1500,13 +1453,12 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
-        new_quantity_map = _sum_item_quantities(items) if _borrow_status_uses_inventory(request_data.get("status")) else {}
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map={},
-            new_quantity_map=new_quantity_map,
-            depleted_status="2",
-        )
+        selected_item_ids = _normalize_request_item_ids(items)
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        for item_id in selected_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            if _borrow_status_uses_inventory(request_data.get("status")):
+                _set_inventory_status(row, "2")
         request_id = _next_id(request_rows)
         request_rows.append(
             {
@@ -1529,7 +1481,7 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
@@ -1617,14 +1569,27 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
             return False
 
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_quantity_map = _sum_item_quantities(old_items) if _borrow_status_uses_inventory(previous_status) else {}
-        new_quantity_map = _sum_item_quantities(items) if _borrow_status_uses_inventory(request_data.get("status")) else {}
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=old_quantity_map,
-            new_quantity_map=new_quantity_map,
-            depleted_status="2",
-        )
+        old_item_ids = {_to_int(row.get("item_id")) for row in old_items}
+        new_item_ids = set(_normalize_request_item_ids(items))
+        old_active_ids = old_item_ids if _borrow_status_uses_inventory(previous_status) else set()
+        new_active_ids = new_item_ids if _borrow_status_uses_inventory(request_data.get("status")) else set()
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+
+        for item_id in new_item_ids - old_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+            if item_id in new_active_ids:
+                _set_inventory_status(row, "2")
+        for item_id in new_item_ids & old_item_ids:
+            allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
+            if item_id in new_active_ids:
+                _set_inventory_status(row, "2")
+            else:
+                _set_inventory_status(row, "0")
+        for item_id in old_item_ids - new_item_ids:
+            allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
+            _set_inventory_status(row, "0")
 
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
@@ -1634,7 +1599,7 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
                     "id": next_item_id + index,
                     "request_id": request_id,
                     "item_id": item["item_id"],
-                    "quantity": item["quantity"],
+                    "quantity": 1,
                     "note": item.get("note", ""),
                 }
             )
@@ -1659,17 +1624,12 @@ def delete_borrow_request(request_id: int) -> bool:
             return False
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_quantity_map = (
-            _sum_item_quantities(old_items)
-            if request_row is not None and _borrow_status_uses_inventory(request_row.get("status"))
-            else {}
-        )
-        _apply_inventory_request_delta(
-            inventory_rows=inventory_rows,
-            old_quantity_map=old_quantity_map,
-            new_quantity_map={},
-            depleted_status="2",
-        )
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        if request_row is not None and _borrow_status_uses_inventory(request_row.get("status")):
+            for old_item in old_items:
+                item_id = _to_int(old_item.get("item_id"))
+                row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"2"})
+                _set_inventory_status(row, "0")
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["borrow_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["borrow_items"], remaining_items)

--- a/backend/main.py
+++ b/backend/main.py
@@ -790,9 +790,8 @@ def create_issue_request_api(request: IssueRequestCreate, background_tasks: Back
     if not request.items:
         raise HTTPException(status_code=400, detail="items is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids([item.item_id for item in request.items])
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         request_id = create_issue_request(issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
     except ValueError as exc:
@@ -819,9 +818,8 @@ def update_issue_request_api(request_id: int, request: IssueRequestCreate, backg
     if not request.items:
         raise HTTPException(status_code=400, detail="items is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids([item.item_id for item in request.items])
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         updated = update_issue_request(request_id, issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
     except ValueError as exc:
@@ -926,9 +924,8 @@ def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: Ba
     if not request.items:
         raise HTTPException(status_code=400, detail="items is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids([item.item_id for item in request.items])
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         request_id = create_borrow_request(borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
     except ValueError as exc:
@@ -955,9 +952,8 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
     if not request.items:
         raise HTTPException(status_code=400, detail="items is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids([item.item_id for item in request.items])
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         updated = update_borrow_request(request_id, borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
     except ValueError as exc:
@@ -1062,9 +1058,8 @@ def create_donation_request_api(request: DonationRequestCreate):
     if not request.recipient.strip():
         raise HTTPException(status_code=400, detail="recipient is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids([item.item_id for item in request.items], enforce_unique=True)
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         request_id = create_donation_request(
             donation_request_to_db_payload(request),
@@ -1095,13 +1090,8 @@ def update_donation_request_api(request_id: int, request: DonationRequestCreate)
     if not request.recipient.strip():
         raise HTTPException(status_code=400, detail="recipient is required")
     for item in request.items:
-        if item.quantity <= 0:
-            raise HTTPException(status_code=400, detail="quantity must be greater than 0")
-    _ensure_available_item_ids(
-        [item.item_id for item in request.items],
-        allow_donation_request_id=request_id,
-        enforce_unique=True,
-    )
+        if item.quantity != 1:
+            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
     try:
         updated = update_donation_request(
             request_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -793,7 +793,10 @@ def create_issue_request_api(request: IssueRequestCreate, background_tasks: Back
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
     _ensure_available_item_ids([item.item_id for item in request.items])
-    request_id = create_issue_request(issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    try:
+        request_id = create_issue_request(issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     row = get_issue_request(request_id)
     if row is None:
         log_inventory_action(
@@ -819,7 +822,10 @@ def update_issue_request_api(request_id: int, request: IssueRequestCreate, backg
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
     _ensure_available_item_ids([item.item_id for item in request.items])
-    updated = update_issue_request(request_id, issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    try:
+        updated = update_issue_request(request_id, issue_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not updated:
         log_inventory_action(
             action="update",
@@ -848,7 +854,10 @@ def update_issue_request_api(request_id: int, request: IssueRequestCreate, backg
 
 @app.delete("/api/issues/{request_id}")
 def delete_issue_request_api(request_id: int, background_tasks: BackgroundTasks):
-    deleted = delete_issue_request(request_id)
+    try:
+        deleted = delete_issue_request(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not deleted:
         log_inventory_action(
             action="delete",
@@ -920,7 +929,10 @@ def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: Ba
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
     _ensure_available_item_ids([item.item_id for item in request.items])
-    request_id = create_borrow_request(borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    try:
+        request_id = create_borrow_request(borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     row = get_borrow_request(request_id)
     if row is None:
         log_inventory_action(
@@ -946,7 +958,10 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="quantity must be greater than 0")
     _ensure_available_item_ids([item.item_id for item in request.items])
-    updated = update_borrow_request(request_id, borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    try:
+        updated = update_borrow_request(request_id, borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not updated:
         log_inventory_action(
             action="update",
@@ -975,7 +990,10 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
 
 @app.delete("/api/borrows/{request_id}")
 def delete_borrow_request_api(request_id: int, background_tasks: BackgroundTasks):
-    deleted = delete_borrow_request(request_id)
+    try:
+        deleted = delete_borrow_request(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not deleted:
         log_inventory_action(
             action="delete",
@@ -1119,7 +1137,10 @@ def update_donation_request_api(request_id: int, request: DonationRequestCreate)
 
 @app.delete("/api/donations/{request_id}")
 def delete_donation_request_api(request_id: int):
-    deleted = delete_donation_request(request_id)
+    try:
+        deleted = delete_donation_request(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not deleted:
         log_inventory_action(
             action="delete",

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -20,11 +20,11 @@ class TransactionConsistencyTests(unittest.TestCase):
         db.LOCK_PATH = self._original_lock_path
         self._tmpdir.cleanup()
 
-    def _create_item(self, *, count: int) -> int:
+    def _create_item(self, *, asset_status: str = "0", count: int = 1) -> int:
         return db.create_item(
             {
                 "asset_type": "A1",
-                "asset_status": "0",
+                "asset_status": asset_status,
                 "name": "測試品項",
                 "model": "M1",
                 "count": count,
@@ -62,87 +62,70 @@ class TransactionConsistencyTests(unittest.TestCase):
             "memo": "",
         }
 
-    def test_issue_request_updates_inventory_and_reverts_on_delete(self) -> None:
+    def test_quantity_must_be_one(self) -> None:
+        item_id = self._create_item()
+        with self.assertRaisesRegex(ValueError, "quantity must be 1"):
+            db.create_issue_request(
+                self._issue_payload(),
+                [{"item_id": item_id, "quantity": 2, "note": ""}],
+            )
+
+    def test_issue_request_updates_status_only(self) -> None:
         item_id = self._create_item(count=5)
 
         request_id = db.create_issue_request(
             self._issue_payload(),
-            [{"item_id": item_id, "quantity": 3, "note": ""}],
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
         )
         item_after_create = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_create)
-        self.assertEqual(item_after_create["count"], 2)
-        self.assertEqual(item_after_create["asset_status"], "0")
-
-        db.update_issue_request(
-            request_id,
-            self._issue_payload(),
-            [{"item_id": item_id, "quantity": 5, "note": ""}],
-        )
-        item_after_update = db.get_item_by_id(item_id)
-        self.assertIsNotNone(item_after_update)
-        self.assertEqual(item_after_update["count"], 0)
-        self.assertEqual(item_after_update["asset_status"], "1")
+        self.assertEqual(item_after_create["count"], 1)
+        self.assertEqual(item_after_create["asset_status"], "1")
 
         db.delete_issue_request(request_id)
         item_after_delete = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_delete)
-        self.assertEqual(item_after_delete["count"], 5)
+        self.assertEqual(item_after_delete["count"], 1)
         self.assertEqual(item_after_delete["asset_status"], "0")
 
-    def test_issue_request_rejects_overdraw(self) -> None:
-        item_id = self._create_item(count=2)
-
-        with self.assertRaisesRegex(ValueError, "quantity is insufficient"):
-            db.create_issue_request(
-                self._issue_payload(),
-                [{"item_id": item_id, "quantity": 3, "note": ""}],
-            )
-
-    def test_borrow_return_flow_updates_inventory(self) -> None:
-        item_id = self._create_item(count=2)
+    def test_borrow_return_flow_updates_status_only(self) -> None:
+        item_id = self._create_item()
 
         request_id = db.create_borrow_request(
             self._borrow_payload(status="borrowed"),
-            [{"item_id": item_id, "quantity": 2, "note": ""}],
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
         )
         item_after_borrow = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_borrow)
-        self.assertEqual(item_after_borrow["count"], 0)
+        self.assertEqual(item_after_borrow["count"], 1)
         self.assertEqual(item_after_borrow["asset_status"], "2")
 
         db.update_borrow_request(
             request_id,
             self._borrow_payload(status="returned"),
-            [{"item_id": item_id, "quantity": 2, "note": ""}],
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
         )
         item_after_return = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_return)
-        self.assertEqual(item_after_return["count"], 2)
+        self.assertEqual(item_after_return["count"], 1)
         self.assertEqual(item_after_return["asset_status"], "0")
 
-    def test_donation_requires_full_available_count_and_reverts_on_delete(self) -> None:
-        item_id = self._create_item(count=3)
-
-        with self.assertRaisesRegex(ValueError, "donation quantity must equal available count"):
-            db.create_donation_request(
-                self._donation_payload(),
-                [{"item_id": item_id, "quantity": 2, "note": ""}],
-            )
+    def test_donation_sets_status_and_reverts_on_delete(self) -> None:
+        item_id = self._create_item()
 
         request_id = db.create_donation_request(
             self._donation_payload(),
-            [{"item_id": item_id, "quantity": 3, "note": ""}],
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
         )
         item_after_create = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_create)
-        self.assertEqual(item_after_create["count"], 0)
+        self.assertEqual(item_after_create["count"], 1)
         self.assertEqual(item_after_create["asset_status"], "3")
 
         db.delete_donation_request(request_id)
         item_after_delete = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_delete)
-        self.assertEqual(item_after_delete["count"], 3)
+        self.assertEqual(item_after_delete["count"], 1)
         self.assertEqual(item_after_delete["asset_status"], "0")
 
 

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -1,0 +1,150 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import db
+
+
+class TransactionConsistencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        self._tmpdir.cleanup()
+
+    def _create_item(self, *, count: int) -> int:
+        return db.create_item(
+            {
+                "asset_type": "A1",
+                "asset_status": "0",
+                "name": "測試品項",
+                "model": "M1",
+                "count": count,
+            }
+        )
+
+    def _issue_payload(self) -> dict:
+        return {
+            "requester": "tester",
+            "department": "qa",
+            "purpose": "test",
+            "request_date": "2026-04-10",
+            "memo": "",
+        }
+
+    def _borrow_payload(self, *, status: str) -> dict:
+        return {
+            "borrower": "tester",
+            "department": "qa",
+            "purpose": "test",
+            "borrow_date": "2026-04-10",
+            "due_date": "2026-04-20",
+            "return_date": "",
+            "status": status,
+            "memo": "",
+        }
+
+    def _donation_payload(self) -> dict:
+        return {
+            "donor": "tester",
+            "department": "qa",
+            "recipient": "receiver",
+            "purpose": "test",
+            "donation_date": "2026-04-10",
+            "memo": "",
+        }
+
+    def test_issue_request_updates_inventory_and_reverts_on_delete(self) -> None:
+        item_id = self._create_item(count=5)
+
+        request_id = db.create_issue_request(
+            self._issue_payload(),
+            [{"item_id": item_id, "quantity": 3, "note": ""}],
+        )
+        item_after_create = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_create)
+        self.assertEqual(item_after_create["count"], 2)
+        self.assertEqual(item_after_create["asset_status"], "0")
+
+        db.update_issue_request(
+            request_id,
+            self._issue_payload(),
+            [{"item_id": item_id, "quantity": 5, "note": ""}],
+        )
+        item_after_update = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_update)
+        self.assertEqual(item_after_update["count"], 0)
+        self.assertEqual(item_after_update["asset_status"], "1")
+
+        db.delete_issue_request(request_id)
+        item_after_delete = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_delete)
+        self.assertEqual(item_after_delete["count"], 5)
+        self.assertEqual(item_after_delete["asset_status"], "0")
+
+    def test_issue_request_rejects_overdraw(self) -> None:
+        item_id = self._create_item(count=2)
+
+        with self.assertRaisesRegex(ValueError, "quantity is insufficient"):
+            db.create_issue_request(
+                self._issue_payload(),
+                [{"item_id": item_id, "quantity": 3, "note": ""}],
+            )
+
+    def test_borrow_return_flow_updates_inventory(self) -> None:
+        item_id = self._create_item(count=2)
+
+        request_id = db.create_borrow_request(
+            self._borrow_payload(status="borrowed"),
+            [{"item_id": item_id, "quantity": 2, "note": ""}],
+        )
+        item_after_borrow = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_borrow)
+        self.assertEqual(item_after_borrow["count"], 0)
+        self.assertEqual(item_after_borrow["asset_status"], "2")
+
+        db.update_borrow_request(
+            request_id,
+            self._borrow_payload(status="returned"),
+            [{"item_id": item_id, "quantity": 2, "note": ""}],
+        )
+        item_after_return = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_return)
+        self.assertEqual(item_after_return["count"], 2)
+        self.assertEqual(item_after_return["asset_status"], "0")
+
+    def test_donation_requires_full_available_count_and_reverts_on_delete(self) -> None:
+        item_id = self._create_item(count=3)
+
+        with self.assertRaisesRegex(ValueError, "donation quantity must equal available count"):
+            db.create_donation_request(
+                self._donation_payload(),
+                [{"item_id": item_id, "quantity": 2, "note": ""}],
+            )
+
+        request_id = db.create_donation_request(
+            self._donation_payload(),
+            [{"item_id": item_id, "quantity": 3, "note": ""}],
+        )
+        item_after_create = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_create)
+        self.assertEqual(item_after_create["count"], 0)
+        self.assertEqual(item_after_create["asset_status"], "3")
+
+        db.delete_donation_request(request_id)
+        item_after_delete = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_delete)
+        self.assertEqual(item_after_delete["count"], 3)
+        self.assertEqual(item_after_delete["asset_status"], "0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -8,7 +8,6 @@ import { Button } from '../ui/button'
 import { FilterBar } from '../ui/filter-bar'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
@@ -112,18 +111,14 @@ export function BorrowListPage() {
 
   return (
     <>
-      <PageHeader
-        title="借用清單"
-        description="追蹤借出、歸還與逾期狀態。"
-        actions={
-          <Link to="/borrows/new">
-            <Button>
-              <Plus className="size-4" />
-              新增借用
-            </Button>
-          </Link>
-        }
-      />
+      <div className="flex justify-end">
+        <Link to="/borrows/new">
+          <Button>
+            <Plus className="size-4" />
+            新增借用
+          </Button>
+        </Link>
+      </div>
 
       <SectionCard>
         <FilterBar className="xl:grid-cols-[2fr_1fr_1fr]">

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -4,7 +4,6 @@ import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
@@ -179,13 +178,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   }
 
   return (
-    <>
-      <PageHeader
-        title={isEditing ? '編輯借用單' : '新增借用單'}
-        description="建立借用紀錄並追蹤歸還狀態。"
-      />
-
-      <div className="grid gap-4">
+    <div className="grid gap-4">
         <SectionCard title="基本資料">
           <div className="grid gap-3 md:grid-cols-2">
             <div className="grid gap-1.5">
@@ -279,6 +272,5 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
         </SectionCard>
       </div>
-    </>
   )
 }

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -117,14 +117,14 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     if (lines.length === 0) {
       return false
     }
-    return lines.every((line) => line.item_id !== '' && line.quantity > 0)
+    return lines.every((line) => line.item_id !== '' && line.quantity === 1)
   }
 
   const normalizeDate = (value: string) => (value ? value : null)
 
   const handleSubmit = async () => {
     if (!validateLines()) {
-      void toast.fire({ icon: 'error', title: '請確認每筆借用品項已選擇品項且數量大於 0。' })
+      void toast.fire({ icon: 'error', title: '單件模式下，每筆借用品項數量必須為 1。' })
       return
     }
 
@@ -146,7 +146,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           memo,
           items: lines.map((line) => ({
             item_id: line.item_id,
-            quantity: line.quantity,
+            quantity: 1,
             note: line.note,
           })),
         }),
@@ -250,8 +250,9 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                   <Input
                     type="number"
                     min={1}
-                    value={line.quantity}
-                    onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
+                    max={1}
+                    value={1}
+                    disabled
                   />
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/DonationListPage.tsx
+++ b/frontend/src/components/pages/DonationListPage.tsx
@@ -7,7 +7,6 @@ import { Button } from '../ui/button'
 import { FilterBar } from '../ui/filter-bar'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import type { DonationRequest, PaginatedResponse } from './types'
@@ -92,18 +91,14 @@ export function DonationListPage() {
 
   return (
     <>
-      <PageHeader
-        title="捐贈清單"
-        description="查詢捐贈交易與受贈流向。"
-        actions={
-          <Link to="/donations/new">
-            <Button>
-              <Plus className="size-4" />
-              新增捐贈
-            </Button>
-          </Link>
-        }
-      />
+      <div className="flex justify-end">
+        <Link to="/donations/new">
+          <Button>
+            <Plus className="size-4" />
+            新增捐贈
+          </Button>
+        </Link>
+      </div>
 
       <SectionCard>
         <FilterBar className="xl:grid-cols-[2fr_1fr]">

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -121,7 +121,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
     if (lines.length === 0) {
       return false
     }
-    return lines.every((line) => line.item_id !== '' && line.quantity > 0)
+    return lines.every((line) => line.item_id !== '' && line.quantity === 1)
   }
 
   const handleSubmit = async () => {
@@ -130,7 +130,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
       return
     }
     if (!validateLines()) {
-      void toast.fire({ icon: 'error', title: '請確認每筆捐贈品項已選擇品項且數量大於 0。' })
+      void toast.fire({ icon: 'error', title: '單件模式下，每筆捐贈品項數量必須為 1。' })
       return
     }
 
@@ -150,7 +150,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
           memo,
           items: lines.map((line) => ({
             item_id: line.item_id,
-            quantity: line.quantity,
+            quantity: 1,
             note: line.note,
           })),
         }),
@@ -247,8 +247,9 @@ export function DonationPage({ requestId }: DonationPageProps) {
                   <Input
                     type="number"
                     min={1}
-                    value={line.quantity}
-                    onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
+                    max={1}
+                    value={1}
+                    disabled
                   />
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -4,7 +4,6 @@ import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
@@ -188,13 +187,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
   }
 
   return (
-    <>
-      <PageHeader
-        title={isEditing ? '編輯捐贈單' : '新增捐贈單'}
-        description="建立捐贈交易並標記對應庫存。"
-      />
-
-      <div className="grid gap-4">
+    <div className="grid gap-4">
         <SectionCard title="基本資料">
           <div className="grid gap-3 md:grid-cols-2">
             <div className="grid gap-1.5">
@@ -276,6 +269,5 @@ export function DonationPage({ requestId }: DonationPageProps) {
           {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
         </SectionCard>
       </div>
-    </>
   )
 }

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -95,11 +95,9 @@ function formatDateTime(value: string | null | undefined): string {
 }
 
 function toSubmitPayload(formData: InventoryFormData) {
-  const normalizedCount = Number.isFinite(formData.count) && formData.count > 0 ? Math.floor(formData.count) : 1
-
   return {
     ...formData,
-    count: normalizedCount,
+    count: 1,
     purchase_date: formData.purchase_date || null,
     due_date: formData.due_date || null,
     return_date: formData.return_date || null,
@@ -206,14 +204,6 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
     setFormData((previousData) => ({
       ...previousData,
       [field]: value,
-    }))
-  }
-
-  const handleCountChange = (value: string) => {
-    const nextValue = Number(value)
-    setFormData((previousData) => ({
-      ...previousData,
-      count: Number.isFinite(nextValue) ? nextValue : 0,
     }))
   }
 
@@ -348,7 +338,10 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
                   <div className="grid gap-1.5">
                     <Label>數量</Label>
-                    <Input type="number" min={1} value={formData.count} onChange={(event) => handleCountChange(event.target.value)} />
+                    <Input type="number" min={1} max={1} value={1} disabled />
+                    {loadedItem && loadedItem.count > 1 ? (
+                      <p className="m-0 text-xs text-amber-700">此筆為歷史資料（count &gt; 1），目前單件模式僅允許新異動固定為 1。</p>
+                    ) : null}
                   </div>
 
                   <div className="grid gap-1.5">

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -3,7 +3,6 @@ import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
@@ -242,11 +241,6 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
   return (
     <>
-      <PageHeader
-        title={isEditMode ? '編輯庫存' : '新增庫存'}
-        description="以分頁分區方式維護資產資料。"
-      />
-
       {loading ? <p className="mt-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
       {errorMessage ? <p className="mt-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{errorMessage}</p> : null}
       {successMessage ? <p className="mt-0 rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{successMessage}</p> : null}

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -10,7 +10,6 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { FilterBar } from '../ui/filter-bar'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
@@ -305,18 +304,14 @@ export function InventoryListPage() {
 
   return (
     <>
-      <PageHeader
-        title="財產清單"
-        description="管理資產資料，支援條件過濾、掃碼查詢與刪除。"
-        actions={
-          <Link to="/inventory/new">
-            <Button>
-              <Plus className="size-4" />
-              新增庫存
-            </Button>
-          </Link>
-        }
-      />
+      <div className="flex justify-end">
+        <Link to="/inventory/new">
+          <Button>
+            <Plus className="size-4" />
+            新增庫存
+          </Button>
+        </Link>
+      </div>
 
       <SectionCard>
         <FilterBar className="xl:grid-cols-[2fr_1fr_1fr_1fr]">

--- a/frontend/src/components/pages/IssueListPage.tsx
+++ b/frontend/src/components/pages/IssueListPage.tsx
@@ -7,7 +7,6 @@ import { Button } from '../ui/button'
 import { FilterBar } from '../ui/filter-bar'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import type { IssueRequest, PaginatedResponse } from './types'
@@ -92,18 +91,14 @@ export function IssueListPage() {
 
   return (
     <>
-      <PageHeader
-        title="領用清單"
-        description="檢視、搜尋與維護領用申請資料。"
-        actions={
-          <Link to="/issues/new">
-            <Button>
-              <Plus className="size-4" />
-              新增領用
-            </Button>
-          </Link>
-        }
-      />
+      <div className="flex justify-end">
+        <Link to="/issues/new">
+          <Button>
+            <Plus className="size-4" />
+            新增領用
+          </Button>
+        </Link>
+      </div>
 
       <SectionCard>
         <FilterBar className="xl:grid-cols-[2fr_1fr]">

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -4,7 +4,6 @@ import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { PageHeader } from '../ui/page-header'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
@@ -165,13 +164,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
   }
 
   return (
-    <>
-      <PageHeader
-        title={isEditing ? '編輯領用單' : '新增領用單'}
-        description="填寫領用人與品項資訊，建立領用交易。"
-      />
-
-      <div className="grid gap-4">
+    <div className="grid gap-4">
         <SectionCard title="基本資料">
           <div className="grid gap-3 md:grid-cols-2">
             <div className="grid gap-1.5">
@@ -249,6 +242,5 @@ export function IssuePage({ requestId }: IssuePageProps) {
           {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
         </SectionCard>
       </div>
-    </>
   )
 }

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -111,12 +111,12 @@ export function IssuePage({ requestId }: IssuePageProps) {
     if (lines.length === 0) {
       return false
     }
-    return lines.every((line) => line.item_id !== '' && line.quantity > 0)
+    return lines.every((line) => line.item_id !== '' && line.quantity === 1)
   }
 
   const handleSubmit = async () => {
     if (!validateLines()) {
-      void toast.fire({ icon: 'error', title: '請確認每筆領用品項已選擇品項且數量大於 0。' })
+      void toast.fire({ icon: 'error', title: '單件模式下，每筆領用品項數量必須為 1。' })
       return
     }
 
@@ -135,7 +135,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
           memo,
           items: lines.map((line) => ({
             item_id: line.item_id,
-            quantity: line.quantity,
+            quantity: 1,
             note: line.note,
           })),
         }),
@@ -220,8 +220,9 @@ export function IssuePage({ requestId }: IssuePageProps) {
                   <Input
                     type="number"
                     min={1}
-                    value={line.quantity}
-                    onChange={(event) => handleLineChange(index, { quantity: Number(event.target.value) })}
+                    max={1}
+                    value={1}
+                    disabled
                   />
                 </div>
                 <div className="grid gap-1.5">


### PR DESCRIPTION
## Summary
- enforce inventory status consistency across issue/borrow/donation create/update/delete flows
- validate single-item mode constraints (quantity=1, no duplicate item_id)
- add backend transaction consistency tests
- remove in-page PageHeader blocks in frontend main content pages

## Validation
- frontend: npm run build
- backend: test file added at backend/tests/test_transaction_consistency.py

Closes #11