### PR TITLE
feat(frontend/backend): stock availability guard + grouped item options (closes #12)

### DIFF
--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -7,6 +7,7 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
+import { buildGroupedItemOptions } from './itemOptionGroups'
 import type { BorrowRequest, InventoryItem, PaginatedResponse } from './types'
 
 type BorrowLine = {
@@ -16,6 +17,7 @@ type BorrowLine = {
 }
 
 const emptyLine = (): BorrowLine => ({ item_id: '', quantity: 1, note: '' })
+const GROUP_OPTION_PREFIX = '__group__:'
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -115,15 +117,21 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     })
   }, [inventoryItems, isEditing, selectedItemIds])
 
-  const itemOptions = useMemo(() => {
-    return selectableItems.map((item) => ({
-      value: item.id,
-      label: `${item.name || '未命名'} ${item.model ? `(${item.model})` : ''} ${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn ? `｜${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn}` : ''}`.trim(),
-    }))
-  }, [selectableItems])
+  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
 
   const handleLineChange = (index: number, patch: Partial<BorrowLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleItemSelectChange = (index: number, rawValue: string) => {
+    if (!rawValue) {
+      handleLineChange(index, { item_id: '' })
+      return
+    }
+    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
+      return
+    }
+    handleLineChange(index, { item_id: Number(rawValue) })
   }
 
   const getLineValidationError = () => {
@@ -263,14 +271,23 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                   <Label>品項</Label>
                   <Select
                     value={line.item_id}
-                    onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
+                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
                   >
                     <option value="">請選擇品項</option>
-                    {itemOptions.map((option) => (
-                      <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
-                        {option.label}
-                      </option>
-                    ))}
+                    {itemOptionGroups.flatMap((group) => [
+                      <option
+                        key={`group-${group.groupLabel}`}
+                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
+                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
+                      >
+                        {`==== ${group.groupLabel} ====`}
+                      </option>,
+                      ...group.options.map((option) => (
+                        <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
+                          {`  ${option.label}`}
+                        </option>
+                      )),
+                    ])}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -7,6 +7,7 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
+import { buildGroupedItemOptions } from './itemOptionGroups'
 import type { DonationRequest, InventoryItem, PaginatedResponse } from './types'
 
 type DonationLine = {
@@ -18,6 +19,7 @@ type DonationLine = {
 const FIXED_DONOR = '固定捐贈人'
 const FIXED_DEPARTMENT = '固定單位'
 const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '' })
+const GROUP_OPTION_PREFIX = '__group__:'
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -99,7 +101,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
     void loadRequest()
   }, [isEditing, requestId])
 
-  const itemOptions = useMemo(() => {
+  const selectableItems = useMemo(() => {
     if (!isEditing || !requestId) {
       return inventoryItems.filter((item) => !item.donated_at)
     }
@@ -112,8 +114,21 @@ export function DonationPage({ requestId }: DonationPageProps) {
     })
   }, [inventoryItems, isEditing, requestId])
 
+  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
+
   const handleLineChange = (index: number, patch: Partial<DonationLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleItemSelectChange = (index: number, rawValue: string) => {
+    if (!rawValue) {
+      handleLineChange(index, { item_id: '' })
+      return
+    }
+    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
+      return
+    }
+    handleLineChange(index, { item_id: Number(rawValue) })
   }
 
   const validateLines = () => {
@@ -225,14 +240,23 @@ export function DonationPage({ requestId }: DonationPageProps) {
                   <Label>品項</Label>
                   <Select
                     value={line.item_id}
-                    onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
+                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
                   >
                     <option value="">請選擇品項</option>
-                    {itemOptions.map((item) => (
-                      <option key={item.id} value={item.id}>
-                        {`${item.name || '未命名'} ${item.model ? `(${item.model})` : ''} ${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn ? `｜${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn}` : ''}`.trim()}
-                      </option>
-                    ))}
+                    {itemOptionGroups.flatMap((group) => [
+                      <option
+                        key={`group-${group.groupLabel}`}
+                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
+                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
+                      >
+                        {`==== ${group.groupLabel} ====`}
+                      </option>,
+                      ...group.options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {`  ${option.label}`}
+                        </option>
+                      )),
+                    ])}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -7,6 +7,7 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
+import { buildGroupedItemOptions } from './itemOptionGroups'
 import type { InventoryItem, IssueRequest, PaginatedResponse } from './types'
 
 type IssueLine = {
@@ -16,6 +17,7 @@ type IssueLine = {
 }
 
 const emptyLine = (): IssueLine => ({ item_id: '', quantity: 1, note: '' })
+const GROUP_OPTION_PREFIX = '__group__:'
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -109,15 +111,21 @@ export function IssuePage({ requestId }: IssuePageProps) {
     })
   }, [inventoryItems, isEditing, selectedItemIds])
 
