### PR TITLE
feat(frontend): redesign logs list data table UX (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ VITE_API_BASE_URL=http://localhost:8000 npm run dev
 
 - `GET /api/logs/movements`
 - `GET /api/logs/operations`
+  - 可選參數：`scope=hot|all`（預設 `hot`，僅查近 90 天）
 
 ## 交易規則（重要）
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - 代碼維護：資產狀態 lookup（CRUD）
 - Excel 匯入：`POST /api/items/import`
 - 資料保留：軟刪除資料逾 6 個月自動清除
-- 操作日誌：create/read/update/delete/import/purge/sync
+- 日誌查詢：異動流水帳與操作日誌（可依時間/動作/實體/品項/單據篩選）
 
 ## 專案結構
 
@@ -82,6 +82,7 @@ VITE_API_BASE_URL=http://localhost:8000 npm run dev
 - `/borrows`、`/borrows/new`、`/borrows/:requestId`：借用
 - `/donations`、`/donations/new`、`/donations/:requestId`：捐贈
 - `/upload`：批次上傳
+- `/logs`：異動流水帳與操作日誌查詢
 
 ## API 概覽
 
@@ -133,6 +134,11 @@ VITE_API_BASE_URL=http://localhost:8000 npm run dev
 - `POST /api/items/import`（`multipart/form-data`）
   - `file`：`.xlsx`
   - `asset_type`：`11` / `A1` / `A2`
+
+### 日誌查詢
+
+- `GET /api/logs/movements`
+- `GET /api/logs/operations`
 
 ## 交易規則（重要）
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -64,6 +64,17 @@ SHEETS: dict[str, list[str]] = {
         "detail",
         "created_at",
     ],
+    "movement_ledger": [
+        "id",
+        "item_id",
+        "from_status",
+        "to_status",
+        "action",
+        "entity",
+        "entity_id",
+        "operator",
+        "created_at",
+    ],
     "issue_requests": [
         "id",
         "requester",
@@ -173,6 +184,7 @@ STRING_FIELDS: dict[str, list[str]] = {
     ],
     "donation_items": ["note"],
     "asset_status_codes": ["code", "description", "created_at", "updated_at"],
+    "movement_ledger": ["from_status", "to_status", "action", "entity", "operator", "created_at"],
 }
 
 REMOVED_SHEETS = {
@@ -988,6 +1000,204 @@ def log_inventory_action(
         wb.save(DB_PATH)
 
 
+def _append_movement_ledger_entry(
+    movement_rows: list[dict[str, Any]],
+    *,
+    item_id: int,
+    from_status: str,
+    to_status: str,
+    action: str,
+    entity: str,
+    entity_id: int | None,
+    operator: str = "system",
+) -> None:
+    movement_rows.append(
+        {
+            "id": _next_id(movement_rows),
+            "item_id": item_id,
+            "from_status": from_status,
+            "to_status": to_status,
+            "action": action,
+            "entity": entity,
+            "entity_id": entity_id if entity_id is not None else "",
+            "operator": operator,
+            "created_at": _now_str(),
+        }
+    )
+
+
+def _set_inventory_status_with_movement(
+    *,
+    movement_rows: list[dict[str, Any]],
+    row: dict[str, Any],
+    item_id: int,
+    status: str,
+    action: str,
+    entity: str,
+    entity_id: int | None,
+    operator: str = "system",
+) -> None:
+    previous_status = _to_str(row.get("asset_status")).strip()
+    _set_inventory_status(row, status)
+    _append_movement_ledger_entry(
+        movement_rows,
+        item_id=item_id,
+        from_status=previous_status,
+        to_status=status,
+        action=action,
+        entity=entity,
+        entity_id=entity_id,
+        operator=operator,
+    )
+
+
+def _parse_log_time(value: Any) -> datetime | None:
+    raw = _to_str(value).strip()
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def _matches_time_filter(*, created_at: Any, start_at: datetime | None, end_at: datetime | None) -> bool:
+    if start_at is None and end_at is None:
+        return True
+    created_time = _parse_log_time(created_at)
+    if created_time is None:
+        return False
+    if start_at is not None and created_time < start_at:
+        return False
+    if end_at is not None and created_time > end_at:
+        return False
+    return True
+
+
+def _parse_json_detail(value: Any) -> dict[str, Any]:
+    raw = _to_str(value).strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _matches_item_filter_from_detail(detail: dict[str, Any], item_id: int) -> bool:
+    detail_item_id = _to_int(detail.get("item_id"))
+    if detail_item_id == item_id:
+        return True
+    item_ids = detail.get("item_ids")
+    if isinstance(item_ids, list):
+        return item_id in {_to_int(value) for value in item_ids}
+    return False
+
+
+def list_movement_ledger(
+    *,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    action: str = "",
+    entity: str = "",
+    item_id: int | None = None,
+    entity_id: int | None = None,
+) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        movement_rows = _read_rows(wb["movement_ledger"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+
+    inventory_map = {
+        _to_int(row.get("id")): {
+            "item_name": _to_str(row.get("name")),
+            "item_model": _to_str(row.get("model")),
+        }
+        for row in inventory_rows
+    }
+    normalized_action = _to_str(action).strip().lower()
+    normalized_entity = _to_str(entity).strip().lower()
+    filtered: list[dict[str, Any]] = []
+    for row in movement_rows:
+        row_action = _to_str(row.get("action")).strip()
+        row_entity = _to_str(row.get("entity")).strip()
+        row_item_id = _to_int(row.get("item_id"))
+        row_entity_id = _to_int(row.get("entity_id"))
+        if normalized_action and row_action.lower() != normalized_action:
+            continue
+        if normalized_entity and row_entity.lower() != normalized_entity:
+            continue
+        if item_id is not None and row_item_id != item_id:
+            continue
+        if entity_id is not None and row_entity_id != entity_id:
+            continue
+        if not _matches_time_filter(created_at=row.get("created_at"), start_at=start_at, end_at=end_at):
+            continue
+        item_info = inventory_map.get(row_item_id, {})
+        filtered.append(
+            {
+                "id": _to_int(row.get("id")),
+                "item_id": row_item_id,
+                "item_name": _to_str(item_info.get("item_name")),
+                "item_model": _to_str(item_info.get("item_model")),
+                "from_status": _to_str(row.get("from_status")),
+                "to_status": _to_str(row.get("to_status")),
+                "action": row_action,
+                "entity": row_entity,
+                "entity_id": row_entity_id if row_entity_id > 0 else None,
+                "operator": _to_str(row.get("operator")),
+                "created_at": _to_str(row.get("created_at")),
+            }
+        )
+
+    return sorted(filtered, key=lambda entry: _to_int(entry.get("id")), reverse=True)
+
+
+def list_operation_logs(
+    *,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    action: str = "",
+    entity: str = "",
+    item_id: int | None = None,
+    entity_id: int | None = None,
+) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["operation_logs"])
+
+    normalized_action = _to_str(action).strip().lower()
+    normalized_entity = _to_str(entity).strip().lower()
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        row_action = _to_str(row.get("action")).strip()
+        row_entity = _to_str(row.get("entity")).strip()
+        row_entity_id = _to_int(row.get("entity_id"))
+        detail = _parse_json_detail(row.get("detail"))
+        if normalized_action and row_action.lower() != normalized_action:
+            continue
+        if normalized_entity and row_entity.lower() != normalized_entity:
+            continue
+        if entity_id is not None and row_entity_id != entity_id:
+            continue
+        if item_id is not None and not _matches_item_filter_from_detail(detail, item_id):
+            continue
+        if not _matches_time_filter(created_at=row.get("created_at"), start_at=start_at, end_at=end_at):
+            continue
+        filtered.append(
+            {
+                "id": _to_int(row.get("id")),
+                "action": row_action,
+                "entity": row_entity,
+                "entity_id": row_entity_id if row_entity_id > 0 else None,
+                "status": _to_str(row.get("status")),
+                "detail": detail,
+                "created_at": _to_str(row.get("created_at")),
+            }
+        )
+
+    return sorted(filtered, key=lambda entry: _to_int(entry.get("id")), reverse=True)
+
+
 def get_order_sn(name: str) -> dict[str, Any] | None:
     with _locked_workbook() as wb:
         ws = wb["order_sn"]
@@ -1085,15 +1295,25 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         selected_item_ids = _normalize_request_item_ids(items)
         inventory_map = _active_inventory_rows_map(inventory_rows)
+        request_id = _next_id(request_rows)
         for item_id in selected_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            _set_inventory_status(row, "1")
-        request_id = _next_id(request_rows)
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="1",
+                action="create",
+                entity="issue_request",
+                entity_id=request_id,
+            )
         request_rows.append(
             {
                 "id": request_id,
@@ -1119,6 +1339,7 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
         _write_rows(request_ws, SHEETS["issue_requests"], request_rows)
         _write_rows(item_ws, SHEETS["issue_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -1174,9 +1395,11 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         updated = False
         for row in request_rows:
             if _to_int(row.get("id")) == request_id:
@@ -1201,13 +1424,37 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
 
         for item_id in new_item_ids - old_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            _set_inventory_status(row, "1")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="1",
+                action="update",
+                entity="issue_request",
+                entity_id=request_id,
+            )
         for item_id in new_item_ids & old_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0", "1"})
-            _set_inventory_status(row, "1")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="1",
+                action="update",
+                entity="issue_request",
+                entity_id=request_id,
+            )
         for item_id in old_item_ids - new_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"1"})
-            _set_inventory_status(row, "0")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="0",
+                action="update",
+                entity="issue_request",
+                entity_id=request_id,
+            )
 
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
@@ -1224,6 +1471,7 @@ def update_issue_request(request_id: int, request_data: dict[str, Any], items: l
         _write_rows(request_ws, SHEETS["issue_requests"], request_rows)
         _write_rows(item_ws, SHEETS["issue_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1233,9 +1481,11 @@ def delete_issue_request(request_id: int) -> bool:
         request_ws = wb["issue_requests"]
         item_ws = wb["issue_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
         deleted = len(remaining_requests) != len(request_rows)
         if not deleted:
@@ -1245,11 +1495,20 @@ def delete_issue_request(request_id: int) -> bool:
         for old_item in old_items:
             item_id = _to_int(old_item.get("item_id"))
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"1"})
-            _set_inventory_status(row, "0")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="0",
+                action="delete",
+                entity="issue_request",
+                entity_id=request_id,
+            )
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["issue_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["issue_items"], remaining_items)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1259,17 +1518,26 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
         request_ws = wb["donation_requests"]
         item_ws = wb["donation_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
 
         selected_item_ids = _normalize_request_item_ids(items)
         inventory_map = _active_inventory_rows_map(inventory_rows)
+        request_id = _next_id(request_rows)
         for item_id in selected_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            _set_inventory_status(row, "3")
-
-        request_id = _next_id(request_rows)
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="3",
+                action="create",
+                entity="donation_request",
+                entity_id=request_id,
+            )
         request_rows.append(
             {
                 "id": request_id,
@@ -1298,6 +1566,7 @@ def create_donation_request(request_data: dict[str, Any], items: list[dict[str, 
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -1353,9 +1622,11 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
         request_ws = wb["donation_requests"]
         item_ws = wb["donation_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
 
         request_row = None
         for row in request_rows:
@@ -1372,13 +1643,37 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
         inventory_map = _active_inventory_rows_map(inventory_rows)
         for item_id in new_item_ids - old_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            _set_inventory_status(row, "3")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="3",
+                action="update",
+                entity="donation_request",
+                entity_id=request_id,
+            )
         for item_id in new_item_ids & old_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0", "3"})
-            _set_inventory_status(row, "3")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="3",
+                action="update",
+                entity="donation_request",
+                entity_id=request_id,
+            )
         for item_id in old_item_ids - new_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"3"})
-            _set_inventory_status(row, "0")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="0",
+                action="update",
+                entity="donation_request",
+                entity_id=request_id,
+            )
 
         request_row.update(
             {
@@ -1407,6 +1702,7 @@ def update_donation_request(request_id: int, request_data: dict[str, Any], items
         _write_rows(request_ws, SHEETS["donation_requests"], request_rows)
         _write_rows(item_ws, SHEETS["donation_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1416,9 +1712,11 @@ def delete_donation_request(request_id: int) -> bool:
         request_ws = wb["donation_requests"]
         item_ws = wb["donation_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
 
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
         deleted = len(remaining_requests) != len(request_rows)
@@ -1431,11 +1729,20 @@ def delete_donation_request(request_id: int) -> bool:
         for removed_item in removed_items:
             item_id = _to_int(removed_item.get("item_id"))
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"3"})
-            _set_inventory_status(row, "0")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="0",
+                action="delete",
+                entity="donation_request",
+                entity_id=request_id,
+            )
 
         _write_rows(request_ws, SHEETS["donation_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["donation_items"], remaining_items)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1518,16 +1825,26 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         selected_item_ids = _normalize_request_item_ids(items)
         inventory_map = _active_inventory_rows_map(inventory_rows)
+        request_id = _next_id(request_rows)
         for item_id in selected_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
             if _borrow_status_uses_inventory(next_status):
-                _set_inventory_status(row, "2")
-        request_id = _next_id(request_rows)
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="2",
+                    action="create",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
         request_rows.append(
             {
                 "id": request_id,
@@ -1556,6 +1873,7 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
         _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -1635,9 +1953,11 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         updated = False
         previous_status = ""
         for row in request_rows:
@@ -1673,18 +1993,50 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
         for item_id in new_item_ids - old_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
             if item_id in new_active_ids:
-                _set_inventory_status(row, "2")
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="2",
+                    action="update",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
         for item_id in new_item_ids & old_item_ids:
             allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
             if item_id in new_active_ids:
-                _set_inventory_status(row, "2")
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="2",
+                    action="update",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
             else:
-                _set_inventory_status(row, "0")
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="0",
+                    action="update",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
         for item_id in old_item_ids - new_item_ids:
             allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
-            _set_inventory_status(row, "0")
+            _set_inventory_status_with_movement(
+                movement_rows=movement_rows,
+                row=row,
+                item_id=item_id,
+                status="0",
+                action="update",
+                entity="borrow_request",
+                entity_id=request_id,
+            )
 
         item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         next_item_id = _next_id(item_rows)
@@ -1701,6 +2053,7 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], items: 
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
         _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 
@@ -1710,9 +2063,11 @@ def delete_borrow_request(request_id: int) -> bool:
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
         inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
         inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
         deleted = len(remaining_requests) != len(request_rows)
         if not deleted:
@@ -1730,11 +2085,20 @@ def delete_borrow_request(request_id: int) -> bool:
             for old_item in old_items:
                 item_id = _to_int(old_item.get("item_id"))
                 row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"2"})
-                _set_inventory_status(row, "0")
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="0",
+                    action="delete",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["borrow_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["borrow_items"], remaining_items)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return True
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -13,6 +14,9 @@ BASE_DIR = Path(__file__).resolve().parent
 DB_PATH = BASE_DIR / "inventory.xlsx"
 LOCK_PATH = BASE_DIR / "inventory.xlsx.lock"
 ASSET_CATEGORY_NAME_PATH = BASE_DIR.parent / "asset_category_name.xlsx"
+LOG_ARCHIVE_DIR = BASE_DIR / "log_archive"
+HOT_LOG_RETENTION_DAYS = 90
+ARCHIVE_FILE_PATTERN = re.compile(r"^logs_(\d{6})\.xlsx$")
 
 SHEETS: dict[str, list[str]] = {
     "inventory_items": [
@@ -1095,6 +1099,154 @@ def _matches_item_filter_from_detail(detail: dict[str, Any], item_id: int) -> bo
     return False
 
 
+def _month_key_from_datetime(value: datetime) -> str:
+    return value.strftime("%Y%m")
+
+
+def _archive_workbook_path(month_key: str) -> Path:
+    return LOG_ARCHIVE_DIR / f"logs_{month_key}.xlsx"
+
+
+def _ensure_archive_dir() -> None:
+    LOG_ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _list_archive_month_keys() -> list[str]:
+    if not LOG_ARCHIVE_DIR.exists():
+        return []
+    keys: list[str] = []
+    for path in LOG_ARCHIVE_DIR.iterdir():
+        match = ARCHIVE_FILE_PATTERN.match(path.name)
+        if match:
+            keys.append(match.group(1))
+    return sorted(set(keys))
+
+
+def _month_bounds(month_key: str) -> tuple[datetime, datetime] | None:
+    if len(month_key) != 6 or not month_key.isdigit():
+        return None
+    year = int(month_key[:4])
+    month = int(month_key[4:6])
+    if month < 1 or month > 12:
+        return None
+    start = datetime(year, month, 1)
+    if month == 12:
+        next_month = datetime(year + 1, 1, 1)
+    else:
+        next_month = datetime(year, month + 1, 1)
+    end = next_month - timedelta(seconds=1)
+    return start, end
+
+
+def _month_intersects_range(month_key: str, start_at: datetime | None, end_at: datetime | None) -> bool:
+    bounds = _month_bounds(month_key)
+    if bounds is None:
+        return False
+    month_start, month_end = bounds
+    if start_at is not None and month_end < start_at:
+        return False
+    if end_at is not None and month_start > end_at:
+        return False
+    return True
+
+
+def _candidate_archive_month_keys(start_at: datetime | None, end_at: datetime | None) -> list[str]:
+    keys = _list_archive_month_keys()
+    if start_at is None and end_at is None:
+        return keys
+    return [key for key in keys if _month_intersects_range(key, start_at, end_at)]
+
+
+def _load_archive_workbook(path: Path) -> Workbook:
+    if path.exists():
+        wb = load_workbook(path)
+    else:
+        wb = Workbook()
+        default_sheet = wb.active
+        wb.remove(default_sheet)
+    _ensure_sheet(wb, "operation_logs", SHEETS["operation_logs"])
+    _ensure_sheet(wb, "movement_ledger", SHEETS["movement_ledger"])
+    return wb
+
+
+def _append_rows_to_archive(sheet_name: str, rows: list[dict[str, Any]], month_key: str) -> None:
+    if not rows:
+        return
+    _ensure_archive_dir()
+    archive_path = _archive_workbook_path(month_key)
+    lock_path = archive_path.with_suffix(".lock")
+    lock = FileLock(str(lock_path))
+    with lock:
+        wb = _load_archive_workbook(archive_path)
+        ws = wb[sheet_name]
+        headers = SHEETS[sheet_name]
+        for row in rows:
+            ws.append([row.get(header, "") for header in headers])
+        wb.save(archive_path)
+
+
+def archive_old_logs(*, retention_days: int = HOT_LOG_RETENTION_DAYS) -> dict[str, int]:
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    with _locked_workbook() as wb:
+        operation_rows = _read_rows(wb["operation_logs"])
+        movement_rows = _read_rows(wb["movement_ledger"])
+
+        kept_operations: list[dict[str, Any]] = []
+        kept_movements: list[dict[str, Any]] = []
+        archived_operations_by_month: dict[str, list[dict[str, Any]]] = {}
+        archived_movements_by_month: dict[str, list[dict[str, Any]]] = {}
+
+        for row in operation_rows:
+            created_time = _parse_log_time(row.get("created_at"))
+            if created_time is None or created_time >= cutoff:
+                kept_operations.append(row)
+                continue
+            month_key = _month_key_from_datetime(created_time)
+            archived_operations_by_month.setdefault(month_key, []).append(row)
+
+        for row in movement_rows:
+            created_time = _parse_log_time(row.get("created_at"))
+            if created_time is None or created_time >= cutoff:
+                kept_movements.append(row)
+                continue
+            month_key = _month_key_from_datetime(created_time)
+            archived_movements_by_month.setdefault(month_key, []).append(row)
+
+        operation_archived = len(operation_rows) - len(kept_operations)
+        movement_archived = len(movement_rows) - len(kept_movements)
+        if operation_archived:
+            _write_rows(wb["operation_logs"], SHEETS["operation_logs"], kept_operations)
+        if movement_archived:
+            _write_rows(wb["movement_ledger"], SHEETS["movement_ledger"], kept_movements)
+        if operation_archived or movement_archived:
+            wb.save(DB_PATH)
+
+    for month_key, rows in archived_operations_by_month.items():
+        _append_rows_to_archive("operation_logs", rows, month_key)
+    for month_key, rows in archived_movements_by_month.items():
+        _append_rows_to_archive("movement_ledger", rows, month_key)
+
+    return {
+        "operation_logs_archived": operation_archived,
+        "movement_ledger_archived": movement_archived,
+    }
+
+
+def _list_archive_sheet_rows(sheet_name: str, *, start_at: datetime | None, end_at: datetime | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for month_key in _candidate_archive_month_keys(start_at, end_at):
+        archive_path = _archive_workbook_path(month_key)
+        if not archive_path.exists():
+            continue
+        lock = FileLock(str(archive_path.with_suffix(".lock")))
+        with lock:
+            wb = _load_archive_workbook(archive_path)
+            if sheet_name not in wb.sheetnames:
+                continue
+            rows.extend(_read_rows(wb[sheet_name]))
+    return rows
+
+
 def list_movement_ledger(
     *,
     start_at: datetime | None = None,
@@ -1103,10 +1255,13 @@ def list_movement_ledger(
     entity: str = "",
     item_id: int | None = None,
     entity_id: int | None = None,
+    scope: str = "hot",
 ) -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         movement_rows = _read_rows(wb["movement_ledger"])
         inventory_rows = _read_rows(wb["inventory_items"])
+    if scope == "all":
+        movement_rows.extend(_list_archive_sheet_rows("movement_ledger", start_at=start_at, end_at=end_at))
 
     inventory_map = {
         _to_int(row.get("id")): {
@@ -1161,9 +1316,12 @@ def list_operation_logs(
     entity: str = "",
     item_id: int | None = None,
     entity_id: int | None = None,
+    scope: str = "hot",
 ) -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         rows = _read_rows(wb["operation_logs"])
+    if scope == "all":
+        rows.extend(_list_archive_sheet_rows("operation_logs", start_at=start_at, end_at=end_at))
 
     normalized_action = _to_str(action).strip().lower()
     normalized_entity = _to_str(entity).strip().lower()
@@ -1172,17 +1330,21 @@ def list_operation_logs(
         row_action = _to_str(row.get("action")).strip()
         row_entity = _to_str(row.get("entity")).strip()
         row_entity_id = _to_int(row.get("entity_id"))
-        detail = _parse_json_detail(row.get("detail"))
+        detail: dict[str, Any] = {}
         if normalized_action and row_action.lower() != normalized_action:
             continue
         if normalized_entity and row_entity.lower() != normalized_entity:
             continue
         if entity_id is not None and row_entity_id != entity_id:
             continue
-        if item_id is not None and not _matches_item_filter_from_detail(detail, item_id):
-            continue
+        if item_id is not None:
+            detail = _parse_json_detail(row.get("detail"))
+            if not _matches_item_filter_from_detail(detail, item_id):
+                continue
         if not _matches_time_filter(created_at=row.get("created_at"), start_at=start_at, end_at=end_at):
             continue
+        if not detail:
+            detail = _parse_json_detail(row.get("detail"))
         filtered.append(
             {
                 "id": _to_int(row.get("id")),

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from db import (
+    archive_old_logs,
     create_asset_status_code,
     create_item,
     create_items_bulk,
@@ -397,6 +398,15 @@ def _normalize_pagination(page: int, page_size: int) -> tuple[int, int]:
     if page_size < 1:
         raise HTTPException(status_code=400, detail="page_size must be greater than 0")
     return page, page_size
+
+
+def _normalize_log_scope(scope: str) -> str:
+    normalized = scope.strip().lower()
+    if not normalized:
+        return "hot"
+    if normalized not in {"hot", "all"}:
+        raise HTTPException(status_code=400, detail="scope must be one of: hot, all")
+    return normalized
 
 
 def _paginate_rows[T](rows: list[T], page: int, page_size: int) -> tuple[list[T], int, int]:
@@ -1222,12 +1232,15 @@ def list_movement_ledger_api(
     end_at: str = "",
     action: str = "",
     entity: str = "",
+    scope: str = "hot",
     item_id: int | None = None,
     entity_id: int | None = None,
     page: int = Query(default=1),
     page_size: int = Query(default=10),
 ):
     page, page_size = _normalize_pagination(page, page_size)
+    normalized_scope = _normalize_log_scope(scope)
+    archive_old_logs()
     start_time, end_time = _parse_datetime_range_filters(start_at, end_at)
     rows = list_movement_ledger(
         start_at=start_time,
@@ -1236,24 +1249,10 @@ def list_movement_ledger_api(
         entity=entity,
         item_id=item_id,
         entity_id=entity_id,
+        scope=normalized_scope,
     )
     paged_items, total, total_pages = _paginate_rows(rows, page, page_size)
     models = [MovementLedgerEntry(**row) for row in paged_items]
-    log_inventory_action(
-        action="read",
-        entity="movement_ledger",
-        detail={
-            "count": len(models),
-            "total": total,
-            "page": page,
-            "page_size": page_size,
-            "mode": "list",
-            "action_filter": action,
-            "entity_filter": entity,
-            "item_id_filter": item_id,
-            "entity_id_filter": entity_id,
-        },
-    )
     return MovementLedgerListResponse(items=models, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
@@ -1263,12 +1262,15 @@ def list_operation_logs_api(
     end_at: str = "",
     action: str = "",
     entity: str = "",
+    scope: str = "hot",
     item_id: int | None = None,
     entity_id: int | None = None,
     page: int = Query(default=1),
     page_size: int = Query(default=10),
 ):
     page, page_size = _normalize_pagination(page, page_size)
+    normalized_scope = _normalize_log_scope(scope)
+    archive_old_logs()
     start_time, end_time = _parse_datetime_range_filters(start_at, end_at)
     rows = list_operation_logs(
         start_at=start_time,
@@ -1277,24 +1279,10 @@ def list_operation_logs_api(
         entity=entity,
         item_id=item_id,
         entity_id=entity_id,
+        scope=normalized_scope,
     )
     paged_items, total, total_pages = _paginate_rows(rows, page, page_size)
     models = [OperationLogEntry(**row) for row in paged_items]
-    log_inventory_action(
-        action="read",
-        entity="operation_log",
-        detail={
-            "count": len(models),
-            "total": total,
-            "page": page,
-            "page_size": page_size,
-            "mode": "list",
-            "action_filter": action,
-            "entity_filter": entity,
-            "item_id_filter": item_id,
-            "entity_id_filter": entity_id,
-        },
-    )
     return OperationLogListResponse(items=models, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 import math
 from pathlib import Path
+from typing import Any
 
 from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -34,6 +35,8 @@ from db import (
     list_donation_items,
     list_donation_requests,
     list_items,
+    list_movement_ledger,
+    list_operation_logs,
     log_inventory_action,
     purge_soft_deleted_items,
     update_asset_status_code,
@@ -229,6 +232,46 @@ class DonationRequestListResponse(BaseModel):
     total_pages: int
 
 
+class MovementLedgerEntry(BaseModel):
+    id: int
+    item_id: int
+    item_name: str = ""
+    item_model: str = ""
+    from_status: str = ""
+    to_status: str = ""
+    action: str = ""
+    entity: str = ""
+    entity_id: int | None = None
+    operator: str = ""
+    created_at: str = ""
+
+
+class MovementLedgerListResponse(BaseModel):
+    items: list[MovementLedgerEntry]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class OperationLogEntry(BaseModel):
+    id: int
+    action: str = ""
+    entity: str = ""
+    entity_id: int | None = None
+    status: str = ""
+    detail: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = ""
+
+
+class OperationLogListResponse(BaseModel):
+    items: list[OperationLogEntry]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
 class ImportErrorDetail(BaseModel):
     row: int
     message: str
@@ -253,6 +296,33 @@ def _parse_purchase_date(value: str) -> date:
 def _parse_datetime(value: str) -> datetime | None:
     if not value:
         return None
+
+
+def _parse_datetime_filter_value(value: str, *, field_name: str, is_end: bool = False) -> datetime | None:
+    raw_value = value.strip()
+    if not raw_value:
+        return None
+    date_formats = [
+        ("%Y-%m-%d %H:%M:%S", False),
+        ("%Y-%m-%d", True),
+    ]
+    for fmt, is_date_only in date_formats:
+        try:
+            parsed = datetime.strptime(raw_value, fmt)
+        except ValueError:
+            continue
+        if is_date_only and is_end:
+            return parsed.replace(hour=23, minute=59, second=59)
+        return parsed
+    raise HTTPException(status_code=400, detail=f"invalid {field_name} format")
+
+
+def _parse_datetime_range_filters(start_at: str, end_at: str) -> tuple[datetime | None, datetime | None]:
+    start_time = _parse_datetime_filter_value(start_at, field_name="start_at")
+    end_time = _parse_datetime_filter_value(end_at, field_name="end_at", is_end=True)
+    if start_time and end_time and start_time > end_time:
+        raise HTTPException(status_code=400, detail="start_at must be earlier than or equal to end_at")
+    return start_time, end_time
     try:
         return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
     except ValueError:
@@ -1144,6 +1214,88 @@ def delete_donation_request_api(request_id: int):
         raise HTTPException(status_code=404, detail="Donation request not found")
     log_inventory_action(action="delete", entity="donation_request", entity_id=request_id)
     return {"success": True}
+
+
+@app.get("/api/logs/movements", response_model=MovementLedgerListResponse, response_model_by_alias=False)
+def list_movement_ledger_api(
+    start_at: str = "",
+    end_at: str = "",
+    action: str = "",
+    entity: str = "",
+    item_id: int | None = None,
+    entity_id: int | None = None,
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
+    start_time, end_time = _parse_datetime_range_filters(start_at, end_at)
+    rows = list_movement_ledger(
+        start_at=start_time,
+        end_at=end_time,
+        action=action,
+        entity=entity,
+        item_id=item_id,
+        entity_id=entity_id,
+    )
+    paged_items, total, total_pages = _paginate_rows(rows, page, page_size)
+    models = [MovementLedgerEntry(**row) for row in paged_items]
+    log_inventory_action(
+        action="read",
+        entity="movement_ledger",
+        detail={
+            "count": len(models),
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "mode": "list",
+            "action_filter": action,
+            "entity_filter": entity,
+            "item_id_filter": item_id,
+            "entity_id_filter": entity_id,
+        },
+    )
+    return MovementLedgerListResponse(items=models, page=page, page_size=page_size, total=total, total_pages=total_pages)
+
+
+@app.get("/api/logs/operations", response_model=OperationLogListResponse, response_model_by_alias=False)
+def list_operation_logs_api(
+    start_at: str = "",
+    end_at: str = "",
+    action: str = "",
+    entity: str = "",
+    item_id: int | None = None,
+    entity_id: int | None = None,
+    page: int = Query(default=1),
+    page_size: int = Query(default=10),
+):
+    page, page_size = _normalize_pagination(page, page_size)
+    start_time, end_time = _parse_datetime_range_filters(start_at, end_at)
+    rows = list_operation_logs(
+        start_at=start_time,
+        end_at=end_time,
+        action=action,
+        entity=entity,
+        item_id=item_id,
+        entity_id=entity_id,
+    )
+    paged_items, total, total_pages = _paginate_rows(rows, page, page_size)
+    models = [OperationLogEntry(**row) for row in paged_items]
+    log_inventory_action(
+        action="read",
+        entity="operation_log",
+        detail={
+            "count": len(models),
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "mode": "list",
+            "action_filter": action,
+            "entity_filter": entity,
+            "item_id_filter": item_id,
+            "entity_id_filter": entity_id,
+        },
+    )
+    return OperationLogListResponse(items=models, page=page, page_size=page_size, total=total, total_pages=total_pages)
 
 
 @app.post("/api/items/import", response_model=ImportResponse)

--- a/backend/tests/test_movement_and_log_queries.py
+++ b/backend/tests/test_movement_and_log_queries.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import db
+import main as app_main
 
 
 class MovementAndLogQueryTests(unittest.TestCase):
@@ -11,14 +12,17 @@ class MovementAndLogQueryTests(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._original_db_path = db.DB_PATH
         self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
 
         db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
         db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
         db.init_db()
 
     def tearDown(self) -> None:
         db.DB_PATH = self._original_db_path
         db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
         self._tmpdir.cleanup()
 
     def _create_item(self, *, name: str = "測試品項") -> int:
@@ -128,6 +132,56 @@ class MovementAndLogQueryTests(unittest.TestCase):
         future_end = future_start + timedelta(days=1)
         self.assertEqual(db.list_movement_ledger(start_at=future_start, end_at=future_end), [])
         self.assertEqual(db.list_operation_logs(start_at=future_start, end_at=future_end), [])
+
+    def test_archive_old_logs_moves_old_data_and_scope_all_can_read(self) -> None:
+        item_id = self._create_item(name="歸檔測試")
+        request_id = db.create_issue_request(
+            {
+                "requester": "tester",
+                "department": "qa",
+                "purpose": "archive",
+                "request_date": "2026-04-10",
+                "memo": "",
+            },
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
+        )
+        db.log_inventory_action(action="update", entity="issue_request", entity_id=request_id, detail={"item_id": item_id})
+
+        old_time = (datetime.now() - timedelta(days=120)).strftime("%Y-%m-%d %H:%M:%S")
+        with db._locked_workbook() as wb:  # type: ignore[attr-defined]
+            movement_rows = db._read_rows(wb["movement_ledger"])  # type: ignore[attr-defined]
+            operation_rows = db._read_rows(wb["operation_logs"])  # type: ignore[attr-defined]
+            for row in movement_rows:
+                row["created_at"] = old_time
+            for row in operation_rows:
+                row["created_at"] = old_time
+            db._write_rows(wb["movement_ledger"], db.SHEETS["movement_ledger"], movement_rows)  # type: ignore[attr-defined]
+            db._write_rows(wb["operation_logs"], db.SHEETS["operation_logs"], operation_rows)  # type: ignore[attr-defined]
+            wb.save(db.DB_PATH)
+
+        archive_result = db.archive_old_logs(retention_days=90)
+        self.assertGreaterEqual(archive_result["movement_ledger_archived"], 1)
+        self.assertGreaterEqual(archive_result["operation_logs_archived"], 1)
+
+        hot_movements = db.list_movement_ledger(entity="issue_request", entity_id=request_id, scope="hot")
+        hot_operations = db.list_operation_logs(entity="issue_request", entity_id=request_id, scope="hot")
+        self.assertEqual(hot_movements, [])
+        self.assertEqual(hot_operations, [])
+
+        all_movements = db.list_movement_ledger(entity="issue_request", entity_id=request_id, scope="all")
+        all_operations = db.list_operation_logs(entity="issue_request", entity_id=request_id, scope="all")
+        self.assertGreaterEqual(len(all_movements), 1)
+        self.assertGreaterEqual(len(all_operations), 1)
+
+    def test_logs_api_does_not_write_read_logs(self) -> None:
+        db.log_inventory_action(action="update", entity="inventory_item", entity_id=1001, detail={"item_id": 1})
+        before_count = len(db.list_operation_logs(scope="hot"))
+
+        response = app_main.list_operation_logs_api(page=1, page_size=10)
+        self.assertGreaterEqual(response.total, 1)
+
+        after_count = len(db.list_operation_logs(scope="hot"))
+        self.assertEqual(after_count, before_count)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_movement_and_log_queries.py
+++ b/backend/tests/test_movement_and_log_queries.py
@@ -1,0 +1,134 @@
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import db
+
+
+class MovementAndLogQueryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        self._tmpdir.cleanup()
+
+    def _create_item(self, *, name: str = "測試品項") -> int:
+        return db.create_item(
+            {
+                "asset_type": "A1",
+                "asset_status": "0",
+                "name": name,
+                "model": "M1",
+                "count": 1,
+            }
+        )
+
+    def test_issue_flow_writes_movement_ledger(self) -> None:
+        item_id = self._create_item()
+        request_id = db.create_issue_request(
+            {
+                "requester": "tester",
+                "department": "qa",
+                "purpose": "test",
+                "request_date": "2026-04-10",
+                "memo": "",
+            },
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
+        )
+
+        rows = db.list_movement_ledger(entity="issue_request", entity_id=request_id, item_id=item_id)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["action"], "create")
+        self.assertEqual(rows[0]["from_status"], "0")
+        self.assertEqual(rows[0]["to_status"], "1")
+        self.assertEqual(rows[0]["operator"], "system")
+
+    def test_borrow_return_flow_writes_open_and_return_movements(self) -> None:
+        item_id = self._create_item(name="借用品項")
+        request_id = db.create_borrow_request(
+            {
+                "borrower": "tester",
+                "department": "qa",
+                "purpose": "test",
+                "borrow_date": "2026-04-10",
+                "due_date": "2026-04-20",
+                "return_date": "",
+                "status": "borrowed",
+                "memo": "",
+            },
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
+        )
+        db.update_borrow_request(
+            request_id,
+            {
+                "borrower": "tester",
+                "department": "qa",
+                "purpose": "test",
+                "borrow_date": "2026-04-10",
+                "due_date": "2026-04-20",
+                "return_date": "2026-04-12",
+                "status": "returned",
+                "memo": "",
+            },
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
+        )
+
+        rows = db.list_movement_ledger(entity="borrow_request", entity_id=request_id, item_id=item_id)
+        self.assertEqual(len(rows), 2)
+        transitions = {(row["from_status"], row["to_status"], row["action"]) for row in rows}
+        self.assertIn(("0", "2", "create"), transitions)
+        self.assertIn(("2", "0", "update"), transitions)
+
+    def test_operation_log_filters_by_entity_id_and_item_id(self) -> None:
+        db.log_inventory_action(
+            action="update",
+            entity="issue_request",
+            entity_id=777,
+            detail={"item_id": 11, "note": "target"},
+        )
+        db.log_inventory_action(
+            action="update",
+            entity="issue_request",
+            entity_id=778,
+            detail={"item_id": 22, "note": "other"},
+        )
+
+        filtered_by_entity = db.list_operation_logs(entity="issue_request", entity_id=777)
+        self.assertEqual(len(filtered_by_entity), 1)
+        self.assertEqual(filtered_by_entity[0]["entity_id"], 777)
+
+        filtered_by_item = db.list_operation_logs(entity="issue_request", item_id=11)
+        self.assertEqual(len(filtered_by_item), 1)
+        self.assertEqual(filtered_by_item[0]["detail"].get("item_id"), 11)
+
+    def test_time_range_filter_applies_to_movement_and_operation_logs(self) -> None:
+        item_id = self._create_item(name="時間測試")
+        db.create_issue_request(
+            {
+                "requester": "tester",
+                "department": "qa",
+                "purpose": "time",
+                "request_date": "2026-04-10",
+                "memo": "",
+            },
+            [{"item_id": item_id, "quantity": 1, "note": ""}],
+        )
+        db.log_inventory_action(action="create", entity="inventory_item", detail={"item_id": item_id})
+
+        future_start = datetime.now() + timedelta(days=1)
+        future_end = future_start + timedelta(days=1)
+        self.assertEqual(db.list_movement_ledger(start_at=future_start, end_at=future_end), [])
+        self.assertEqual(db.list_operation_logs(start_at=future_start, end_at=future_end), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -14,14 +14,17 @@ class RequestApiGuardTests(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._original_db_path = db.DB_PATH
         self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
 
         db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
         db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
         db.init_db()
 
     def tearDown(self) -> None:
         db.DB_PATH = self._original_db_path
         db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
         self._tmpdir.cleanup()
 
     def _create_item(self, *, asset_status: str = "0") -> int:
@@ -107,6 +110,12 @@ class RequestApiGuardTests(unittest.TestCase):
         created = app_main.create_borrow_request_api(request, BackgroundTasks())
         self.assertEqual(created.status, "borrowed")
         self.assertTrue(created.is_due_soon)
+
+    def test_logs_api_rejects_invalid_scope(self) -> None:
+        with self.assertRaises(HTTPException) as exc:
+            app_main.list_operation_logs_api(scope="archive-only", page=1, page_size=10)
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, "scope must be one of: hot, all")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -42,13 +42,14 @@ class TransactionConsistencyTests(unittest.TestCase):
         }
 
     def _borrow_payload(self, *, status: str) -> dict:
+        return_date = "2026-04-12" if status == "returned" else ""
         return {
             "borrower": "tester",
             "department": "qa",
             "purpose": "test",
             "borrow_date": "2026-04-10",
             "due_date": "2026-04-20",
-            "return_date": "",
+            "return_date": return_date,
             "status": status,
             "memo": "",
         }

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -11,14 +11,17 @@ class TransactionConsistencyTests(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._original_db_path = db.DB_PATH
         self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
 
         db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
         db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
         db.init_db()
 
     def tearDown(self) -> None:
         db.DB_PATH = self._original_db_path
         db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
         self._tmpdir.cleanup()
 
     def _create_item(self, *, asset_status: str = "0", count: int = 1) -> int:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { InventoryFormPage } from './components/pages/InventoryFormPage'
 import { InventoryListPage } from './components/pages/InventoryListPage'
 import { IssueListPage } from './components/pages/IssueListPage'
 import { IssuePage } from './components/pages/IssuePage'
+import { LogsPage } from './components/pages/LogsPage'
 import { UploadPage } from './components/pages/UploadPage'
 import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card'
 
@@ -24,7 +25,7 @@ function NotFoundPage() {
         <CardTitle>找不到頁面</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">請使用側邊導覽前往 Dashboard、財產、領用、借用、捐贈或上傳頁面。</p>
+        <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">請使用側邊導覽前往 Dashboard、財產、領用、借用、捐贈、上傳或日誌頁面。</p>
       </CardContent>
     </Card>
   )
@@ -168,6 +169,12 @@ const uploadRoute = createRoute({
   component: UploadPage,
 })
 
+const logsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/logs',
+  component: LogsPage,
+})
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   inventoryRoute,
@@ -183,6 +190,7 @@ const routeTree = rootRoute.addChildren([
   donationCreateRoute,
   donationEditRoute,
   uploadRoute,
+  logsRoute,
 ])
 
 const router = createRouter({ routeTree, defaultPreload: 'intent' })

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo, useState } from 'react'
 import { Link, Outlet, useLocation } from '@tanstack/react-router'
-import { Boxes, ChevronDown, ClipboardList, FilePlus2, HandCoins, Handshake, LayoutDashboard, Menu, Upload, X } from 'lucide-react'
+import { Boxes, ChevronDown, ClipboardList, FilePlus2, HandCoins, Handshake, LayoutDashboard, Logs, Menu, Upload, X } from 'lucide-react'
 import { cn } from '../../lib/utils'
 
 type NavigationLink = {
@@ -70,6 +70,10 @@ const NAVIGATION_SECTIONS: NavigationSection[] = [
       { to: '/upload', label: '批次上傳', icon: <Upload className="size-4" />, exact: true },
     ],
   },
+  {
+    title: '稽核',
+    links: [{ to: '/logs', label: '日誌查詢', icon: <Logs className="size-4" />, exact: true }],
+  },
 ]
 
 type PageMeta = {
@@ -119,6 +123,9 @@ function resolvePageMeta(pathname: string): PageMeta {
   }
   if (pathname === '/upload') {
     return { title: '批次上傳', description: '透過 xlsx 匯入資產資料' }
+  }
+  if (pathname === '/logs') {
+    return { title: '日誌查詢', description: '檢視異動流水帳與操作日誌' }
   }
 
   return { title: '頁面', description: '系統頁面' }

--- a/frontend/src/components/pages/LogsPage.tsx
+++ b/frontend/src/components/pages/LogsPage.tsx
@@ -10,6 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import type { MovementLedgerEntry, OperationLogEntry, PaginatedResponse } from './types'
 
 type LogTab = 'movements' | 'operations'
+type LogScope = 'hot' | 'all'
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
@@ -26,10 +27,15 @@ function parseInitialTab(value: string | null): LogTab {
   return value === 'operations' ? 'operations' : 'movements'
 }
 
+function parseInitialScope(value: string | null): LogScope {
+  return value === 'all' ? 'all' : 'hot'
+}
+
 function readInitialState() {
   const params = new URLSearchParams(window.location.search)
   return {
     tab: parseInitialTab(params.get('tab')),
+    scope: parseInitialScope(params.get('scope')),
     startAt: params.get('start_at') ?? '',
     endAt: params.get('end_at') ?? '',
     action: params.get('action') ?? '',
@@ -52,6 +58,7 @@ function safeJsonPreview(value: unknown): string {
 export function LogsPage() {
   const initialState = readInitialState()
   const [tab, setTab] = useState<LogTab>(initialState.tab)
+  const [scope, setScope] = useState<LogScope>(initialState.scope)
   const [startAt, setStartAt] = useState(initialState.startAt)
   const [endAt, setEndAt] = useState(initialState.endAt)
   const [action, setAction] = useState(initialState.action)
@@ -72,6 +79,9 @@ export function LogsPage() {
   useEffect(() => {
     const params = new URLSearchParams()
     params.set('tab', tab)
+    if (scope !== 'hot') {
+      params.set('scope', scope)
+    }
     if (startAt) {
       params.set('start_at', startAt)
     }
@@ -97,7 +107,7 @@ export function LogsPage() {
       params.set('page_size', String(pageSize))
     }
     window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`)
-  }, [tab, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
+  }, [tab, scope, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
 
   useEffect(() => {
     const loadRows = async () => {
@@ -107,6 +117,7 @@ export function LogsPage() {
         const params = new URLSearchParams({
           page: String(page),
           page_size: String(pageSize),
+          scope,
         })
         if (startAt) {
           params.set('start_at', startAt)
@@ -149,7 +160,7 @@ export function LogsPage() {
     }
 
     void loadRows()
-  }, [endpoint, tab, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
+  }, [endpoint, tab, scope, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
 
   return (
     <SectionCard>
@@ -163,6 +174,16 @@ export function LogsPage() {
           }}
         >
           異動流水帳
+        </Button>
+        <Button
+          type="button"
+          variant={scope === 'all' ? 'default' : 'secondary'}
+          onClick={() => {
+            setScope((current) => (current === 'hot' ? 'all' : 'hot'))
+            setPage(1)
+          }}
+        >
+          包含歷史資料
         </Button>
         <Button
           type="button"

--- a/frontend/src/components/pages/LogsPage.tsx
+++ b/frontend/src/components/pages/LogsPage.tsx
@@ -1,0 +1,397 @@
+import { useEffect, useMemo, useState } from 'react'
+import { apiUrl } from '../../api'
+import { DataPagination } from '../ui/data-pagination'
+import { Button } from '../ui/button'
+import { FilterBar } from '../ui/filter-bar'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SectionCard } from '../ui/section-card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import type { MovementLedgerEntry, OperationLogEntry, PaginatedResponse } from './types'
+
+type LogTab = 'movements' | 'operations'
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return parsed
+}
+
+function parseInitialTab(value: string | null): LogTab {
+  return value === 'operations' ? 'operations' : 'movements'
+}
+
+function readInitialState() {
+  const params = new URLSearchParams(window.location.search)
+  return {
+    tab: parseInitialTab(params.get('tab')),
+    startAt: params.get('start_at') ?? '',
+    endAt: params.get('end_at') ?? '',
+    action: params.get('action') ?? '',
+    entity: params.get('entity') ?? '',
+    itemId: params.get('item_id') ?? '',
+    entityId: params.get('entity_id') ?? '',
+    page: parsePositiveInt(params.get('page'), 1),
+    pageSize: parsePositiveInt(params.get('page_size'), 10),
+  }
+}
+
+function safeJsonPreview(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return '{}'
+  }
+}
+
+export function LogsPage() {
+  const initialState = readInitialState()
+  const [tab, setTab] = useState<LogTab>(initialState.tab)
+  const [startAt, setStartAt] = useState(initialState.startAt)
+  const [endAt, setEndAt] = useState(initialState.endAt)
+  const [action, setAction] = useState(initialState.action)
+  const [entity, setEntity] = useState(initialState.entity)
+  const [itemId, setItemId] = useState(initialState.itemId)
+  const [entityId, setEntityId] = useState(initialState.entityId)
+  const [page, setPage] = useState(initialState.page)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [movementRows, setMovementRows] = useState<MovementLedgerEntry[]>([])
+  const [operationRows, setOperationRows] = useState<OperationLogEntry[]>([])
+
+  const endpoint = useMemo(() => (tab === 'movements' ? '/api/logs/movements' : '/api/logs/operations'), [tab])
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    params.set('tab', tab)
+    if (startAt) {
+      params.set('start_at', startAt)
+    }
+    if (endAt) {
+      params.set('end_at', endAt)
+    }
+    if (action.trim()) {
+      params.set('action', action.trim())
+    }
+    if (entity.trim()) {
+      params.set('entity', entity.trim())
+    }
+    if (itemId.trim()) {
+      params.set('item_id', itemId.trim())
+    }
+    if (entityId.trim()) {
+      params.set('entity_id', entityId.trim())
+    }
+    if (page !== 1) {
+      params.set('page', String(page))
+    }
+    if (pageSize !== 10) {
+      params.set('page_size', String(pageSize))
+    }
+    window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`)
+  }, [tab, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
+
+  useEffect(() => {
+    const loadRows = async () => {
+      setLoading(true)
+      setLoadError('')
+      try {
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(pageSize),
+        })
+        if (startAt) {
+          params.set('start_at', startAt)
+        }
+        if (endAt) {
+          params.set('end_at', endAt)
+        }
+        if (action.trim()) {
+          params.set('action', action.trim())
+        }
+        if (entity.trim()) {
+          params.set('entity', entity.trim())
+        }
+        if (itemId.trim()) {
+          params.set('item_id', itemId.trim())
+        }
+        if (entityId.trim()) {
+          params.set('entity_id', entityId.trim())
+        }
+        const response = await fetch(apiUrl(`${endpoint}?${params.toString()}`))
+        if (!response.ok) {
+          throw new Error('無法載入日誌資料')
+        }
+        if (tab === 'movements') {
+          const payload = (await response.json()) as PaginatedResponse<MovementLedgerEntry>
+          setMovementRows(payload.items)
+          setTotal(payload.total)
+          setTotalPages(payload.total_pages)
+        } else {
+          const payload = (await response.json()) as PaginatedResponse<OperationLogEntry>
+          setOperationRows(payload.items)
+          setTotal(payload.total)
+          setTotalPages(payload.total_pages)
+        }
+      } catch {
+        setLoadError('目前無法讀取日誌資料，請稍後重試。')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void loadRows()
+  }, [endpoint, tab, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
+
+  return (
+    <SectionCard>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant={tab === 'movements' ? 'default' : 'secondary'}
+          onClick={() => {
+            setTab('movements')
+            setPage(1)
+          }}
+        >
+          異動流水帳
+        </Button>
+        <Button
+          type="button"
+          variant={tab === 'operations' ? 'default' : 'secondary'}
+          onClick={() => {
+            setTab('operations')
+            setPage(1)
+          }}
+        >
+          操作日誌
+        </Button>
+      </div>
+
+      <FilterBar className="xl:grid-cols-[repeat(6,minmax(0,1fr))_auto]">
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-start-at">開始日期</Label>
+          <Input
+            id="logs-start-at"
+            type="date"
+            value={startAt}
+            onChange={(event) => {
+              setStartAt(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-end-at">結束日期</Label>
+          <Input
+            id="logs-end-at"
+            type="date"
+            value={endAt}
+            onChange={(event) => {
+              setEndAt(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-action">動作</Label>
+          <Input
+            id="logs-action"
+            placeholder="create/update/delete/read"
+            value={action}
+            onChange={(event) => {
+              setAction(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-entity">實體</Label>
+          <Input
+            id="logs-entity"
+            placeholder="issue_request / borrow_request ..."
+            value={entity}
+            onChange={(event) => {
+              setEntity(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-item-id">品項 ID</Label>
+          <Input
+            id="logs-item-id"
+            type="number"
+            min={1}
+            value={itemId}
+            onChange={(event) => {
+              setItemId(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="logs-entity-id">單據 ID</Label>
+          <Input
+            id="logs-entity-id"
+            type="number"
+            min={1}
+            value={entityId}
+            onChange={(event) => {
+              setEntityId(event.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
+      </FilterBar>
+
+      {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
+      {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
+
+      {!loading && !loadError && tab === 'movements' ? (
+        <>
+          <div className="hidden overflow-x-auto md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {['#', '時間', '品項', '狀態變更', '動作', '實體', '單據', '操作者'].map((header) => (
+                    <TableHead key={header}>{header}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {movementRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={8}>
+                      目前沒有符合條件的異動流水帳。
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  movementRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>{row.id}</TableCell>
+                      <TableCell>{row.created_at || '--'}</TableCell>
+                      <TableCell>
+                        <div className="font-semibold">{row.item_name || `#${row.item_id}`}</div>
+                        <div className="text-xs text-[hsl(var(--muted-foreground))]">{row.item_model || ''}</div>
+                      </TableCell>
+                      <TableCell>{`${row.from_status || '--'} -> ${row.to_status || '--'}`}</TableCell>
+                      <TableCell>{row.action || '--'}</TableCell>
+                      <TableCell>{row.entity || '--'}</TableCell>
+                      <TableCell>{row.entity_id ?? '--'}</TableCell>
+                      <TableCell>{row.operator || '--'}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="grid gap-3 md:hidden">
+            {movementRows.length === 0 ? (
+              <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                目前沒有符合條件的異動流水帳。
+              </p>
+            ) : (
+              movementRows.map((row) => (
+                <article key={row.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                  <p className="m-0 text-sm font-semibold">#{row.id}</p>
+                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{row.created_at || '--'}</p>
+                  <p className="mt-2 mb-0 text-sm">
+                    品項：{row.item_name || `#${row.item_id}`} {row.item_model ? `(${row.item_model})` : ''}
+                  </p>
+                  <p className="mt-1 mb-0 text-sm">狀態：{`${row.from_status || '--'} -> ${row.to_status || '--'}`}</p>
+                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
+                    {row.action || '--'} / {row.entity || '--'} / #{row.entity_id ?? '--'} / {row.operator || '--'}
+                  </p>
+                </article>
+              ))
+            )}
+          </div>
+        </>
+      ) : null}
+
+      {!loading && !loadError && tab === 'operations' ? (
+        <>
+          <div className="hidden overflow-x-auto md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {['#', '時間', '動作', '實體', '單據', '狀態', '細節'].map((header) => (
+                    <TableHead key={header}>{header}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {operationRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={7}>
+                      目前沒有符合條件的操作日誌。
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  operationRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>{row.id}</TableCell>
+                      <TableCell>{row.created_at || '--'}</TableCell>
+                      <TableCell>{row.action || '--'}</TableCell>
+                      <TableCell>{row.entity || '--'}</TableCell>
+                      <TableCell>{row.entity_id ?? '--'}</TableCell>
+                      <TableCell>{row.status || '--'}</TableCell>
+                      <TableCell className="max-w-[360px] truncate text-xs text-[hsl(var(--muted-foreground))]">
+                        {safeJsonPreview(row.detail)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="grid gap-3 md:hidden">
+            {operationRows.length === 0 ? (
+              <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
+                目前沒有符合條件的操作日誌。
+              </p>
+            ) : (
+              operationRows.map((row) => (
+                <article key={row.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+                  <p className="m-0 text-sm font-semibold">#{row.id}</p>
+                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{row.created_at || '--'}</p>
+                  <p className="mt-2 mb-0 text-sm">
+                    {row.action || '--'} / {row.entity || '--'} / #{row.entity_id ?? '--'}
+                  </p>
+                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">狀態：{row.status || '--'}</p>
+                  <p className="mt-1 mb-0 break-all text-xs text-[hsl(var(--muted-foreground))]">{safeJsonPreview(row.detail)}</p>
+                </article>
+              ))
+            )}
+          </div>
+        </>
+      ) : null}
+
+      {!loading && !loadError ? (
+        <DataPagination
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          totalPages={totalPages}
+          onPageChange={setPage}
+          onPageSizeChange={(nextPageSize) => {
+            setPageSize(nextPageSize)
+            setPage(1)
+          }}
+        />
+      ) : null}
+    </SectionCard>
+  )
+}

--- a/frontend/src/components/pages/LogsPage.tsx
+++ b/frontend/src/components/pages/LogsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
 import { Button } from '../ui/button'
-import { FilterBar } from '../ui/filter-bar'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
@@ -12,40 +12,109 @@ import type { MovementLedgerEntry, OperationLogEntry, PaginatedResponse } from '
 type LogTab = 'movements' | 'operations'
 type LogScope = 'hot' | 'all'
 
-function parsePositiveInt(value: string | null, fallback: number): number {
-  if (!value) {
-    return fallback
-  }
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    return fallback
-  }
-  return parsed
+type MovementColumnKey = 'id' | 'created_at' | 'item' | 'status_change' | 'action' | 'entity' | 'entity_id' | 'operator'
+type OperationColumnKey = 'id' | 'created_at' | 'action' | 'entity' | 'entity_id' | 'status' | 'detail'
+
+type MovementColumnDef = {
+  key: MovementColumnKey
+  label: string
+  render: (row: MovementLedgerEntry) => React.ReactNode
+  cellClassName?: string
 }
 
-function parseInitialTab(value: string | null): LogTab {
-  return value === 'operations' ? 'operations' : 'movements'
+type OperationColumnDef = {
+  key: OperationColumnKey
+  label: string
+  render: (row: OperationLogEntry) => React.ReactNode
+  cellClassName?: string
 }
 
-function parseInitialScope(value: string | null): LogScope {
-  return value === 'all' ? 'all' : 'hot'
-}
+const movementColumns: MovementColumnDef[] = [
+  {
+    key: 'id',
+    label: '#',
+    render: (row) => row.id,
+  },
+  {
+    key: 'created_at',
+    label: '時間',
+    render: (row) => row.created_at || '--',
+  },
+  {
+    key: 'item',
+    label: '品項',
+    render: (row) => (
+      <>
+        <div className="font-semibold">{row.item_name || `#${row.item_id}`}</div>
+        <div className="text-xs text-[hsl(var(--muted-foreground))]">{row.item_model || ''}</div>
+      </>
+    ),
+  },
+  {
+    key: 'status_change',
+    label: '狀態變更',
+    render: (row) => `${row.from_status || '--'} -> ${row.to_status || '--'}`,
+  },
+  {
+    key: 'action',
+    label: '動作',
+    render: (row) => row.action || '--',
+  },
+  {
+    key: 'entity',
+    label: '實體',
+    render: (row) => row.entity || '--',
+  },
+  {
+    key: 'entity_id',
+    label: '單據',
+    render: (row) => row.entity_id ?? '--',
+  },
+  {
+    key: 'operator',
+    label: '操作者',
+    render: (row) => row.operator || '--',
+  },
+]
 
-function readInitialState() {
-  const params = new URLSearchParams(window.location.search)
-  return {
-    tab: parseInitialTab(params.get('tab')),
-    scope: parseInitialScope(params.get('scope')),
-    startAt: params.get('start_at') ?? '',
-    endAt: params.get('end_at') ?? '',
-    action: params.get('action') ?? '',
-    entity: params.get('entity') ?? '',
-    itemId: params.get('item_id') ?? '',
-    entityId: params.get('entity_id') ?? '',
-    page: parsePositiveInt(params.get('page'), 1),
-    pageSize: parsePositiveInt(params.get('page_size'), 10),
-  }
-}
+const operationColumns: OperationColumnDef[] = [
+  {
+    key: 'id',
+    label: '#',
+    render: (row) => row.id,
+  },
+  {
+    key: 'created_at',
+    label: '時間',
+    render: (row) => row.created_at || '--',
+  },
+  {
+    key: 'action',
+    label: '動作',
+    render: (row) => row.action || '--',
+  },
+  {
+    key: 'entity',
+    label: '實體',
+    render: (row) => row.entity || '--',
+  },
+  {
+    key: 'entity_id',
+    label: '單據',
+    render: (row) => row.entity_id ?? '--',
+  },
+  {
+    key: 'status',
+    label: '狀態',
+    render: (row) => row.status || '--',
+  },
+  {
+    key: 'detail',
+    label: '細節',
+    cellClassName: 'max-w-[360px] truncate text-xs text-[hsl(var(--muted-foreground))]',
+    render: (row) => safeJsonPreview(row.detail),
+  },
+]
 
 function safeJsonPreview(value: unknown): string {
   try {
@@ -56,58 +125,85 @@ function safeJsonPreview(value: unknown): string {
 }
 
 export function LogsPage() {
-  const initialState = readInitialState()
-  const [tab, setTab] = useState<LogTab>(initialState.tab)
-  const [scope, setScope] = useState<LogScope>(initialState.scope)
-  const [startAt, setStartAt] = useState(initialState.startAt)
-  const [endAt, setEndAt] = useState(initialState.endAt)
-  const [action, setAction] = useState(initialState.action)
-  const [entity, setEntity] = useState(initialState.entity)
-  const [itemId, setItemId] = useState(initialState.itemId)
-  const [entityId, setEntityId] = useState(initialState.entityId)
-  const [page, setPage] = useState(initialState.page)
-  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [tab, setTab] = useState<LogTab>('movements')
+  const [scope, setScope] = useState<LogScope>('hot')
+  const [startAt, setStartAt] = useState('')
+  const [endAt, setEndAt] = useState('')
+  const [action, setAction] = useState('')
+  const [entity, setEntity] = useState('')
+  const [itemId, setItemId] = useState('')
+  const [entityId, setEntityId] = useState('')
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
   const [total, setTotal] = useState(0)
   const [totalPages, setTotalPages] = useState(1)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
   const [movementRows, setMovementRows] = useState<MovementLedgerEntry[]>([])
   const [operationRows, setOperationRows] = useState<OperationLogEntry[]>([])
+  const [movementColumnVisibility, setMovementColumnVisibility] = useState<Record<MovementColumnKey, boolean>>({
+    id: true,
+    created_at: true,
+    item: true,
+    status_change: true,
+    action: true,
+    entity: true,
+    entity_id: true,
+    operator: true,
+  })
+  const [operationColumnVisibility, setOperationColumnVisibility] = useState<Record<OperationColumnKey, boolean>>({
+    id: true,
+    created_at: true,
+    action: true,
+    entity: true,
+    entity_id: true,
+    status: true,
+    detail: true,
+  })
 
   const endpoint = useMemo(() => (tab === 'movements' ? '/api/logs/movements' : '/api/logs/operations'), [tab])
 
-  useEffect(() => {
-    const params = new URLSearchParams()
-    params.set('tab', tab)
-    if (scope !== 'hot') {
-      params.set('scope', scope)
-    }
-    if (startAt) {
-      params.set('start_at', startAt)
-    }
-    if (endAt) {
-      params.set('end_at', endAt)
-    }
-    if (action.trim()) {
-      params.set('action', action.trim())
-    }
-    if (entity.trim()) {
-      params.set('entity', entity.trim())
-    }
-    if (itemId.trim()) {
-      params.set('item_id', itemId.trim())
-    }
-    if (entityId.trim()) {
-      params.set('entity_id', entityId.trim())
-    }
-    if (page !== 1) {
-      params.set('page', String(page))
-    }
-    if (pageSize !== 10) {
-      params.set('page_size', String(pageSize))
-    }
-    window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`)
-  }, [tab, scope, startAt, endAt, action, entity, itemId, entityId, page, pageSize])
+  const hasActiveFilters = scope === 'all' || Boolean(startAt || endAt || action.trim() || entity.trim() || itemId.trim() || entityId.trim())
+
+  const visibleMovementColumns = useMemo(
+    () => movementColumns.filter((column) => movementColumnVisibility[column.key]),
+    [movementColumnVisibility],
+  )
+  const visibleOperationColumns = useMemo(
+    () => operationColumns.filter((column) => operationColumnVisibility[column.key]),
+    [operationColumnVisibility],
+  )
+
+  function resetFilters() {
+    setScope('hot')
+    setStartAt('')
+    setEndAt('')
+    setAction('')
+    setEntity('')
+    setItemId('')
+    setEntityId('')
+    setPage(1)
+  }
+
+  function toggleMovementColumn(key: MovementColumnKey) {
+    setMovementColumnVisibility((current) => {
+      const visibleCount = Object.values(current).filter(Boolean).length
+      if (current[key] && visibleCount === 1) {
+        return current
+      }
+      return { ...current, [key]: !current[key] }
+    })
+  }
+
+  function toggleOperationColumn(key: OperationColumnKey) {
+    setOperationColumnVisibility((current) => {
+      const visibleCount = Object.values(current).filter(Boolean).length
+      if (current[key] && visibleCount === 1) {
+        return current
+      }
+      return { ...current, [key]: !current[key] }
+    })
+  }
 
   useEffect(() => {
     const loadRows = async () => {
@@ -137,21 +233,24 @@ export function LogsPage() {
         if (entityId.trim()) {
           params.set('entity_id', entityId.trim())
         }
+
         const response = await fetch(apiUrl(`${endpoint}?${params.toString()}`))
         if (!response.ok) {
           throw new Error('無法載入日誌資料')
         }
+
         if (tab === 'movements') {
           const payload = (await response.json()) as PaginatedResponse<MovementLedgerEntry>
           setMovementRows(payload.items)
           setTotal(payload.total)
           setTotalPages(payload.total_pages)
-        } else {
-          const payload = (await response.json()) as PaginatedResponse<OperationLogEntry>
-          setOperationRows(payload.items)
-          setTotal(payload.total)
-          setTotalPages(payload.total_pages)
+          return
         }
+
+        const payload = (await response.json()) as PaginatedResponse<OperationLogEntry>
+        setOperationRows(payload.items)
+        setTotal(payload.total)
+        setTotalPages(payload.total_pages)
       } catch {
         setLoadError('目前無法讀取日誌資料，請稍後重試。')
       } finally {
@@ -164,40 +263,56 @@ export function LogsPage() {
 
   return (
     <SectionCard>
-      <div className="mb-4 flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant={tab === 'movements' ? 'default' : 'secondary'}
-          onClick={() => {
-            setTab('movements')
-            setPage(1)
-          }}
-        >
-          異動流水帳
-        </Button>
-        <Button
-          type="button"
-          variant={scope === 'all' ? 'default' : 'secondary'}
-          onClick={() => {
-            setScope((current) => (current === 'hot' ? 'all' : 'hot'))
-            setPage(1)
-          }}
-        >
-          包含歷史資料
-        </Button>
-        <Button
-          type="button"
-          variant={tab === 'operations' ? 'default' : 'secondary'}
-          onClick={() => {
-            setTab('operations')
-            setPage(1)
-          }}
-        >
-          操作日誌
-        </Button>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant={tab === 'movements' ? 'default' : 'secondary'}
+            onClick={() => {
+              setTab('movements')
+              setPage(1)
+            }}
+          >
+            異動流水帳
+          </Button>
+          <Button
+            type="button"
+            variant={tab === 'operations' ? 'default' : 'secondary'}
+            onClick={() => {
+              setTab('operations')
+              setPage(1)
+            }}
+          >
+            操作日誌
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger>欄位顯示</DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {tab === 'movements'
+                ? movementColumns.map((column) => (
+                    <DropdownMenuItem key={column.key} onClick={() => toggleMovementColumn(column.key)}>
+                      <span className="mr-2 inline-flex w-4 justify-center">{movementColumnVisibility[column.key] ? '✓' : ''}</span>
+                      {column.label}
+                    </DropdownMenuItem>
+                  ))
+                : operationColumns.map((column) => (
+                    <DropdownMenuItem key={column.key} onClick={() => toggleOperationColumn(column.key)}>
+                      <span className="mr-2 inline-flex w-4 justify-center">{operationColumnVisibility[column.key] ? '✓' : ''}</span>
+                      {column.label}
+                    </DropdownMenuItem>
+                  ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button type="button" variant="ghost" onClick={resetFilters} disabled={!hasActiveFilters}>
+            重設篩選
+          </Button>
+        </div>
       </div>
 
-      <FilterBar className="xl:grid-cols-[repeat(6,minmax(0,1fr))_auto]">
+      <div className="mb-4 grid gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] p-3 md:grid-cols-2 xl:grid-cols-[repeat(7,minmax(0,1fr))_auto]">
         <div className="grid gap-1.5">
           <Label htmlFor="logs-start-at">開始日期</Label>
           <Input
@@ -210,6 +325,7 @@ export function LogsPage() {
             }}
           />
         </div>
+
         <div className="grid gap-1.5">
           <Label htmlFor="logs-end-at">結束日期</Label>
           <Input
@@ -222,6 +338,7 @@ export function LogsPage() {
             }}
           />
         </div>
+
         <div className="grid gap-1.5">
           <Label htmlFor="logs-action">動作</Label>
           <Input
@@ -234,6 +351,7 @@ export function LogsPage() {
             }}
           />
         </div>
+
         <div className="grid gap-1.5">
           <Label htmlFor="logs-entity">實體</Label>
           <Input
@@ -246,6 +364,7 @@ export function LogsPage() {
             }}
           />
         </div>
+
         <div className="grid gap-1.5">
           <Label htmlFor="logs-item-id">品項 ID</Label>
           <Input
@@ -259,6 +378,7 @@ export function LogsPage() {
             }}
           />
         </div>
+
         <div className="grid gap-1.5">
           <Label htmlFor="logs-entity-id">單據 ID</Label>
           <Input
@@ -272,105 +392,81 @@ export function LogsPage() {
             }}
           />
         </div>
+
+        <div className="grid gap-1.5">
+          <Label>資料範圍</Label>
+          <div className="inline-flex w-fit items-center rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-1">
+            <Button
+              type="button"
+              size="sm"
+              variant={scope === 'hot' ? 'default' : 'ghost'}
+              onClick={() => {
+                setScope('hot')
+                setPage(1)
+              }}
+            >
+              近期資料
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={scope === 'all' ? 'default' : 'ghost'}
+              onClick={() => {
+                setScope('all')
+                setPage(1)
+              }}
+            >
+              含歷史資料
+            </Button>
+          </div>
+        </div>
+
         <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
-      </FilterBar>
+      </div>
 
       {loading ? <p className="m-0 rounded-md bg-[hsl(var(--card-soft))] px-3 py-2 text-sm">資料載入中...</p> : null}
       {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
 
-      {!loading && !loadError && tab === 'movements' ? (
+      {!loading && !loadError ? (
         <>
-          <div className="hidden overflow-x-auto md:block">
-            <Table>
+          <div className="overflow-x-auto rounded-md border border-[hsl(var(--border))]">
+            <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow>
-                  {['#', '時間', '品項', '狀態變更', '動作', '實體', '單據', '操作者'].map((header) => (
-                    <TableHead key={header}>{header}</TableHead>
+                  {(tab === 'movements' ? visibleMovementColumns : visibleOperationColumns).map((column) => (
+                    <TableHead key={column.key}>{column.label}</TableHead>
                   ))}
                 </TableRow>
               </TableHeader>
+
               <TableBody>
-                {movementRows.length === 0 ? (
+                {(tab === 'movements' ? movementRows : operationRows).length === 0 ? (
                   <TableRow>
-                    <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={8}>
-                      目前沒有符合條件的異動流水帳。
+                    <TableCell
+                      className="h-24 text-center text-[hsl(var(--muted-foreground))]"
+                      colSpan={tab === 'movements' ? visibleMovementColumns.length : visibleOperationColumns.length}
+                    >
+                      {tab === 'movements' ? '目前沒有符合條件的異動流水帳。' : '目前沒有符合條件的操作日誌。'}
                     </TableCell>
                   </TableRow>
-                ) : (
+                ) : tab === 'movements' ? (
                   movementRows.map((row) => (
                     <TableRow key={row.id}>
-                      <TableCell>{row.id}</TableCell>
-                      <TableCell>{row.created_at || '--'}</TableCell>
-                      <TableCell>
-                        <div className="font-semibold">{row.item_name || `#${row.item_id}`}</div>
-                        <div className="text-xs text-[hsl(var(--muted-foreground))]">{row.item_model || ''}</div>
-                      </TableCell>
-                      <TableCell>{`${row.from_status || '--'} -> ${row.to_status || '--'}`}</TableCell>
-                      <TableCell>{row.action || '--'}</TableCell>
-                      <TableCell>{row.entity || '--'}</TableCell>
-                      <TableCell>{row.entity_id ?? '--'}</TableCell>
-                      <TableCell>{row.operator || '--'}</TableCell>
+                      {visibleMovementColumns.map((column) => (
+                        <TableCell key={`${row.id}-${column.key}`} className={column.cellClassName}>
+                          {column.render(row)}
+                        </TableCell>
+                      ))}
                     </TableRow>
                   ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
-
-          <div className="grid gap-3 md:hidden">
-            {movementRows.length === 0 ? (
-              <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
-                目前沒有符合條件的異動流水帳。
-              </p>
-            ) : (
-              movementRows.map((row) => (
-                <article key={row.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
-                  <p className="m-0 text-sm font-semibold">#{row.id}</p>
-                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{row.created_at || '--'}</p>
-                  <p className="mt-2 mb-0 text-sm">
-                    品項：{row.item_name || `#${row.item_id}`} {row.item_model ? `(${row.item_model})` : ''}
-                  </p>
-                  <p className="mt-1 mb-0 text-sm">狀態：{`${row.from_status || '--'} -> ${row.to_status || '--'}`}</p>
-                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
-                    {row.action || '--'} / {row.entity || '--'} / #{row.entity_id ?? '--'} / {row.operator || '--'}
-                  </p>
-                </article>
-              ))
-            )}
-          </div>
-        </>
-      ) : null}
-
-      {!loading && !loadError && tab === 'operations' ? (
-        <>
-          <div className="hidden overflow-x-auto md:block">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  {['#', '時間', '動作', '實體', '單據', '狀態', '細節'].map((header) => (
-                    <TableHead key={header}>{header}</TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {operationRows.length === 0 ? (
-                  <TableRow>
-                    <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={7}>
-                      目前沒有符合條件的操作日誌。
-                    </TableCell>
-                  </TableRow>
                 ) : (
                   operationRows.map((row) => (
                     <TableRow key={row.id}>
-                      <TableCell>{row.id}</TableCell>
-                      <TableCell>{row.created_at || '--'}</TableCell>
-                      <TableCell>{row.action || '--'}</TableCell>
-                      <TableCell>{row.entity || '--'}</TableCell>
-                      <TableCell>{row.entity_id ?? '--'}</TableCell>
-                      <TableCell>{row.status || '--'}</TableCell>
-                      <TableCell className="max-w-[360px] truncate text-xs text-[hsl(var(--muted-foreground))]">
-                        {safeJsonPreview(row.detail)}
-                      </TableCell>
+                      {visibleOperationColumns.map((column) => (
+                        <TableCell key={`${row.id}-${column.key}`} className={column.cellClassName}>
+                          {column.render(row)}
+                        </TableCell>
+                      ))}
                     </TableRow>
                   ))
                 )}
@@ -378,40 +474,18 @@ export function LogsPage() {
             </Table>
           </div>
 
-          <div className="grid gap-3 md:hidden">
-            {operationRows.length === 0 ? (
-              <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
-                目前沒有符合條件的操作日誌。
-              </p>
-            ) : (
-              operationRows.map((row) => (
-                <article key={row.id} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
-                  <p className="m-0 text-sm font-semibold">#{row.id}</p>
-                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{row.created_at || '--'}</p>
-                  <p className="mt-2 mb-0 text-sm">
-                    {row.action || '--'} / {row.entity || '--'} / #{row.entity_id ?? '--'}
-                  </p>
-                  <p className="mt-1 mb-0 text-xs text-[hsl(var(--muted-foreground))]">狀態：{row.status || '--'}</p>
-                  <p className="mt-1 mb-0 break-all text-xs text-[hsl(var(--muted-foreground))]">{safeJsonPreview(row.detail)}</p>
-                </article>
-              ))
-            )}
-          </div>
+          <DataPagination
+            page={page}
+            pageSize={pageSize}
+            total={total}
+            totalPages={totalPages}
+            onPageChange={setPage}
+            onPageSizeChange={(nextPageSize) => {
+              setPageSize(nextPageSize)
+              setPage(1)
+            }}
+          />
         </>
-      ) : null}
-
-      {!loading && !loadError ? (
-        <DataPagination
-          page={page}
-          pageSize={pageSize}
-          total={total}
-          totalPages={totalPages}
-          onPageChange={setPage}
-          onPageSizeChange={(nextPageSize) => {
-            setPageSize(nextPageSize)
-            setPage(1)
-          }}
-        />
       ) : null}
     </SectionCard>
   )

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -112,3 +112,27 @@ export type DonationRequest = {
   memo: string
   items: DonationItem[]
 }
+
+export type MovementLedgerEntry = {
+  id: number
+  item_id: number
+  item_name: string
+  item_model: string
+  from_status: string
+  to_status: string
+  action: string
+  entity: string
+  entity_id?: number | null
+  operator: string
+  created_at: string
+}
+
+export type OperationLogEntry = {
+  id: number
+  action: string
+  entity: string
+  entity_id?: number | null
+  status: string
+  detail: Record<string, unknown>
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- redesign logs page to tasks-style data table layout
- add toolbar actions for reset filters and column visibility toggles
- unify mobile and desktop into one scrollable table view
- replace historical-data checkbox with data-range segmented toggle

## Validation
- npm run build (frontend)

Closes #14