-  const itemOptions = useMemo(() => {
-    return selectableItems.map((item) => ({
-      value: item.id,
-      label: `${item.name || '未命名'} ${item.model ? `(${item.model})` : ''} ${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn ? `｜${item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn}` : ''}`.trim(),
-    }))
-  }, [selectableItems])
+  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
 
   const handleLineChange = (index: number, patch: Partial<IssueLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleItemSelectChange = (index: number, rawValue: string) => {
+    if (!rawValue) {
+      handleLineChange(index, { item_id: '' })
+      return
+    }
+    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
+      return
+    }
+    handleLineChange(index, { item_id: Number(rawValue) })
   }
 
   const getLineValidationError = () => {
@@ -233,14 +241,23 @@ export function IssuePage({ requestId }: IssuePageProps) {
                   <Label>品項</Label>
                   <Select
                     value={line.item_id}
-                    onChange={(event) => handleLineChange(index, { item_id: event.target.value ? Number(event.target.value) : '' })}
+                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
                   >
                     <option value="">請選擇品項</option>
-                    {itemOptions.map((option) => (
-                      <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
-                        {option.label}
-                      </option>
-                    ))}
+                    {itemOptionGroups.flatMap((group) => [
+                      <option
+                        key={`group-${group.groupLabel}`}
+                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
+                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
+                      >
+                        {`==== ${group.groupLabel} ====`}
+                      </option>,
+                      ...group.options.map((option) => (
+                        <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
+                          {`  ${option.label}`}
+                        </option>
+                      )),
+                    ])}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/itemOptionGroups.ts
+++ b/frontend/src/components/pages/itemOptionGroups.ts
@@ -1,0 +1,86 @@
+import type { InventoryItem } from './types'
+
+const ASSET_TYPE_LABEL_MAP: Record<string, string> = {
+  '11': '財產 (11)',
+  A1: '物品 (A1)',
+  A2: '其他 (A2)',
+}
+
+const ASSET_TYPE_ORDER = ['11', 'A1', 'A2']
+
+export type GroupedItemOption = {
+  groupLabel: string
+  options: Array<{
+    value: number
+    label: string
+  }>
+}
+
+function itemDisplayLabel(item: InventoryItem): string {
+  const serial = item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn
+  return `${item.name || '未命名'} ${item.model ? `(${item.model})` : ''} ${serial ? `｜${serial}` : ''}`.trim()
+}
+
+function assetTypeSortRank(assetType: string): number {
+  const rank = ASSET_TYPE_ORDER.indexOf(assetType)
+  if (rank >= 0) {
+    return rank
+  }
+  return ASSET_TYPE_ORDER.length
+}
+
+function assetTypeGroupLabel(assetType: string): string {
+  const trimmed = assetType.trim()
+  if (!trimmed) {
+    return '未分類'
+  }
+  return ASSET_TYPE_LABEL_MAP[trimmed] || trimmed
+}
+
+function compareItems(left: InventoryItem, right: InventoryItem): number {
+  const rankDiff = assetTypeSortRank(left.asset_type) - assetTypeSortRank(right.asset_type)
+  if (rankDiff !== 0) {
+    return rankDiff
+  }
+
+  const typeDiff = left.asset_type.localeCompare(right.asset_type, 'zh-TW', { numeric: true, sensitivity: 'base' })
+  if (typeDiff !== 0) {
+    return typeDiff
+  }
+
+  const leftName = left.name || ''
+  const rightName = right.name || ''
+  const nameDiff = leftName.localeCompare(rightName, 'zh-TW', { numeric: true, sensitivity: 'base' })
+  if (nameDiff !== 0) {
+    return nameDiff
+  }
+
+  const leftModel = left.model || ''
+  const rightModel = right.model || ''
+  const modelDiff = leftModel.localeCompare(rightModel, 'zh-TW', { numeric: true, sensitivity: 'base' })
+  if (modelDiff !== 0) {
+    return modelDiff
+  }
+
+  const leftSerial = left.n_property_sn || left.property_sn || left.n_item_sn || left.item_sn || ''
+  const rightSerial = right.n_property_sn || right.property_sn || right.n_item_sn || right.item_sn || ''
+  return leftSerial.localeCompare(rightSerial, 'zh-TW', { numeric: true, sensitivity: 'base' })
+}
+
+export function buildGroupedItemOptions(items: InventoryItem[]): GroupedItemOption[] {
+  const sortedItems = [...items].sort(compareItems)
+  const grouped = new Map<string, GroupedItemOption>()
+
+  for (const item of sortedItems) {
+    const groupLabel = assetTypeGroupLabel(item.asset_type)
+    const existing = grouped.get(groupLabel)
+    const option = { value: item.id, label: itemDisplayLabel(item) }
+    if (!existing) {
+      grouped.set(groupLabel, { groupLabel, options: [option] })
+      continue
+    }
+    existing.options.push(option)
+  }
+
+  return Array.from(grouped.values())
+}


### PR DESCRIPTION
## Summary
- enforce issue/borrow availability guards and duplicate-item validation
- add backend guard tests for DB/API paths
- improve issue/borrow/donation item selectors with grouped + ordered options
- improve form error feedback using API detail messages

## Validation
- backend: `uv run python -m unittest discover -s tests -p 'test_*.py'`
- frontend: `npm run build`

Closes #12