### PR TITLE
feat: partial borrow pickup + dashboard reserved-borrow reminder (closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ VITE_API_BASE_URL=http://localhost:8000 npm run dev
 ## 交易規則（重要）
 
 - 領用/借用/捐贈目前為單件模式：每個 item 的 `quantity` 必須是 `1`
+- 借用預約 `borrow_date`、`due_date` 必填，且 `due_date` 不可早於 `borrow_date`
+- 借用預約天數上限為 30 天（`due_date - borrow_date <= 30`）
 - 建立或更新捐贈單時 `recipient` 必填
 - 交易會檢查品項可用性，不可重複占用或占用不可用資產
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -89,6 +89,8 @@ uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ## 規則與資料行為
 
 - 領用/借用/捐贈為單件模式：`quantity` 必須是 `1`
+- 借用預約 `borrow_date`、`due_date` 必填，且 `due_date` 不可早於 `borrow_date`
+- 借用預約天數上限為 30 天（`due_date - borrow_date <= 30`）
 - 捐贈單建立與更新時 `recipient` 必填
 - API 會驗證 item 可用性，避免重複占用
 - 刪除採軟刪除，超過 6 個月自動清除

--- a/backend/db.py
+++ b/backend/db.py
@@ -2534,6 +2534,65 @@ def list_borrow_items(request_id: int) -> list[dict[str, Any]]:
     return list_borrow_items_map({request_id}).get(request_id, [])
 
 
+def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | None:
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+        request_rows = _read_rows(request_ws)
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        if request_row is None:
+            return None
+        status = _to_str(request_row.get("status")).strip().lower()
+        if status not in {"reserved", "expired"}:
+            raise ValueError("only reserved request can be picked up")
+        if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
+            raise ValueError("borrow request already allocated")
+
+    candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    request_lines = sorted(
+        (row for row in line_rows if _to_int(row.get("request_id")) == request_id),
+        key=lambda row: _to_int(row.get("id")),
+    )
+    if not request_lines:
+        raise ValueError("request_lines is required")
+
+    results: list[dict[str, Any]] = []
+    for line in request_lines:
+        line_id = _to_int(line.get("id"))
+        item_name = _to_str(line.get("item_name"))
+        item_model = _to_str(line.get("item_model"))
+        key = _borrow_key(item_name, item_model)
+        candidates = candidates_by_key.get(key, [])
+        results.append(
+            {
+                "line_id": line_id,
+                "item_name": item_name,
+                "item_model": item_model,
+                "requested_qty": _to_int(line.get("requested_qty")),
+                "candidates": [
+                    {
+                        "id": _to_int(item.get("id")),
+                        "n_property_sn": _to_str(item.get("n_property_sn")),
+                        "property_sn": _to_str(item.get("property_sn")),
+                        "n_item_sn": _to_str(item.get("n_item_sn")),
+                        "item_sn": _to_str(item.get("item_sn")),
+                    }
+                    for item in candidates
+                ],
+            }
+        )
+    return results
+
+
 def list_borrow_reservation_options(*, exclude_request_id: int | None = None) -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         request_rows = _read_rows(wb["borrow_requests"])
@@ -2661,7 +2720,7 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], request
         return True
 
 
-def pickup_borrow_request(request_id: int) -> bool:
+def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
@@ -2693,16 +2752,44 @@ def pickup_borrow_request(request_id: int) -> bool:
         if not target_lines:
             raise ValueError("request_lines is required")
 
-        required_totals: dict[tuple[str, str], int] = {}
-        for row in target_lines:
-            key = _borrow_key(row.get("item_name"), row.get("item_model"))
-            required_totals[key] = required_totals.get(key, 0) + _to_int(row.get("requested_qty"))
+        line_map = {_to_int(row.get("id")): row for row in target_lines}
+        target_line_ids = set(line_map.keys())
+        if not selections_data:
+            raise ValueError("pickup selections are required")
 
-        candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
-        available_totals = {key: len(rows) for key, rows in candidates_by_key.items()}
-        shortages = _collect_shortages(required_totals, available_totals)
-        if shortages:
-            raise ValueError(json.dumps({"message": "insufficient_pickup_quantity", "shortages": shortages}, ensure_ascii=False))
+        selections_by_line: dict[int, list[int]] = {}
+        selected_item_ids: set[int] = set()
+        for row in selections_data:
+            line_id = _to_int(row.get("line_id"))
+            if line_id not in target_line_ids:
+                raise ValueError(f"line_id {line_id} does not belong to request")
+            if line_id in selections_by_line:
+                raise ValueError(f"line_id {line_id} duplicated in pickup selections")
+            raw_item_ids = row.get("item_ids")
+            if not isinstance(raw_item_ids, list):
+                raise ValueError(f"item_ids for line_id {line_id} must be a list")
+            line_item_ids: list[int] = []
+            line_seen: set[int] = set()
+            for raw_item_id in raw_item_ids:
+                item_id = _to_int(raw_item_id)
+                if item_id <= 0:
+                    raise ValueError(f"invalid item_id in line_id {line_id}")
+                if item_id in line_seen:
+                    raise ValueError(f"item_id {item_id} duplicated in line_id {line_id}")
+                if item_id in selected_item_ids:
+                    raise ValueError(f"item_id {item_id} duplicated across lines")
+                line_seen.add(item_id)
+                selected_item_ids.add(item_id)
+                line_item_ids.append(item_id)
+            selections_by_line[line_id] = line_item_ids
+
+        if set(selections_by_line.keys()) != target_line_ids:
+            missing = sorted(target_line_ids - set(selections_by_line.keys()))
+            extra = sorted(set(selections_by_line.keys()) - target_line_ids)
+            if missing:
+                raise ValueError(f"missing pickup selections for line_ids: {','.join(str(value) for value in missing)}")
+            if extra:
+                raise ValueError(f"unexpected line_ids in pickup selections: {','.join(str(value) for value in extra)}")
 
         inventory_map = _active_inventory_rows_map(inventory_rows)
         next_allocation_id = _next_id(allocation_rows)
@@ -2711,13 +2798,14 @@ def pickup_borrow_request(request_id: int) -> bool:
             line_id = _to_int(line.get("id"))
             key = _borrow_key(line.get("item_name"), line.get("item_model"))
             requested_qty = _to_int(line.get("requested_qty"))
-            candidates = candidates_by_key.get(key, [])
-            for _ in range(requested_qty):
-                if not candidates:
-                    raise ValueError("insufficient pickup candidates")
-                picked = candidates.pop(0)
-                item_id = _to_int(picked.get("id"))
+            selected_ids = selections_by_line.get(line_id, [])
+            if len(selected_ids) != requested_qty:
+                raise ValueError(f"line_id {line_id} requires {requested_qty} items")
+            for item_id in selected_ids:
                 inventory_row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+                item_key = _borrow_key(inventory_row.get("name"), inventory_row.get("model"))
+                if item_key != key:
+                    raise ValueError(f"item_id {item_id} does not match line_id {line_id}")
                 _set_inventory_status_with_movement(
                     movement_rows=movement_rows,
                     row=inventory_row,

--- a/backend/db.py
+++ b/backend/db.py
@@ -16,6 +16,7 @@ LOCK_PATH = BASE_DIR / "inventory.xlsx.lock"
 ASSET_CATEGORY_NAME_PATH = BASE_DIR.parent / "asset_category_name.xlsx"
 LOG_ARCHIVE_DIR = BASE_DIR / "log_archive"
 HOT_LOG_RETENTION_DAYS = 90
+MAX_BORROW_RESERVATION_DAYS = 30
 ARCHIVE_FILE_PATTERN = re.compile(r"^logs_(\d{6})\.xlsx$")
 
 SHEETS: dict[str, list[str]] = {
@@ -2174,6 +2175,27 @@ def _normalize_borrow_request_lines(lines: list[dict[str, Any]]) -> list[dict[st
     return normalized
 
 
+def _validate_borrow_request_dates(*, borrow_date_value: Any, due_date_value: Any) -> None:
+    borrow_date_raw = _to_str(borrow_date_value).strip()
+    due_date_raw = _to_str(due_date_value).strip()
+    if not borrow_date_raw:
+        raise ValueError("borrow_date is required")
+    if not due_date_raw:
+        raise ValueError("due_date is required")
+
+    borrow_date = _parse_request_date(borrow_date_raw)
+    if borrow_date is None:
+        raise ValueError("invalid borrow_date format")
+    due_date = _parse_request_date(due_date_raw)
+    if due_date is None:
+        raise ValueError("invalid due_date format")
+
+    if due_date < borrow_date:
+        raise ValueError("due_date cannot be earlier than borrow_date")
+    if (due_date - borrow_date).days > MAX_BORROW_RESERVATION_DAYS:
+        raise ValueError(f"borrow reservation cannot exceed {MAX_BORROW_RESERVATION_DAYS} days")
+
+
 def _build_borrow_reservation_usage(
     *,
     request_rows: list[dict[str, Any]],
@@ -2324,6 +2346,10 @@ def _sync_borrow_statuses_in_place(
 
 
 def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict[str, Any]]) -> int:
+    _validate_borrow_request_dates(
+        borrow_date_value=request_data.get("borrow_date"),
+        due_date_value=request_data.get("due_date"),
+    )
     normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
@@ -2534,6 +2560,219 @@ def list_borrow_items(request_id: int) -> list[dict[str, Any]]:
     return list_borrow_items_map({request_id}).get(request_id, [])
 
 
+def _validate_pickup_request_context(
+    *,
+    request_id: int,
+    request_rows: list[dict[str, Any]],
+    line_rows: list[dict[str, Any]],
+    allocation_rows: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+    if request_row is None:
+        return None, []
+    status = _to_str(request_row.get("status")).strip().lower()
+    if status not in {"reserved", "expired"}:
+        raise ValueError("only reserved request can be picked up")
+    if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
+        raise ValueError("borrow request already allocated")
+    request_lines = sorted(
+        (row for row in line_rows if _to_int(row.get("request_id")) == request_id),
+        key=lambda row: _to_int(row.get("id")),
+    )
+    if not request_lines:
+        raise ValueError("request_lines is required")
+    return request_row, request_lines
+
+
+def _normalize_scan_code(value: Any) -> str:
+    return _to_str(value).strip().lower()
+
+
+def _inventory_serial_values(row: dict[str, Any]) -> list[str]:
+    return [
+        _normalize_scan_code(row.get("n_property_sn")),
+        _normalize_scan_code(row.get("property_sn")),
+        _normalize_scan_code(row.get("n_item_sn")),
+        _normalize_scan_code(row.get("item_sn")),
+    ]
+
+
+def list_borrow_pickup_lines(request_id: int) -> list[dict[str, Any]] | None:
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+        request_rows = _read_rows(request_ws)
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row, request_lines = _validate_pickup_request_context(
+            request_id=request_id,
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+        )
+        if request_row is None:
+            return None
+
+    candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    summaries: list[dict[str, Any]] = []
+    for line in request_lines:
+        key = _borrow_key(line.get("item_name"), line.get("item_model"))
+        summaries.append(
+            {
+                "line_id": _to_int(line.get("id")),
+                "item_name": _to_str(line.get("item_name")),
+                "item_model": _to_str(line.get("item_model")),
+                "requested_qty": _to_int(line.get("requested_qty")),
+                "candidate_count": len(candidates_by_key.get(key, [])),
+            }
+        )
+    return summaries
+
+
+def list_borrow_pickup_line_candidates(
+    request_id: int,
+    line_id: int,
+    *,
+    keyword: str = "",
+    page: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | None:
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+        request_rows = _read_rows(request_ws)
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row, request_lines = _validate_pickup_request_context(
+            request_id=request_id,
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+        )
+        if request_row is None:
+            return None
+
+    target_line = next((row for row in request_lines if _to_int(row.get("id")) == line_id), None)
+    if target_line is None:
+        raise ValueError("line_id does not belong to request")
+
+    key = _borrow_key(target_line.get("item_name"), target_line.get("item_model"))
+    candidates = _build_inventory_candidates_by_key(inventory_rows).get(key, [])
+    normalized_keyword = _normalize_scan_code(keyword)
+    if normalized_keyword:
+        filtered_candidates: list[dict[str, Any]] = []
+        for item in candidates:
+            serial_values = _inventory_serial_values(item)
+            if any(normalized_keyword in serial_value for serial_value in serial_values if serial_value):
+                filtered_candidates.append(item)
+        candidates = filtered_candidates
+
+    total = len(candidates)
+    total_pages = max((total + page_size - 1) // page_size, 1)
+    start = (page - 1) * page_size
+    end = start + page_size
+    paged_candidates = candidates[start:end]
+    return {
+        "line_id": _to_int(target_line.get("id")),
+        "item_name": _to_str(target_line.get("item_name")),
+        "item_model": _to_str(target_line.get("item_model")),
+        "requested_qty": _to_int(target_line.get("requested_qty")),
+        "items": [
+            {
+                "id": _to_int(item.get("id")),
+                "n_property_sn": _to_str(item.get("n_property_sn")),
+                "property_sn": _to_str(item.get("property_sn")),
+                "n_item_sn": _to_str(item.get("n_item_sn")),
+                "item_sn": _to_str(item.get("item_sn")),
+            }
+            for item in paged_candidates
+        ],
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "total_pages": total_pages,
+    }
+
+
+def resolve_borrow_pickup_scan(request_id: int, code: str) -> dict[str, Any] | None:
+    normalized_code = _normalize_scan_code(code)
+    if not normalized_code:
+        raise ValueError("scan code is required")
+
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+        request_rows = _read_rows(request_ws)
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row, request_lines = _validate_pickup_request_context(
+            request_id=request_id,
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+        )
+        if request_row is None:
+            return None
+
+    candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    eligible_line_ids_by_key: dict[tuple[str, str], list[int]] = {}
+    for line in request_lines:
+        key = _borrow_key(line.get("item_name"), line.get("item_model"))
+        eligible_line_ids_by_key.setdefault(key, []).append(_to_int(line.get("id")))
+
+    matched_item: dict[str, Any] | None = None
+    matched_key: tuple[str, str] | None = None
+    for key, candidates in candidates_by_key.items():
+        for item in candidates:
+            serial_values = _inventory_serial_values(item)
+            if normalized_code in serial_values:
+                if matched_item is not None:
+                    raise ValueError("scan code matches multiple items")
+                matched_item = item
+                matched_key = key
+
+    if matched_item is None or matched_key is None:
+        raise ValueError("scan code not found")
+
+    eligible_line_ids = eligible_line_ids_by_key.get(matched_key, [])
+    if not eligible_line_ids:
+        raise ValueError("scanned item does not belong to this request")
+
+    return {
+        "item": {
+            "id": _to_int(matched_item.get("id")),
+            "n_property_sn": _to_str(matched_item.get("n_property_sn")),
+            "property_sn": _to_str(matched_item.get("property_sn")),
+            "n_item_sn": _to_str(matched_item.get("n_item_sn")),
+            "item_sn": _to_str(matched_item.get("item_sn")),
+            "item_name": _to_str(matched_item.get("name")),
+            "item_model": _to_str(matched_item.get("model")),
+        },
+        "eligible_line_ids": eligible_line_ids,
+    }
+
+
 def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
@@ -2548,23 +2787,16 @@ def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | Non
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
         )
-        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        request_row, request_lines = _validate_pickup_request_context(
+            request_id=request_id,
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+        )
         if request_row is None:
             return None
-        status = _to_str(request_row.get("status")).strip().lower()
-        if status not in {"reserved", "expired"}:
-            raise ValueError("only reserved request can be picked up")
-        if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
-            raise ValueError("borrow request already allocated")
 
     candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
-    request_lines = sorted(
-        (row for row in line_rows if _to_int(row.get("request_id")) == request_id),
-        key=lambda row: _to_int(row.get("id")),
-    )
-    if not request_lines:
-        raise ValueError("request_lines is required")
-
     results: list[dict[str, Any]] = []
     for line in request_lines:
         line_id = _to_int(line.get("id"))
@@ -2641,6 +2873,10 @@ def list_borrow_reservation_options(*, exclude_request_id: int | None = None) ->
 
 
 def update_borrow_request(request_id: int, request_data: dict[str, Any], request_lines: list[dict[str, Any]]) -> bool:
+    _validate_borrow_request_dates(
+        borrow_date_value=request_data.get("borrow_date"),
+        due_date_value=request_data.get("due_date"),
+    )
     normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]

--- a/backend/db.py
+++ b/backend/db.py
@@ -17,6 +17,7 @@ ASSET_CATEGORY_NAME_PATH = BASE_DIR.parent / "asset_category_name.xlsx"
 LOG_ARCHIVE_DIR = BASE_DIR / "log_archive"
 HOT_LOG_RETENTION_DAYS = 90
 MAX_BORROW_RESERVATION_DAYS = 30
+BORROW_RESERVATION_CANCEL_AFTER_DAYS = 3
 ARCHIVE_FILE_PATTERN = re.compile(r"^logs_(\d{6})\.xlsx$")
 
 SHEETS: dict[str, list[str]] = {
@@ -1164,6 +1165,28 @@ def log_inventory_action(
         wb.save(DB_PATH)
 
 
+def _append_operation_log_entry(
+    operation_rows: list[dict[str, Any]],
+    *,
+    action: str,
+    entity: str = "inventory_item",
+    entity_id: int | None = None,
+    status: str = "success",
+    detail: dict[str, Any] | None = None,
+) -> None:
+    operation_rows.append(
+        {
+            "id": _next_id(operation_rows),
+            "action": action,
+            "entity": entity,
+            "entity_id": entity_id if entity_id is not None else "",
+            "status": status,
+            "detail": json.dumps(detail or {}, ensure_ascii=False),
+            "created_at": _now_str(),
+        }
+    )
+
+
 def _append_movement_ledger_entry(
     movement_rows: list[dict[str, Any]],
     *,
@@ -2126,8 +2149,12 @@ def _derive_borrow_status(
     status = _to_str(status_value).strip().lower()
     borrow_date = _parse_request_date(borrow_date_value)
     if not has_allocations:
-        if borrow_date is not None and borrow_date < now:
-            return "expired"
+        if borrow_date is not None:
+            overdue_days = (now - borrow_date).days
+            if overdue_days >= BORROW_RESERVATION_CANCEL_AFTER_DAYS:
+                return "cancelled"
+            if overdue_days >= 1:
+                return "expired"
         if status in {"expired", "cancelled"}:
             return status
         return "reserved"
@@ -2323,6 +2350,7 @@ def _sync_borrow_statuses_in_place(
     request_rows: list[dict[str, Any]],
     allocation_rows: list[dict[str, Any]],
     legacy_item_rows: list[dict[str, Any]] | None = None,
+    operation_rows: list[dict[str, Any]] | None = None,
     today: date | None = None,
 ) -> bool:
     legacy_rows = legacy_item_rows or []
@@ -2336,12 +2364,33 @@ def _sync_borrow_statuses_in_place(
     status_changed = False
     for row in request_rows:
         request_id = _to_int(row.get("id"))
+        previous_status = _to_str(row.get("status")).strip().lower()
         if _normalize_borrow_status_in_place(
             row,
             has_allocations=allocation_count_map.get(request_id, 0) > 0,
             today=today,
         ):
             status_changed = True
+            next_status = _to_str(row.get("status")).strip().lower()
+            if previous_status != "cancelled" and next_status == "cancelled" and operation_rows is not None:
+                borrow_date = _parse_request_date(row.get("borrow_date"))
+                expired_days = 0
+                if borrow_date is not None:
+                    current_day = today or date.today()
+                    expired_days = max((current_day - borrow_date).days, 0)
+                _append_operation_log_entry(
+                    operation_rows,
+                    action="auto_cancel_reservation",
+                    entity="borrow_request",
+                    entity_id=request_id if request_id > 0 else None,
+                    detail={
+                        "request_id": request_id if request_id > 0 else None,
+                        "borrower": _to_str(row.get("borrower")),
+                        "borrow_date": _to_str(row.get("borrow_date")),
+                        "expired_days": expired_days,
+                        "rule_days": BORROW_RESERVATION_CANCEL_AFTER_DAYS,
+                    },
+                )
     return status_changed
 
 
@@ -2353,18 +2402,21 @@ def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict
     normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_ws = wb["borrow_request_lines"]
         allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
         line_rows = _read_rows(line_ws)
         allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
 
         requested_totals: dict[tuple[str, str], int] = {}
@@ -2418,6 +2470,8 @@ def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict
         _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
         _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        if status_changed:
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
         wb.save(DB_PATH)
         return request_id
 
@@ -2425,16 +2479,20 @@ def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict
 def list_borrow_requests() -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
+        operation_rows = _read_rows(operation_ws)
         rows = _read_rows(request_ws)
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
         if status_changed:
             _write_rows(request_ws, SHEETS["borrow_requests"], rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
             wb.save(DB_PATH)
     allocation_count_map: dict[int, int] = {}
     for row in allocation_rows:
@@ -2459,13 +2517,16 @@ def list_borrow_requests() -> list[dict[str, Any]]:
 def get_borrow_request(request_id: int) -> dict[str, Any] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
+        operation_rows = _read_rows(operation_ws)
         rows = _read_rows(request_ws)
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
         target_row: dict[str, Any] | None = None
         for row in rows:
@@ -2475,6 +2536,7 @@ def get_borrow_request(request_id: int) -> dict[str, Any] | None:
             break
         if status_changed:
             _write_rows(request_ws, SHEETS["borrow_requests"], rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
             wb.save(DB_PATH)
     if target_row is None:
         return None
@@ -2600,17 +2662,24 @@ def _inventory_serial_values(row: dict[str, Any]) -> list[str]:
 def list_borrow_pickup_lines(request_id: int) -> list[dict[str, Any]] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_rows = _read_rows(wb["borrow_request_lines"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
         inventory_rows = _read_rows(wb["inventory_items"])
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
+        if status_changed:
+            _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
+            wb.save(DB_PATH)
         request_row, request_lines = _validate_pickup_request_context(
             request_id=request_id,
             request_rows=request_rows,
@@ -2646,17 +2715,24 @@ def list_borrow_pickup_line_candidates(
 ) -> dict[str, Any] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_rows = _read_rows(wb["borrow_request_lines"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
         inventory_rows = _read_rows(wb["inventory_items"])
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
+        if status_changed:
+            _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
+            wb.save(DB_PATH)
         request_row, request_lines = _validate_pickup_request_context(
             request_id=request_id,
             request_rows=request_rows,
@@ -2715,17 +2791,24 @@ def resolve_borrow_pickup_scan(request_id: int, code: str) -> dict[str, Any] | N
 
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_rows = _read_rows(wb["borrow_request_lines"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
         inventory_rows = _read_rows(wb["inventory_items"])
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
+        if status_changed:
+            _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
+            wb.save(DB_PATH)
         request_row, request_lines = _validate_pickup_request_context(
             request_id=request_id,
             request_rows=request_rows,
@@ -2776,17 +2859,24 @@ def resolve_borrow_pickup_scan(request_id: int, code: str) -> dict[str, Any] | N
 def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_rows = _read_rows(wb["borrow_request_lines"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
         inventory_rows = _read_rows(wb["inventory_items"])
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
+        if status_changed:
+            _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
+            wb.save(DB_PATH)
         request_row, request_lines = _validate_pickup_request_context(
             request_id=request_id,
             request_rows=request_rows,
@@ -2827,17 +2917,24 @@ def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | Non
 
 def list_borrow_reservation_options(*, exclude_request_id: int | None = None) -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
-        request_rows = _read_rows(wb["borrow_requests"])
+        request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
+        request_rows = _read_rows(request_ws)
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_rows = _read_rows(wb["borrow_request_lines"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
         inventory_rows = _read_rows(wb["inventory_items"])
-
-    _sync_borrow_statuses_in_place(
-        request_rows=request_rows,
-        allocation_rows=allocation_rows,
-        legacy_item_rows=legacy_item_rows,
-    )
+        operation_rows = _read_rows(operation_ws)
+        status_changed = _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
+        )
+        if status_changed:
+            _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
+            wb.save(DB_PATH)
     reserved_usage = _build_borrow_reservation_usage(
         request_rows=request_rows,
         line_rows=line_rows,
@@ -2880,18 +2977,21 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], request
     normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_ws = wb["borrow_request_lines"]
         allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
         line_rows = _read_rows(line_ws)
         allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
 
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
@@ -2952,6 +3052,8 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], request
         _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
         _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        if status_changed:
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
         wb.save(DB_PATH)
         return True
 
@@ -2959,21 +3061,24 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], request
 def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_ws = wb["borrow_request_lines"]
         allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
         movement_ws = wb["movement_ledger"]
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
         line_rows = _read_rows(line_ws)
         allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
         movement_rows = _read_rows(movement_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
         if request_row is None:
@@ -3076,6 +3181,8 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
         _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
+        if status_changed:
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
         wb.save(DB_PATH)
         return True
 
@@ -3083,21 +3190,24 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
 def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         line_ws = wb["borrow_request_lines"]
         allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
         movement_ws = wb["movement_ledger"]
+        operation_rows = _read_rows(operation_ws)
         request_rows = _read_rows(request_ws)
         line_rows = _read_rows(line_ws)
         allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
         movement_rows = _read_rows(movement_ws)
 
-        _sync_borrow_statuses_in_place(
+        status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
             legacy_item_rows=legacy_item_rows,
+            operation_rows=operation_rows,
         )
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
         if request_row is None:
@@ -3138,6 +3248,8 @@ def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> 
         _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
+        if status_changed:
+            _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
         wb.save(DB_PATH)
         return True
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -847,10 +847,11 @@ def get_dashboard_snapshot() -> dict[str, Any]:
         request_id = _to_int(row.get("request_id"))
         borrow_item_count_map[request_id] = borrow_item_count_map.get(request_id, 0) + 1
 
-    borrow_allocation_count_map: dict[int, int] = {}
-    for row in borrow_allocation_rows:
-        request_id = _to_int(row.get("request_id"))
-        borrow_allocation_count_map[request_id] = borrow_allocation_count_map.get(request_id, 0) + 1
+    borrow_request_allocations, _ = _build_borrow_allocation_stats(
+        allocation_rows=borrow_allocation_rows,
+        legacy_item_rows=borrow_item_rows,
+    )
+    borrow_requested_qty_by_request = _build_borrow_requested_qty_by_request(borrow_line_rows)
 
     donation_item_count_map: dict[int, int] = {}
     for row in donation_item_rows:
@@ -873,17 +874,20 @@ def get_dashboard_snapshot() -> dict[str, Any]:
             }
         )
 
+    reserved_borrow_count = 0
     overdue_borrow_count = 0
     due_soon_borrow_count = 0
     for row in borrow_request_rows:
         request_id = _to_int(row.get("id"))
         _normalize_borrow_status_in_place(
             row,
-            has_allocations=borrow_allocation_count_map.get(request_id, 0) > 0
-            or borrow_item_count_map.get(request_id, 0) > 0,
+            has_allocations=borrow_request_allocations.get(request_id, 0) > 0,
+            is_fully_allocated=borrow_request_allocations.get(request_id, 0) >= borrow_requested_qty_by_request.get(request_id, 0),
         )
         status = _to_str(row.get("status")).strip()
         item_count = borrow_item_count_map.get(request_id, 0)
+        if status == "reserved":
+            reserved_borrow_count += 1
         if status == "overdue":
             overdue_borrow_count += 1
         if status in {"borrowed", "overdue"} and _is_due_soon(
@@ -926,6 +930,7 @@ def get_dashboard_snapshot() -> dict[str, Any]:
         "items": len(active_inventory_rows),
         "pendingFix": pending_fix_count,
         "totalRecords": len(issue_request_rows) + len(borrow_request_rows) + len(donation_request_rows),
+        "reservedBorrowCount": reserved_borrow_count,
         "overdueBorrowCount": overdue_borrow_count,
         "dueSoonBorrowCount": due_soon_borrow_count,
         "donatedItemsCount": donated_count,
@@ -2113,7 +2118,7 @@ def delete_donation_request(request_id: int) -> bool:
 
 def _borrow_status_uses_inventory(status: Any) -> bool:
     normalized = _to_str(status).strip().lower()
-    return normalized in {"borrowed", "overdue"}
+    return normalized in {"partial_borrowed", "borrowed", "overdue"}
 
 
 def _parse_request_date(value: Any) -> date | None:
@@ -2139,6 +2144,7 @@ def _derive_borrow_status(
     status_value: Any = "",
     borrow_date_value: Any = "",
     has_allocations: bool = False,
+    is_fully_allocated: bool = True,
     today: date | None = None,
 ) -> str:
     now = today or date.today()
@@ -2162,6 +2168,8 @@ def _derive_borrow_status(
     due_date = _parse_request_date(due_date_value)
     if due_date is not None and due_date < now:
         return "overdue"
+    if not is_fully_allocated:
+        return "partial_borrowed"
     return "borrowed"
 
 
@@ -2221,6 +2229,39 @@ def _validate_borrow_request_dates(*, borrow_date_value: Any, due_date_value: An
         raise ValueError("due_date cannot be earlier than borrow_date")
     if (due_date - borrow_date).days > MAX_BORROW_RESERVATION_DAYS:
         raise ValueError(f"borrow reservation cannot exceed {MAX_BORROW_RESERVATION_DAYS} days")
+
+
+def _build_borrow_allocation_stats(
+    *,
+    allocation_rows: list[dict[str, Any]],
+    legacy_item_rows: list[dict[str, Any]] | None = None,
+) -> tuple[dict[int, int], dict[int, int]]:
+    legacy_rows = legacy_item_rows or []
+    request_allocations: dict[int, int] = {}
+    line_allocations: dict[int, int] = {}
+    for row in allocation_rows:
+        request_id = _to_int(row.get("request_id"))
+        line_id = _to_int(row.get("line_id"))
+        if request_id > 0:
+            request_allocations[request_id] = request_allocations.get(request_id, 0) + 1
+        if line_id > 0:
+            line_allocations[line_id] = line_allocations.get(line_id, 0) + 1
+    for row in legacy_rows:
+        request_id = _to_int(row.get("request_id"))
+        item_id = _to_int(row.get("item_id"))
+        if request_id > 0 and item_id > 0:
+            request_allocations[request_id] = request_allocations.get(request_id, 0) + 1
+    return request_allocations, line_allocations
+
+
+def _build_borrow_requested_qty_by_request(line_rows: list[dict[str, Any]]) -> dict[int, int]:
+    requested_by_request: dict[int, int] = {}
+    for row in line_rows:
+        request_id = _to_int(row.get("request_id"))
+        if request_id <= 0:
+            continue
+        requested_by_request[request_id] = requested_by_request.get(request_id, 0) + _to_int(row.get("requested_qty"))
+    return requested_by_request
 
 
 def _build_borrow_reservation_usage(
@@ -2312,6 +2353,7 @@ def _normalize_borrow_status_in_place(
     row: dict[str, Any],
     *,
     has_allocations: bool = False,
+    is_fully_allocated: bool = True,
     today: date | None = None,
 ) -> bool:
     next_status = _derive_borrow_status(
@@ -2320,6 +2362,7 @@ def _normalize_borrow_status_in_place(
         status_value=row.get("status"),
         borrow_date_value=row.get("borrow_date"),
         has_allocations=has_allocations,
+        is_fully_allocated=is_fully_allocated,
         today=today,
     )
     previous_status = _to_str(row.get("status")).strip()
@@ -2329,7 +2372,13 @@ def _normalize_borrow_status_in_place(
     return True
 
 
-def _to_borrow_api_row(row: dict[str, Any], *, has_allocations: bool = False, today: date | None = None) -> dict[str, Any]:
+def _to_borrow_api_row(
+    row: dict[str, Any],
+    *,
+    has_allocations: bool = False,
+    is_fully_allocated: bool = True,
+    today: date | None = None,
+) -> dict[str, Any]:
     normalized = dict(row)
     normalized["status"] = _derive_borrow_status(
         due_date_value=row.get("due_date"),
@@ -2337,9 +2386,10 @@ def _to_borrow_api_row(row: dict[str, Any], *, has_allocations: bool = False, to
         status_value=row.get("status"),
         borrow_date_value=row.get("borrow_date"),
         has_allocations=has_allocations,
+        is_fully_allocated=is_fully_allocated,
         today=today,
     )
-    normalized["is_due_soon"] = normalized["status"] in {"borrowed", "overdue"} and _is_due_soon(
+    normalized["is_due_soon"] = normalized["status"] in {"partial_borrowed", "borrowed", "overdue"} and _is_due_soon(
         due_date_value=row.get("due_date"), return_date_value=row.get("return_date"), today=today, days=3
     )
     return normalized
@@ -2349,25 +2399,29 @@ def _sync_borrow_statuses_in_place(
     *,
     request_rows: list[dict[str, Any]],
     allocation_rows: list[dict[str, Any]],
+    line_rows: list[dict[str, Any]] | None = None,
     legacy_item_rows: list[dict[str, Any]] | None = None,
     operation_rows: list[dict[str, Any]] | None = None,
     today: date | None = None,
 ) -> bool:
     legacy_rows = legacy_item_rows or []
-    allocation_count_map: dict[int, int] = {}
-    for row in allocation_rows:
-        request_id = _to_int(row.get("request_id"))
-        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
-    for row in legacy_rows:
-        request_id = _to_int(row.get("request_id"))
-        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    request_allocations, _ = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_rows,
+    )
+    requested_qty_by_request = _build_borrow_requested_qty_by_request(line_rows or [])
     status_changed = False
     for row in request_rows:
         request_id = _to_int(row.get("id"))
+        allocated_qty = request_allocations.get(request_id, 0)
+        has_allocations = allocated_qty > 0
+        requested_qty = requested_qty_by_request.get(request_id, 0)
+        is_fully_allocated = not has_allocations or requested_qty <= 0 or allocated_qty >= requested_qty
         previous_status = _to_str(row.get("status")).strip().lower()
         if _normalize_borrow_status_in_place(
             row,
-            has_allocations=allocation_count_map.get(request_id, 0) > 0,
+            has_allocations=has_allocations,
+            is_fully_allocated=is_fully_allocated,
             today=today,
         ):
             status_changed = True
@@ -2415,6 +2469,7 @@ def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2479,6 +2534,7 @@ def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict
 def list_borrow_requests() -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        line_rows = _read_rows(wb["borrow_request_lines"])
         operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
@@ -2487,6 +2543,7 @@ def list_borrow_requests() -> list[dict[str, Any]]:
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2494,18 +2551,19 @@ def list_borrow_requests() -> list[dict[str, Any]]:
             _write_rows(request_ws, SHEETS["borrow_requests"], rows)
             _write_rows(operation_ws, SHEETS["operation_logs"], operation_rows)
             wb.save(DB_PATH)
-    allocation_count_map: dict[int, int] = {}
-    for row in allocation_rows:
-        request_id = _to_int(row.get("request_id"))
-        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
-    for row in legacy_item_rows:
-        request_id = _to_int(row.get("request_id"))
-        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    request_allocations, _ = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+    )
+    requested_qty_by_request = _build_borrow_requested_qty_by_request(line_rows)
     return sorted(
         (
             _to_borrow_api_row(
                 row,
-                has_allocations=allocation_count_map.get(_to_int(row.get("id")), 0) > 0,
+                has_allocations=request_allocations.get(_to_int(row.get("id")), 0) > 0,
+                is_fully_allocated=(
+                    request_allocations.get(_to_int(row.get("id")), 0) >= requested_qty_by_request.get(_to_int(row.get("id")), 0)
+                ),
             )
             for row in rows
         ),
@@ -2517,6 +2575,7 @@ def list_borrow_requests() -> list[dict[str, Any]]:
 def get_borrow_request(request_id: int) -> dict[str, Any] | None:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
+        line_rows = _read_rows(wb["borrow_request_lines"])
         operation_ws = wb["operation_logs"]
         legacy_item_rows = _read_rows(wb["borrow_items"])
         allocation_rows = _read_rows(wb["borrow_allocations"])
@@ -2525,6 +2584,7 @@ def get_borrow_request(request_id: int) -> dict[str, Any] | None:
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2540,10 +2600,17 @@ def get_borrow_request(request_id: int) -> dict[str, Any] | None:
             wb.save(DB_PATH)
     if target_row is None:
         return None
-    has_allocations = any(_to_int(row.get("request_id")) == request_id for row in allocation_rows) or any(
-        _to_int(row.get("request_id")) == request_id for row in legacy_item_rows
+    request_allocations, _ = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
     )
-    return _to_borrow_api_row(target_row, has_allocations=has_allocations)
+    requested_qty_by_request = _build_borrow_requested_qty_by_request(line_rows)
+    allocated_qty = request_allocations.get(request_id, 0)
+    return _to_borrow_api_row(
+        target_row,
+        has_allocations=allocated_qty > 0,
+        is_fully_allocated=allocated_qty >= requested_qty_by_request.get(request_id, 0),
+    )
 
 
 def list_borrow_items_map(request_ids: set[int] | None = None) -> dict[int, list[dict[str, Any]]]:
@@ -2633,10 +2700,8 @@ def _validate_pickup_request_context(
     if request_row is None:
         return None, []
     status = _to_str(request_row.get("status")).strip().lower()
-    if status not in {"reserved", "expired"}:
+    if status not in {"reserved", "expired", "partial_borrowed"}:
         raise ValueError("only reserved request can be picked up")
-    if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
-        raise ValueError("borrow request already allocated")
     request_lines = sorted(
         (row for row in line_rows if _to_int(row.get("request_id")) == request_id),
         key=lambda row: _to_int(row.get("id")),
@@ -2673,6 +2738,7 @@ def list_borrow_pickup_lines(request_id: int) -> list[dict[str, Any]] | None:
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2690,15 +2756,26 @@ def list_borrow_pickup_lines(request_id: int) -> list[dict[str, Any]] | None:
             return None
 
     candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    _, line_allocations = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+    )
     summaries: list[dict[str, Any]] = []
     for line in request_lines:
+        requested_qty = _to_int(line.get("requested_qty"))
+        allocated_qty = line_allocations.get(_to_int(line.get("id")), 0)
+        remaining_qty = max(requested_qty - allocated_qty, 0)
+        if remaining_qty <= 0:
+            continue
         key = _borrow_key(line.get("item_name"), line.get("item_model"))
         summaries.append(
             {
                 "line_id": _to_int(line.get("id")),
                 "item_name": _to_str(line.get("item_name")),
                 "item_model": _to_str(line.get("item_model")),
-                "requested_qty": _to_int(line.get("requested_qty")),
+                "requested_qty": requested_qty,
+                "allocated_qty": allocated_qty,
+                "remaining_qty": remaining_qty,
                 "candidate_count": len(candidates_by_key.get(key, [])),
             }
         )
@@ -2726,6 +2803,7 @@ def list_borrow_pickup_line_candidates(
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2745,6 +2823,15 @@ def list_borrow_pickup_line_candidates(
     target_line = next((row for row in request_lines if _to_int(row.get("id")) == line_id), None)
     if target_line is None:
         raise ValueError("line_id does not belong to request")
+    _, line_allocations = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+    )
+    requested_qty = _to_int(target_line.get("requested_qty"))
+    allocated_qty = line_allocations.get(line_id, 0)
+    remaining_qty = max(requested_qty - allocated_qty, 0)
+    if remaining_qty <= 0:
+        raise ValueError("line_id is already fully allocated")
 
     key = _borrow_key(target_line.get("item_name"), target_line.get("item_model"))
     candidates = _build_inventory_candidates_by_key(inventory_rows).get(key, [])
@@ -2766,7 +2853,9 @@ def list_borrow_pickup_line_candidates(
         "line_id": _to_int(target_line.get("id")),
         "item_name": _to_str(target_line.get("item_name")),
         "item_model": _to_str(target_line.get("item_model")),
-        "requested_qty": _to_int(target_line.get("requested_qty")),
+        "requested_qty": requested_qty,
+        "allocated_qty": allocated_qty,
+        "remaining_qty": remaining_qty,
         "items": [
             {
                 "id": _to_int(item.get("id")),
@@ -2802,6 +2891,7 @@ def resolve_borrow_pickup_scan(request_id: int, code: str) -> dict[str, Any] | N
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2819,8 +2909,16 @@ def resolve_borrow_pickup_scan(request_id: int, code: str) -> dict[str, Any] | N
             return None
 
     candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    _, line_allocations = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+    )
     eligible_line_ids_by_key: dict[tuple[str, str], list[int]] = {}
     for line in request_lines:
+        requested_qty = _to_int(line.get("requested_qty"))
+        allocated_qty = line_allocations.get(_to_int(line.get("id")), 0)
+        if allocated_qty >= requested_qty:
+            continue
         key = _borrow_key(line.get("item_name"), line.get("item_model"))
         eligible_line_ids_by_key.setdefault(key, []).append(_to_int(line.get("id")))
 
@@ -2870,6 +2968,7 @@ def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | Non
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2887,11 +2986,20 @@ def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | Non
             return None
 
     candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+    _, line_allocations = _build_borrow_allocation_stats(
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+    )
     results: list[dict[str, Any]] = []
     for line in request_lines:
         line_id = _to_int(line.get("id"))
         item_name = _to_str(line.get("item_name"))
         item_model = _to_str(line.get("item_model"))
+        requested_qty = _to_int(line.get("requested_qty"))
+        allocated_qty = line_allocations.get(line_id, 0)
+        remaining_qty = max(requested_qty - allocated_qty, 0)
+        if remaining_qty <= 0:
+            continue
         key = _borrow_key(item_name, item_model)
         candidates = candidates_by_key.get(key, [])
         results.append(
@@ -2899,7 +3007,9 @@ def list_borrow_pickup_candidates(request_id: int) -> list[dict[str, Any]] | Non
                 "line_id": line_id,
                 "item_name": item_name,
                 "item_model": item_model,
-                "requested_qty": _to_int(line.get("requested_qty")),
+                "requested_qty": requested_qty,
+                "allocated_qty": allocated_qty,
+                "remaining_qty": remaining_qty,
                 "candidates": [
                     {
                         "id": _to_int(item.get("id")),
@@ -2928,6 +3038,7 @@ def list_borrow_reservation_options(*, exclude_request_id: int | None = None) ->
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -2990,6 +3101,7 @@ def update_borrow_request(request_id: int, request_data: dict[str, Any], request
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -3077,6 +3189,7 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -3084,22 +3197,30 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
         if request_row is None:
             return False
         status = _to_str(request_row.get("status")).strip().lower()
-        if status not in {"reserved", "expired"}:
+        if status not in {"reserved", "expired", "partial_borrowed"}:
             raise ValueError("only reserved request can be picked up")
-        if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
-            raise ValueError("borrow request already allocated")
 
         target_lines = [row for row in line_rows if _to_int(row.get("request_id")) == request_id]
         if not target_lines:
             raise ValueError("request_lines is required")
 
-        line_map = {_to_int(row.get("id")): row for row in target_lines}
+        line_map = {_to_int(row.get("id")): row for row in target_lines if _to_int(row.get("id")) > 0}
+        requested_qty_by_line = {_to_int(row.get("id")): _to_int(row.get("requested_qty")) for row in target_lines}
+        _, existing_allocations_by_line = _build_borrow_allocation_stats(
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        remaining_qty_by_line = {
+            line_id: max(requested_qty_by_line.get(line_id, 0) - existing_allocations_by_line.get(line_id, 0), 0)
+            for line_id in requested_qty_by_line
+        }
         target_line_ids = set(line_map.keys())
         if not selections_data:
             raise ValueError("pickup selections are required")
 
         selections_by_line: dict[int, list[int]] = {}
         selected_item_ids: set[int] = set()
+        total_selected = 0
         for row in selections_data:
             line_id = _to_int(row.get("line_id"))
             if line_id not in target_line_ids:
@@ -3123,14 +3244,15 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
                 selected_item_ids.add(item_id)
                 line_item_ids.append(item_id)
             selections_by_line[line_id] = line_item_ids
+            total_selected += len(line_item_ids)
+            remaining_qty = remaining_qty_by_line.get(line_id, 0)
+            if remaining_qty <= 0:
+                raise ValueError(f"line_id {line_id} is already fully allocated")
+            if len(line_item_ids) > remaining_qty:
+                raise ValueError(f"line_id {line_id} exceeds remaining qty {remaining_qty}")
 
-        if set(selections_by_line.keys()) != target_line_ids:
-            missing = sorted(target_line_ids - set(selections_by_line.keys()))
-            extra = sorted(set(selections_by_line.keys()) - target_line_ids)
-            if missing:
-                raise ValueError(f"missing pickup selections for line_ids: {','.join(str(value) for value in missing)}")
-            if extra:
-                raise ValueError(f"unexpected line_ids in pickup selections: {','.join(str(value) for value in extra)}")
+        if total_selected <= 0:
+            raise ValueError("pickup selections are required")
 
         inventory_map = _active_inventory_rows_map(inventory_rows)
         next_allocation_id = _next_id(allocation_rows)
@@ -3138,10 +3260,9 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
         for line in sorted(target_lines, key=lambda row: _to_int(row.get("id"))):
             line_id = _to_int(line.get("id"))
             key = _borrow_key(line.get("item_name"), line.get("item_model"))
-            requested_qty = _to_int(line.get("requested_qty"))
             selected_ids = selections_by_line.get(line_id, [])
-            if len(selected_ids) != requested_qty:
-                raise ValueError(f"line_id {line_id} requires {requested_qty} items")
+            if not selected_ids:
+                continue
             for item_id in selected_ids:
                 inventory_row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
                 item_key = _borrow_key(inventory_row.get("name"), inventory_row.get("model"))
@@ -3167,12 +3288,19 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
                 )
 
         allocation_rows.extend(created_allocations)
+        request_allocations_after_pickup, _ = _build_borrow_allocation_stats(
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        requested_qty_by_request = _build_borrow_requested_qty_by_request(target_lines)
+        allocated_qty_after_pickup = request_allocations_after_pickup.get(request_id, 0)
         request_row["status"] = _derive_borrow_status(
             due_date_value=request_row.get("due_date"),
             return_date_value="",
             status_value="borrowed",
             borrow_date_value=request_row.get("borrow_date"),
             has_allocations=True,
+            is_fully_allocated=allocated_qty_after_pickup >= requested_qty_by_request.get(request_id, 0),
         )
         request_row["return_date"] = ""
 
@@ -3206,6 +3334,7 @@ def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> 
         status_changed = _sync_borrow_statuses_in_place(
             request_rows=request_rows,
             allocation_rows=allocation_rows,
+            line_rows=line_rows,
             legacy_item_rows=legacy_item_rows,
             operation_rows=operation_rows,
         )
@@ -3213,7 +3342,7 @@ def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> 
         if request_row is None:
             return False
         current_status = _to_str(request_row.get("status")).strip().lower()
-        if current_status not in {"borrowed", "overdue"}:
+        if current_status not in {"partial_borrowed", "borrowed", "overdue"}:
             raise ValueError("only borrowed request can be returned")
 
         target_allocations = [row for row in allocation_rows if _to_int(row.get("request_id")) == request_id]

--- a/backend/db.py
+++ b/backend/db.py
@@ -114,6 +114,21 @@ SHEETS: dict[str, list[str]] = {
         "quantity",
         "note",
     ],
+    "borrow_request_lines": [
+        "id",
+        "request_id",
+        "item_name",
+        "item_model",
+        "requested_qty",
+        "note",
+    ],
+    "borrow_allocations": [
+        "id",
+        "request_id",
+        "line_id",
+        "item_id",
+        "note",
+    ],
     "donation_requests": [
         "id",
         "donor",
@@ -177,6 +192,8 @@ STRING_FIELDS: dict[str, list[str]] = {
         "created_at",
     ],
     "borrow_items": ["note"],
+    "borrow_request_lines": ["item_name", "item_model", "note"],
+    "borrow_allocations": ["note"],
     "donation_requests": [
         "donor",
         "department",
@@ -792,6 +809,8 @@ def get_dashboard_snapshot() -> dict[str, Any]:
         issue_item_rows = _read_rows(wb["issue_items"])
         borrow_request_rows = _read_rows(wb["borrow_requests"])
         borrow_item_rows = _read_rows(wb["borrow_items"])
+        borrow_line_rows = _read_rows(wb["borrow_request_lines"])
+        borrow_allocation_rows = _read_rows(wb["borrow_allocations"])
         donation_request_rows = _read_rows(wb["donation_requests"])
         donation_item_rows = _read_rows(wb["donation_items"])
 
@@ -822,6 +841,14 @@ def get_dashboard_snapshot() -> dict[str, Any]:
     for row in borrow_item_rows:
         request_id = _to_int(row.get("request_id"))
         borrow_item_count_map[request_id] = borrow_item_count_map.get(request_id, 0) + 1
+    for row in borrow_line_rows:
+        request_id = _to_int(row.get("request_id"))
+        borrow_item_count_map[request_id] = borrow_item_count_map.get(request_id, 0) + 1
+
+    borrow_allocation_count_map: dict[int, int] = {}
+    for row in borrow_allocation_rows:
+        request_id = _to_int(row.get("request_id"))
+        borrow_allocation_count_map[request_id] = borrow_allocation_count_map.get(request_id, 0) + 1
 
     donation_item_count_map: dict[int, int] = {}
     for row in donation_item_rows:
@@ -847,13 +874,17 @@ def get_dashboard_snapshot() -> dict[str, Any]:
     overdue_borrow_count = 0
     due_soon_borrow_count = 0
     for row in borrow_request_rows:
-        _normalize_borrow_status_in_place(row)
-        status = _to_str(row.get("status")).strip()
         request_id = _to_int(row.get("id"))
+        _normalize_borrow_status_in_place(
+            row,
+            has_allocations=borrow_allocation_count_map.get(request_id, 0) > 0
+            or borrow_item_count_map.get(request_id, 0) > 0,
+        )
+        status = _to_str(row.get("status")).strip()
         item_count = borrow_item_count_map.get(request_id, 0)
         if status == "overdue":
             overdue_borrow_count += 1
-        if _is_due_soon(
+        if status in {"borrowed", "overdue"} and _is_due_soon(
             due_date_value=row.get("due_date"),
             return_date_value=row.get("return_date"),
         ):
@@ -2073,11 +2104,32 @@ def _parse_request_date(value: Any) -> date | None:
     return None
 
 
-def _derive_borrow_status(*, due_date_value: Any, return_date_value: Any, today: date | None = None) -> str:
+def _borrow_key(item_name: Any, item_model: Any) -> tuple[str, str]:
+    return (_to_str(item_name).strip(), _to_str(item_model).strip())
+
+
+def _derive_borrow_status(
+    *,
+    due_date_value: Any,
+    return_date_value: Any,
+    status_value: Any = "",
+    borrow_date_value: Any = "",
+    has_allocations: bool = False,
+    today: date | None = None,
+) -> str:
     now = today or date.today()
     return_date = _parse_request_date(return_date_value)
     if return_date is not None:
         return "returned"
+
+    status = _to_str(status_value).strip().lower()
+    borrow_date = _parse_request_date(borrow_date_value)
+    if not has_allocations:
+        if borrow_date is not None and borrow_date < now:
+            return "expired"
+        if status in {"expired", "cancelled"}:
+            return status
+        return "reserved"
 
     due_date = _parse_request_date(due_date_value)
     if due_date is not None and due_date < now:
@@ -2096,10 +2148,129 @@ def _is_due_soon(*, due_date_value: Any, return_date_value: Any, today: date | N
     return 0 <= delta <= days
 
 
-def _normalize_borrow_status_in_place(row: dict[str, Any], *, today: date | None = None) -> bool:
+def _normalize_borrow_request_lines(lines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for line in lines:
+        item_name = _to_str(line.get("item_name")).strip()
+        item_model = _to_str(line.get("item_model")).strip()
+        requested_qty = _to_int(line.get("requested_qty"))
+        note = _to_str(line.get("note"))
+        if not item_name:
+            raise ValueError("item_name is required")
+        if not item_model:
+            raise ValueError("item_model is required")
+        if requested_qty <= 0:
+            raise ValueError("requested_qty must be greater than 0")
+        normalized.append(
+            {
+                "item_name": item_name,
+                "item_model": item_model,
+                "requested_qty": requested_qty,
+                "note": note,
+            }
+        )
+    if not normalized:
+        raise ValueError("request_lines is required")
+    return normalized
+
+
+def _build_borrow_reservation_usage(
+    *,
+    request_rows: list[dict[str, Any]],
+    line_rows: list[dict[str, Any]],
+    allocation_rows: list[dict[str, Any]],
+    legacy_item_rows: list[dict[str, Any]] | None = None,
+    exclude_request_id: int | None = None,
+    today: date | None = None,
+) -> dict[tuple[str, str], int]:
+    legacy_rows = legacy_item_rows or []
+    active_request_ids = {
+        _to_int(row.get("id"))
+        for row in request_rows
+        if _derive_borrow_status(
+            due_date_value=row.get("due_date"),
+            return_date_value=row.get("return_date"),
+            status_value=row.get("status"),
+            borrow_date_value=row.get("borrow_date"),
+            has_allocations=any(_to_int(alloc.get("request_id")) == _to_int(row.get("id")) for alloc in allocation_rows)
+            or any(_to_int(item.get("request_id")) == _to_int(row.get("id")) for item in legacy_rows),
+            today=today,
+        )
+        == "reserved"
+    }
+    if exclude_request_id is not None:
+        active_request_ids.discard(exclude_request_id)
+
+    usage: dict[tuple[str, str], int] = {}
+    for line in line_rows:
+        request_id = _to_int(line.get("request_id"))
+        if request_id not in active_request_ids:
+            continue
+        key = _borrow_key(line.get("item_name"), line.get("item_model"))
+        usage[key] = usage.get(key, 0) + _to_int(line.get("requested_qty"))
+    return usage
+
+
+def _build_inventory_available_by_key(inventory_rows: list[dict[str, Any]]) -> dict[tuple[str, str], int]:
+    available: dict[tuple[str, str], int] = {}
+    for row in inventory_rows:
+        if not _is_blank(row.get("deleted_at")):
+            continue
+        if _to_str(row.get("asset_status")).strip() != "0":
+            continue
+        key = _borrow_key(row.get("name"), row.get("model"))
+        available[key] = available.get(key, 0) + 1
+    return available
+
+
+def _build_inventory_candidates_by_key(inventory_rows: list[dict[str, Any]]) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    candidates: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in inventory_rows:
+        if not _is_blank(row.get("deleted_at")):
+            continue
+        if _to_str(row.get("asset_status")).strip() != "0":
+            continue
+        key = _borrow_key(row.get("name"), row.get("model"))
+        candidates.setdefault(key, []).append(row)
+    for rows in candidates.values():
+        rows.sort(key=lambda item: _to_int(item.get("id")))
+    return candidates
+
+
+def _collect_shortages(
+    requested_totals: dict[tuple[str, str], int],
+    available_totals: dict[tuple[str, str], int],
+) -> list[dict[str, Any]]:
+    shortages: list[dict[str, Any]] = []
+    for key, requested_qty in requested_totals.items():
+        available_qty = available_totals.get(key, 0)
+        if available_qty >= requested_qty:
+            continue
+        shortages.append(
+            {
+                "item_name": key[0],
+                "item_model": key[1],
+                "requested_qty": requested_qty,
+                "available_qty": available_qty,
+                "shortage_qty": requested_qty - available_qty,
+            }
+        )
+    shortages.sort(key=lambda row: (row["item_name"], row["item_model"]))
+    return shortages
+
+
+def _normalize_borrow_status_in_place(
+    row: dict[str, Any],
+    *,
+    has_allocations: bool = False,
+    today: date | None = None,
+) -> bool:
     next_status = _derive_borrow_status(
         due_date_value=row.get("due_date"),
         return_date_value=row.get("return_date"),
+        status_value=row.get("status"),
+        borrow_date_value=row.get("borrow_date"),
+        has_allocations=has_allocations,
         today=today,
     )
     previous_status = _to_str(row.get("status")).strip()
@@ -2109,51 +2280,88 @@ def _normalize_borrow_status_in_place(row: dict[str, Any], *, today: date | None
     return True
 
 
-def _to_borrow_api_row(row: dict[str, Any], *, today: date | None = None) -> dict[str, Any]:
+def _to_borrow_api_row(row: dict[str, Any], *, has_allocations: bool = False, today: date | None = None) -> dict[str, Any]:
     normalized = dict(row)
     normalized["status"] = _derive_borrow_status(
         due_date_value=row.get("due_date"),
         return_date_value=row.get("return_date"),
+        status_value=row.get("status"),
+        borrow_date_value=row.get("borrow_date"),
+        has_allocations=has_allocations,
         today=today,
     )
-    normalized["is_due_soon"] = _is_due_soon(
-        due_date_value=row.get("due_date"),
-        return_date_value=row.get("return_date"),
-        today=today,
-        days=3,
+    normalized["is_due_soon"] = normalized["status"] in {"borrowed", "overdue"} and _is_due_soon(
+        due_date_value=row.get("due_date"), return_date_value=row.get("return_date"), today=today, days=3
     )
     return normalized
 
 
-def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, Any]]) -> int:
-    next_status = _derive_borrow_status(
-        due_date_value=request_data.get("due_date"),
-        return_date_value=request_data.get("return_date"),
-    )
+def _sync_borrow_statuses_in_place(
+    *,
+    request_rows: list[dict[str, Any]],
+    allocation_rows: list[dict[str, Any]],
+    legacy_item_rows: list[dict[str, Any]] | None = None,
+    today: date | None = None,
+) -> bool:
+    legacy_rows = legacy_item_rows or []
+    allocation_count_map: dict[int, int] = {}
+    for row in allocation_rows:
+        request_id = _to_int(row.get("request_id"))
+        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    for row in legacy_rows:
+        request_id = _to_int(row.get("request_id"))
+        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    status_changed = False
+    for row in request_rows:
+        request_id = _to_int(row.get("id"))
+        if _normalize_borrow_status_in_place(
+            row,
+            has_allocations=allocation_count_map.get(request_id, 0) > 0,
+            today=today,
+        ):
+            status_changed = True
+    return status_changed
+
+
+def create_borrow_request(request_data: dict[str, Any], request_lines: list[dict[str, Any]]) -> int:
+    normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
-        item_ws = wb["borrow_items"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_ws = wb["borrow_request_lines"]
+        allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
-        movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
-        item_rows = _read_rows(item_ws)
+        line_rows = _read_rows(line_ws)
+        allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
-        movement_rows = _read_rows(movement_ws)
-        selected_item_ids = _normalize_request_item_ids(items)
-        inventory_map = _active_inventory_rows_map(inventory_rows)
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+
+        requested_totals: dict[tuple[str, str], int] = {}
+        for line in normalized_lines:
+            key = _borrow_key(line["item_name"], line["item_model"])
+            requested_totals[key] = requested_totals.get(key, 0) + line["requested_qty"]
+
+        available_totals = _build_inventory_available_by_key(inventory_rows)
+        reserved_usage = _build_borrow_reservation_usage(
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        reservable_totals = {
+            key: max(available_totals.get(key, 0) - reserved_usage.get(key, 0), 0)
+            for key in set(available_totals) | set(reserved_usage) | set(requested_totals)
+        }
+        shortages = _collect_shortages(requested_totals, reservable_totals)
+        if shortages:
+            raise ValueError(json.dumps({"message": "insufficient_reservable_quantity", "shortages": shortages}, ensure_ascii=False))
+
         request_id = _next_id(request_rows)
-        for item_id in selected_item_ids:
-            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            if _borrow_status_uses_inventory(next_status):
-                _set_inventory_status_with_movement(
-                    movement_rows=movement_rows,
-                    row=row,
-                    item_id=item_id,
-                    status="2",
-                    action="create",
-                    entity="borrow_request",
-                    entity_id=request_id,
-                )
         request_rows.append(
             {
                 "id": request_id,
@@ -2162,80 +2370,146 @@ def create_borrow_request(request_data: dict[str, Any], items: list[dict[str, An
                 "purpose": request_data["purpose"],
                 "borrow_date": request_data["borrow_date"],
                 "due_date": request_data["due_date"],
-                "return_date": request_data["return_date"],
-                "status": next_status,
+                "return_date": "",
+                "status": "reserved",
                 "memo": request_data["memo"],
                 "created_at": _now_str(),
             }
         )
-        next_item_id = _next_id(item_rows)
-        for index, item in enumerate(items):
-            item_rows.append(
+        next_line_id = _next_id(line_rows)
+        for index, line in enumerate(normalized_lines):
+            line_rows.append(
                 {
-                    "id": next_item_id + index,
+                    "id": next_line_id + index,
                     "request_id": request_id,
-                    "item_id": item["item_id"],
-                    "quantity": 1,
-                    "note": item.get("note", ""),
+                    "item_name": line["item_name"],
+                    "item_model": line["item_model"],
+                    "requested_qty": line["requested_qty"],
+                    "note": line["note"],
                 }
             )
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
-        _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
+        _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
+        _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
-        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
         return request_id
 
 
 def list_borrow_requests() -> list[dict[str, Any]]:
     with _locked_workbook() as wb:
-        ws = wb["borrow_requests"]
-        rows = _read_rows(ws)
-        status_changed = False
-        for row in rows:
-            if _normalize_borrow_status_in_place(row):
-                status_changed = True
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        rows = _read_rows(request_ws)
+        status_changed = _sync_borrow_statuses_in_place(
+            request_rows=rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
         if status_changed:
-            _write_rows(ws, SHEETS["borrow_requests"], rows)
+            _write_rows(request_ws, SHEETS["borrow_requests"], rows)
             wb.save(DB_PATH)
-    return sorted((_to_borrow_api_row(row) for row in rows), key=lambda row: _to_int(row.get("id")), reverse=True)
+    allocation_count_map: dict[int, int] = {}
+    for row in allocation_rows:
+        request_id = _to_int(row.get("request_id"))
+        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    for row in legacy_item_rows:
+        request_id = _to_int(row.get("request_id"))
+        allocation_count_map[request_id] = allocation_count_map.get(request_id, 0) + 1
+    return sorted(
+        (
+            _to_borrow_api_row(
+                row,
+                has_allocations=allocation_count_map.get(_to_int(row.get("id")), 0) > 0,
+            )
+            for row in rows
+        ),
+        key=lambda row: _to_int(row.get("id")),
+        reverse=True,
+    )
 
 
 def get_borrow_request(request_id: int) -> dict[str, Any] | None:
     with _locked_workbook() as wb:
-        ws = wb["borrow_requests"]
-        rows = _read_rows(ws)
-        status_changed = False
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        rows = _read_rows(request_ws)
+        status_changed = _sync_borrow_statuses_in_place(
+            request_rows=rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
         target_row: dict[str, Any] | None = None
         for row in rows:
             if _to_int(row.get("id")) != request_id:
                 continue
-            if _normalize_borrow_status_in_place(row):
-                status_changed = True
             target_row = row
             break
         if status_changed:
-            _write_rows(ws, SHEETS["borrow_requests"], rows)
+            _write_rows(request_ws, SHEETS["borrow_requests"], rows)
             wb.save(DB_PATH)
     if target_row is None:
         return None
-    return _to_borrow_api_row(target_row)
+    has_allocations = any(_to_int(row.get("request_id")) == request_id for row in allocation_rows) or any(
+        _to_int(row.get("request_id")) == request_id for row in legacy_item_rows
+    )
+    return _to_borrow_api_row(target_row, has_allocations=has_allocations)
 
 
 def list_borrow_items_map(request_ids: set[int] | None = None) -> dict[int, list[dict[str, Any]]]:
     with _locked_workbook() as wb:
-        item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        legacy_item_rows = _read_rows(wb["borrow_items"])
         inventory_rows = _read_rows(wb["inventory_items"])
 
     inventory_map = _active_inventory_detail_map(inventory_rows)
+    inventory_rows_map = _active_inventory_rows_map(inventory_rows)
     selected_ids = request_ids or set()
     results: dict[int, list[dict[str, Any]]] = {}
-    for row in item_rows:
+    line_map: dict[int, dict[str, Any]] = {}
+    for row in line_rows:
+        line_id = _to_int(row.get("id"))
+        if line_id > 0:
+            line_map[line_id] = row
+
+    allocation_by_line_id: dict[int, list[dict[str, Any]]] = {}
+    for row in allocation_rows:
+        line_id = _to_int(row.get("line_id"))
+        allocation_by_line_id.setdefault(line_id, []).append(row)
+
+    for row in line_rows:
+        request_id = _to_int(row.get("request_id"))
+        if selected_ids and request_id not in selected_ids:
+            continue
+        line_id = _to_int(row.get("id"))
+        allocated_rows = allocation_by_line_id.get(line_id, [])
+        allocated_item_ids = [_to_int(alloc.get("item_id")) for alloc in allocated_rows if _to_int(alloc.get("item_id")) > 0]
+        results.setdefault(request_id, []).append(
+            {
+                "id": row.get("id"),
+                "request_id": row.get("request_id"),
+                "item_id": "",
+                "quantity": row.get("requested_qty"),
+                "note": row.get("note", ""),
+                "item_name": _to_str(row.get("item_name")),
+                "item_model": _to_str(row.get("item_model")),
+                "requested_qty": _to_int(row.get("requested_qty")),
+                "allocated_qty": len(allocated_rows),
+                "allocated_item_ids": allocated_item_ids,
+            }
+        )
+
+    for row in legacy_item_rows:
         request_id = _to_int(row.get("request_id"))
         if selected_ids and request_id not in selected_ids:
             continue
         item_id = _to_int(row.get("item_id"))
         details = inventory_map.get(item_id, {"item_name": None, "item_model": None})
+        item_name = _to_str(details.get("item_name")) or _to_str(inventory_rows_map.get(item_id, {}).get("name"))
+        item_model = _to_str(details.get("item_model")) or _to_str(inventory_rows_map.get(item_id, {}).get("model"))
         results.setdefault(request_id, []).append(
             {
                 "id": row.get("id"),
@@ -2243,8 +2517,11 @@ def list_borrow_items_map(request_ids: set[int] | None = None) -> dict[int, list
                 "item_id": row.get("item_id"),
                 "quantity": row.get("quantity"),
                 "note": row.get("note", ""),
-                "item_name": details.get("item_name"),
-                "item_model": details.get("item_model"),
+                "item_name": item_name,
+                "item_model": item_model,
+                "requested_qty": _to_int(row.get("quantity"), default=1),
+                "allocated_qty": _to_int(row.get("quantity"), default=1),
+                "allocated_item_ids": [item_id] if item_id > 0 else [],
             }
         )
 
@@ -2257,114 +2534,284 @@ def list_borrow_items(request_id: int) -> list[dict[str, Any]]:
     return list_borrow_items_map({request_id}).get(request_id, [])
 
 
-def update_borrow_request(request_id: int, request_data: dict[str, Any], items: list[dict[str, Any]]) -> bool:
-    next_status = _derive_borrow_status(
-        due_date_value=request_data.get("due_date"),
-        return_date_value=request_data.get("return_date"),
+def list_borrow_reservation_options(*, exclude_request_id: int | None = None) -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        request_rows = _read_rows(wb["borrow_requests"])
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_rows = _read_rows(wb["borrow_request_lines"])
+        allocation_rows = _read_rows(wb["borrow_allocations"])
+        inventory_rows = _read_rows(wb["inventory_items"])
+
+    _sync_borrow_statuses_in_place(
+        request_rows=request_rows,
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
     )
+    reserved_usage = _build_borrow_reservation_usage(
+        request_rows=request_rows,
+        line_rows=line_rows,
+        allocation_rows=allocation_rows,
+        legacy_item_rows=legacy_item_rows,
+        exclude_request_id=exclude_request_id,
+    )
+    available_totals = _build_inventory_available_by_key(inventory_rows)
+
+    combo_keys = {
+        _borrow_key(row.get("name"), row.get("model"))
+        for row in inventory_rows
+        if _is_blank(row.get("deleted_at"))
+    }
+
+    options: list[dict[str, Any]] = []
+    for combo_key in sorted(combo_keys):
+        item_name, item_model = combo_key
+        available_qty = available_totals.get(combo_key, 0)
+        reserved_qty = reserved_usage.get(combo_key, 0)
+        reservable_qty = max(available_qty - reserved_qty, 0)
+        options.append(
+            {
+                "item_name": item_name,
+                "item_model": item_model,
+                "available_qty": available_qty,
+                "reserved_qty": reserved_qty,
+                "reservable_qty": reservable_qty,
+                "selectable": reservable_qty > 0,
+            }
+        )
+    return options
+
+
+def update_borrow_request(request_id: int, request_data: dict[str, Any], request_lines: list[dict[str, Any]]) -> bool:
+    normalized_lines = _normalize_borrow_request_lines(request_lines)
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
-        item_ws = wb["borrow_items"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_ws = wb["borrow_request_lines"]
+        allocation_ws = wb["borrow_allocations"]
+        inventory_ws = wb["inventory_items"]
+        request_rows = _read_rows(request_ws)
+        line_rows = _read_rows(line_ws)
+        allocation_rows = _read_rows(allocation_ws)
+        inventory_rows = _read_rows(inventory_ws)
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+
+        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        if request_row is None:
+            return False
+        if _to_str(request_row.get("status")).strip().lower() not in {"reserved", "expired"}:
+            raise ValueError("only reserved request can be updated")
+        if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
+            raise ValueError("allocated borrow request cannot be updated")
+
+        requested_totals: dict[tuple[str, str], int] = {}
+        for line in normalized_lines:
+            key = _borrow_key(line["item_name"], line["item_model"])
+            requested_totals[key] = requested_totals.get(key, 0) + line["requested_qty"]
+
+        available_totals = _build_inventory_available_by_key(inventory_rows)
+        reserved_usage = _build_borrow_reservation_usage(
+            request_rows=request_rows,
+            line_rows=line_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+            exclude_request_id=request_id,
+        )
+        reservable_totals = {
+            key: max(available_totals.get(key, 0) - reserved_usage.get(key, 0), 0)
+            for key in set(available_totals) | set(reserved_usage) | set(requested_totals)
+        }
+        shortages = _collect_shortages(requested_totals, reservable_totals)
+        if shortages:
+            raise ValueError(json.dumps({"message": "insufficient_reservable_quantity", "shortages": shortages}, ensure_ascii=False))
+
+        request_row.update(
+            {
+                "borrower": request_data["borrower"],
+                "department": request_data["department"],
+                "purpose": request_data["purpose"],
+                "borrow_date": request_data["borrow_date"],
+                "due_date": request_data["due_date"],
+                "return_date": "",
+                "status": "reserved",
+                "memo": request_data["memo"],
+            }
+        )
+        line_rows = [row for row in line_rows if _to_int(row.get("request_id")) != request_id]
+        next_line_id = _next_id(line_rows)
+        for index, line in enumerate(normalized_lines):
+            line_rows.append(
+                {
+                    "id": next_line_id + index,
+                    "request_id": request_id,
+                    "item_name": line["item_name"],
+                    "item_model": line["item_model"],
+                    "requested_qty": line["requested_qty"],
+                    "note": line["note"],
+                }
+            )
+        _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+        _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
+        _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        wb.save(DB_PATH)
+        return True
+
+
+def pickup_borrow_request(request_id: int) -> bool:
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_ws = wb["borrow_request_lines"]
+        allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
         movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
-        item_rows = _read_rows(item_ws)
+        line_rows = _read_rows(line_ws)
+        allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
         movement_rows = _read_rows(movement_ws)
-        updated = False
-        previous_status = ""
-        for row in request_rows:
-            if _to_int(row.get("id")) == request_id:
-                previous_status = _derive_borrow_status(
-                    due_date_value=row.get("due_date"),
-                    return_date_value=row.get("return_date"),
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        if request_row is None:
+            return False
+        status = _to_str(request_row.get("status")).strip().lower()
+        if status not in {"reserved", "expired"}:
+            raise ValueError("only reserved request can be picked up")
+        if any(_to_int(row.get("request_id")) == request_id for row in allocation_rows):
+            raise ValueError("borrow request already allocated")
+
+        target_lines = [row for row in line_rows if _to_int(row.get("request_id")) == request_id]
+        if not target_lines:
+            raise ValueError("request_lines is required")
+
+        required_totals: dict[tuple[str, str], int] = {}
+        for row in target_lines:
+            key = _borrow_key(row.get("item_name"), row.get("item_model"))
+            required_totals[key] = required_totals.get(key, 0) + _to_int(row.get("requested_qty"))
+
+        candidates_by_key = _build_inventory_candidates_by_key(inventory_rows)
+        available_totals = {key: len(rows) for key, rows in candidates_by_key.items()}
+        shortages = _collect_shortages(required_totals, available_totals)
+        if shortages:
+            raise ValueError(json.dumps({"message": "insufficient_pickup_quantity", "shortages": shortages}, ensure_ascii=False))
+
+        inventory_map = _active_inventory_rows_map(inventory_rows)
+        next_allocation_id = _next_id(allocation_rows)
+        created_allocations: list[dict[str, Any]] = []
+        for line in sorted(target_lines, key=lambda row: _to_int(row.get("id"))):
+            line_id = _to_int(line.get("id"))
+            key = _borrow_key(line.get("item_name"), line.get("item_model"))
+            requested_qty = _to_int(line.get("requested_qty"))
+            candidates = candidates_by_key.get(key, [])
+            for _ in range(requested_qty):
+                if not candidates:
+                    raise ValueError("insufficient pickup candidates")
+                picked = candidates.pop(0)
+                item_id = _to_int(picked.get("id"))
+                inventory_row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=inventory_row,
+                    item_id=item_id,
+                    status="2",
+                    action="pickup",
+                    entity="borrow_request",
+                    entity_id=request_id,
                 )
-                row.update(
+                created_allocations.append(
                     {
-                        "borrower": request_data["borrower"],
-                        "department": request_data["department"],
-                        "purpose": request_data["purpose"],
-                        "borrow_date": request_data["borrow_date"],
-                        "due_date": request_data["due_date"],
-                        "return_date": request_data["return_date"],
-                        "status": next_status,
-                        "memo": request_data["memo"],
+                        "id": next_allocation_id + len(created_allocations),
+                        "request_id": request_id,
+                        "line_id": line_id,
+                        "item_id": item_id,
+                        "note": _to_str(line.get("note")),
                     }
                 )
-                updated = True
-                break
-        if not updated:
+
+        allocation_rows.extend(created_allocations)
+        request_row["status"] = _derive_borrow_status(
+            due_date_value=request_row.get("due_date"),
+            return_date_value="",
+            status_value="borrowed",
+            borrow_date_value=request_row.get("borrow_date"),
+            has_allocations=True,
+        )
+        request_row["return_date"] = ""
+
+        _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
+        _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
+        _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
+        wb.save(DB_PATH)
+        return True
+
+
+def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> bool:
+    with _locked_workbook() as wb:
+        request_ws = wb["borrow_requests"]
+        legacy_item_rows = _read_rows(wb["borrow_items"])
+        line_ws = wb["borrow_request_lines"]
+        allocation_ws = wb["borrow_allocations"]
+        inventory_ws = wb["inventory_items"]
+        movement_ws = wb["movement_ledger"]
+        request_rows = _read_rows(request_ws)
+        line_rows = _read_rows(line_ws)
+        allocation_rows = _read_rows(allocation_ws)
+        inventory_rows = _read_rows(inventory_ws)
+        movement_rows = _read_rows(movement_ws)
+
+        _sync_borrow_statuses_in_place(
+            request_rows=request_rows,
+            allocation_rows=allocation_rows,
+            legacy_item_rows=legacy_item_rows,
+        )
+        request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
+        if request_row is None:
             return False
+        current_status = _to_str(request_row.get("status")).strip().lower()
+        if current_status not in {"borrowed", "overdue"}:
+            raise ValueError("only borrowed request can be returned")
 
-        old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
-        old_item_ids = {_to_int(row.get("item_id")) for row in old_items}
-        new_item_ids = set(_normalize_request_item_ids(items))
-        old_active_ids = old_item_ids if _borrow_status_uses_inventory(previous_status) else set()
-        new_active_ids = new_item_ids if _borrow_status_uses_inventory(next_status) else set()
+        target_allocations = [row for row in allocation_rows if _to_int(row.get("request_id")) == request_id]
+        target_item_ids = [_to_int(row.get("item_id")) for row in target_allocations if _to_int(row.get("item_id")) > 0]
+        if not target_item_ids:
+            legacy_allocations = [
+                row for row in legacy_item_rows if _to_int(row.get("request_id")) == request_id and _to_int(row.get("item_id")) > 0
+            ]
+            target_item_ids = [_to_int(row.get("item_id")) for row in legacy_allocations]
+        if not target_item_ids:
+            raise ValueError("borrow request has no allocated items")
+
         inventory_map = _active_inventory_rows_map(inventory_rows)
-
-        for item_id in new_item_ids - old_item_ids:
-            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
-            if item_id in new_active_ids:
-                _set_inventory_status_with_movement(
-                    movement_rows=movement_rows,
-                    row=row,
-                    item_id=item_id,
-                    status="2",
-                    action="update",
-                    entity="borrow_request",
-                    entity_id=request_id,
-                )
-        for item_id in new_item_ids & old_item_ids:
-            allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
-            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
-            if item_id in new_active_ids:
-                _set_inventory_status_with_movement(
-                    movement_rows=movement_rows,
-                    row=row,
-                    item_id=item_id,
-                    status="2",
-                    action="update",
-                    entity="borrow_request",
-                    entity_id=request_id,
-                )
-            else:
-                _set_inventory_status_with_movement(
-                    movement_rows=movement_rows,
-                    row=row,
-                    item_id=item_id,
-                    status="0",
-                    action="update",
-                    entity="borrow_request",
-                    entity_id=request_id,
-                )
-        for item_id in old_item_ids - new_item_ids:
-            allowed_statuses = {"0", "2"} if item_id in old_active_ids else {"0"}
-            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses=allowed_statuses)
+        for item_id in target_item_ids:
+            row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"2"})
             _set_inventory_status_with_movement(
                 movement_rows=movement_rows,
                 row=row,
                 item_id=item_id,
                 status="0",
-                action="update",
+                action="return",
                 entity="borrow_request",
                 entity_id=request_id,
             )
 
-        item_rows = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
-        next_item_id = _next_id(item_rows)
-        for index, item in enumerate(items):
-            item_rows.append(
-                {
-                    "id": next_item_id + index,
-                    "request_id": request_id,
-                    "item_id": item["item_id"],
-                    "quantity": 1,
-                    "note": item.get("note", ""),
-                }
-            )
+        normalized_return_date = _parse_request_date(return_date_value) or date.today()
+        request_row["return_date"] = normalized_return_date.strftime("%Y/%m/%d")
+        request_row["status"] = "returned"
+
         _write_rows(request_ws, SHEETS["borrow_requests"], request_rows)
-        _write_rows(item_ws, SHEETS["borrow_items"], item_rows)
+        _write_rows(line_ws, SHEETS["borrow_request_lines"], line_rows)
+        _write_rows(allocation_ws, SHEETS["borrow_allocations"], allocation_rows)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)
@@ -2375,10 +2822,14 @@ def delete_borrow_request(request_id: int) -> bool:
     with _locked_workbook() as wb:
         request_ws = wb["borrow_requests"]
         item_ws = wb["borrow_items"]
+        line_ws = wb["borrow_request_lines"]
+        allocation_ws = wb["borrow_allocations"]
         inventory_ws = wb["inventory_items"]
         movement_ws = wb["movement_ledger"]
         request_rows = _read_rows(request_ws)
         item_rows = _read_rows(item_ws)
+        line_rows = _read_rows(line_ws)
+        allocation_rows = _read_rows(allocation_ws)
         inventory_rows = _read_rows(inventory_ws)
         movement_rows = _read_rows(movement_ws)
         remaining_requests = [row for row in request_rows if _to_int(row.get("id")) != request_id]
@@ -2387,14 +2838,30 @@ def delete_borrow_request(request_id: int) -> bool:
             return False
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
         old_items = [row for row in item_rows if _to_int(row.get("request_id")) == request_id]
+        old_allocations = [row for row in allocation_rows if _to_int(row.get("request_id")) == request_id]
         inventory_map = _active_inventory_rows_map(inventory_rows)
         request_status = ""
         if request_row is not None:
             request_status = _derive_borrow_status(
                 due_date_value=request_row.get("due_date"),
                 return_date_value=request_row.get("return_date"),
+                status_value=request_row.get("status"),
+                borrow_date_value=request_row.get("borrow_date"),
+                has_allocations=bool(old_allocations or old_items),
             )
         if request_row is not None and _borrow_status_uses_inventory(request_status):
+            for allocation in old_allocations:
+                item_id = _to_int(allocation.get("item_id"))
+                row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"2"})
+                _set_inventory_status_with_movement(
+                    movement_rows=movement_rows,
+                    row=row,
+                    item_id=item_id,
+                    status="0",
+                    action="delete",
+                    entity="borrow_request",
+                    entity_id=request_id,
+                )
             for old_item in old_items:
                 item_id = _to_int(old_item.get("item_id"))
                 row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"2"})
@@ -2408,8 +2875,12 @@ def delete_borrow_request(request_id: int) -> bool:
                     entity_id=request_id,
                 )
         remaining_items = [row for row in item_rows if _to_int(row.get("request_id")) != request_id]
+        remaining_lines = [row for row in line_rows if _to_int(row.get("request_id")) != request_id]
+        remaining_allocations = [row for row in allocation_rows if _to_int(row.get("request_id")) != request_id]
         _write_rows(request_ws, SHEETS["borrow_requests"], remaining_requests)
         _write_rows(item_ws, SHEETS["borrow_items"], remaining_items)
+        _write_rows(line_ws, SHEETS["borrow_request_lines"], remaining_lines)
+        _write_rows(allocation_ws, SHEETS["borrow_allocations"], remaining_allocations)
         _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
         _write_rows(movement_ws, SHEETS["movement_ledger"], movement_rows)
         wb.save(DB_PATH)

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,8 @@ from db import (
     list_issue_requests,
     list_borrow_items,
     list_borrow_items_map,
+    list_borrow_pickup_line_candidates,
+    list_borrow_pickup_lines,
     list_borrow_pickup_candidates,
     list_borrow_reservation_options,
     list_borrow_requests,
@@ -46,6 +48,7 @@ from db import (
     log_inventory_action,
     pickup_borrow_request,
     purge_soft_deleted_items,
+    resolve_borrow_pickup_scan,
     return_borrow_request,
     update_asset_status_code,
     update_item,
@@ -189,6 +192,40 @@ class BorrowPickupCandidateLine(BaseModel):
     item_model: str = ""
     requested_qty: int = 0
     candidates: list[BorrowPickupCandidateItem] = Field(default_factory=list)
+
+
+class BorrowPickupLineSummary(BaseModel):
+    line_id: int
+    item_name: str = ""
+    item_model: str = ""
+    requested_qty: int = 0
+    candidate_count: int = 0
+
+
+class BorrowPickupLineCandidatePage(BaseModel):
+    line_id: int
+    item_name: str = ""
+    item_model: str = ""
+    requested_qty: int = 0
+    items: list[BorrowPickupCandidateItem] = Field(default_factory=list)
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class BorrowPickupScanResolveRequest(BaseModel):
+    code: str = ""
+
+
+class BorrowPickupScanResolveItem(BorrowPickupCandidateItem):
+    item_name: str = ""
+    item_model: str = ""
+
+
+class BorrowPickupScanResolveResponse(BaseModel):
+    item: BorrowPickupScanResolveItem
+    eligible_line_ids: list[int] = Field(default_factory=list)
 
 
 class BorrowRequestCreate(BaseModel):
@@ -1186,6 +1223,54 @@ def list_borrow_pickup_candidates_api(request_id: int):
     if rows is None:
         raise HTTPException(status_code=404, detail="Borrow request not found")
     return [BorrowPickupCandidateLine(**row) for row in rows]
+
+
+@app.get("/api/borrows/{request_id}/pickup-lines", response_model=list[BorrowPickupLineSummary], response_model_by_alias=False)
+def list_borrow_pickup_lines_api(request_id: int):
+    try:
+        rows = list_borrow_pickup_lines(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if rows is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    return [BorrowPickupLineSummary(**row) for row in rows]
+
+
+@app.get("/api/borrows/{request_id}/pickup-lines/{line_id}/candidates", response_model=BorrowPickupLineCandidatePage, response_model_by_alias=False)
+def list_borrow_pickup_line_candidates_api(
+    request_id: int,
+    line_id: int,
+    keyword: str = "",
+    page: int = Query(default=1),
+    page_size: int = Query(default=50),
+):
+    page, page_size = _normalize_pagination(page, page_size)
+    if page_size > 200:
+        raise HTTPException(status_code=400, detail="page_size must be less than or equal to 200")
+    try:
+        payload = list_borrow_pickup_line_candidates(
+            request_id,
+            line_id,
+            keyword=keyword,
+            page=page,
+            page_size=page_size,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    return BorrowPickupLineCandidatePage(**payload)
+
+
+@app.post("/api/borrows/{request_id}/pickup-resolve-scan", response_model=BorrowPickupScanResolveResponse, response_model_by_alias=False)
+def resolve_borrow_pickup_scan_api(request_id: int, payload: BorrowPickupScanResolveRequest):
+    try:
+        result = resolve_borrow_pickup_scan(request_id, payload.code)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if result is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    return BorrowPickupScanResolveResponse(**result)
 
 
 @app.post("/api/borrows", response_model=BorrowRequest, response_model_by_alias=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from db import (
     list_issue_requests,
     list_borrow_items,
     list_borrow_items_map,
+    list_borrow_reservation_options,
     list_borrow_requests,
     list_donation_items,
     list_donation_items_map,
@@ -42,7 +43,9 @@ from db import (
     list_movement_ledger,
     list_operation_logs,
     log_inventory_action,
+    pickup_borrow_request,
     purge_soft_deleted_items,
+    return_borrow_request,
     update_asset_status_code,
     update_item,
     update_issue_request,
@@ -147,16 +150,19 @@ class IssueRequest(IssueRequestCreate):
     items: list[IssueItem]
 
 
-class BorrowItemCreate(BaseModel):
-    item_id: int
-    quantity: int = 1
+class BorrowRequestLineCreate(BaseModel):
+    item_name: str = ""
+    item_model: str = ""
+    requested_qty: int = 1
     note: str = ""
 
 
-class BorrowItem(BorrowItemCreate):
+class BorrowRequestLine(BorrowRequestLineCreate):
     id: int
-    item_name: str | None = None
-    item_model: str | None = None
+    item_id: int | None = None
+    quantity: int = 0
+    allocated_qty: int = 0
+    allocated_item_ids: list[int] = Field(default_factory=list)
 
 
 class BorrowRequestCreate(BaseModel):
@@ -165,16 +171,16 @@ class BorrowRequestCreate(BaseModel):
     purpose: str = ""
     borrow_date: date | None = None
     due_date: date | None = None
-    return_date: date | None = None
-    status: str = "borrowed"
     memo: str = ""
-    items: list[BorrowItemCreate] = Field(default_factory=list)
+    request_lines: list[BorrowRequestLineCreate] = Field(default_factory=list)
 
 
 class BorrowRequest(BorrowRequestCreate):
     id: int
+    return_date: date | None = None
+    status: str = "reserved"
     is_due_soon: bool = False
-    items: list[BorrowItem]
+    request_lines: list[BorrowRequestLine]
 
 
 class DonationItemCreate(BaseModel):
@@ -226,6 +232,15 @@ class BorrowRequestListResponse(BaseModel):
     page_size: int
     total: int
     total_pages: int
+
+
+class BorrowReservationOption(BaseModel):
+    item_name: str = ""
+    item_model: str = ""
+    available_qty: int = 0
+    reserved_qty: int = 0
+    reservable_qty: int = 0
+    selectable: bool = False
 
 
 class DonationRequestListResponse(BaseModel):
@@ -449,7 +464,9 @@ def _request_items_sort_key(items: list[Any]) -> tuple[str, int, int]:
     item_count = len(items)
     total_quantity = 0
     for item in items:
-        quantity = getattr(item, "quantity", 0)
+        quantity = getattr(item, "requested_qty", None)
+        if quantity is None:
+            quantity = getattr(item, "quantity", 0)
         try:
             total_quantity += int(quantity or 0)
         except (TypeError, ValueError):
@@ -538,14 +555,25 @@ def row_to_issue_item(row) -> IssueItem:
     )
 
 
-def row_to_borrow_item(row) -> BorrowItem:
-    return BorrowItem(
+def row_to_borrow_item(row) -> BorrowRequestLine:
+    allocated_ids: list[int] = []
+    for raw_item_id in row.get("allocated_item_ids", []):
+        try:
+            item_id = int(raw_item_id)
+        except (TypeError, ValueError):
+            continue
+        if item_id > 0:
+            allocated_ids.append(item_id)
+    return BorrowRequestLine(
         id=row["id"],
-        item_id=row["item_id"],
+        item_id=row.get("item_id") if row.get("item_id") not in ("", None) else None,
         quantity=row["quantity"],
         note=_coerce_str(row["note"]),
-        item_name=row["item_name"],
-        item_model=row["item_model"],
+        item_name=_coerce_str(row.get("item_name")),
+        item_model=_coerce_str(row.get("item_model")),
+        requested_qty=int(row.get("requested_qty") or row.get("quantity") or 0),
+        allocated_qty=int(row.get("allocated_qty") or 0),
+        allocated_item_ids=allocated_ids,
     )
 
 
@@ -577,8 +605,6 @@ def borrow_request_to_db_payload(request: BorrowRequestCreate) -> dict:
         "purpose": request.purpose,
         "borrow_date": _format_date(request.borrow_date),
         "due_date": _format_date(request.due_date),
-        "return_date": _format_date(request.return_date),
-        "status": request.status,
         "memo": request.memo,
     }
 
@@ -607,7 +633,7 @@ def issue_request_row_to_model(row, items: list[IssueItem]) -> IssueRequest:
     )
 
 
-def borrow_request_row_to_model(row, items: list[BorrowItem]) -> BorrowRequest:
+def borrow_request_row_to_model(row, request_lines: list[BorrowRequestLine]) -> BorrowRequest:
     borrow_date = _parse_purchase_date(row["borrow_date"]) if row["borrow_date"] else None
     due_date = _parse_purchase_date(row["due_date"]) if row["due_date"] else None
     return_date = _parse_purchase_date(row["return_date"]) if row["return_date"] else None
@@ -622,7 +648,7 @@ def borrow_request_row_to_model(row, items: list[BorrowItem]) -> BorrowRequest:
         status=_coerce_str(row["status"]),
         is_due_soon=bool(row.get("is_due_soon")),
         memo=_coerce_str(row["memo"]),
-        items=items,
+        request_lines=request_lines,
     )
 
 
@@ -653,6 +679,17 @@ def _ensure_available_item_ids(
     )
     if not is_available:
         raise HTTPException(status_code=400, detail=error_message or "invalid item_id")
+
+
+def _to_http_error_detail(error: ValueError) -> str | dict[str, Any]:
+    raw = str(error)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if isinstance(parsed, dict):
+        return parsed
+    return raw
 
 
 def _sync_requests_safe() -> None:
@@ -744,6 +781,12 @@ def delete_asset_status_code_api(code: str):
 
     log_inventory_action(action="delete", entity="asset_status_code", detail={"code": code})
     return {"success": True}
+
+
+@app.get("/api/lookups/borrow-reservations", response_model=list[BorrowReservationOption], response_model_by_alias=False)
+def list_borrow_reservation_options_api(request_id: int | None = None):
+    rows = list_borrow_reservation_options(exclude_request_id=request_id)
+    return [BorrowReservationOption(**row) for row in rows]
 
 
 @app.get("/api/items", response_model=InventoryItemListResponse, response_model_by_alias=False)
@@ -1055,12 +1098,12 @@ def list_borrow_requests_api(
     normalized_keyword = keyword.strip().lower()
     results: list[BorrowRequest] = []
     for row in rows:
-        items = [row_to_borrow_item(item) for item in request_item_map.get(int(row.get("id") or 0), [])]
-        model = borrow_request_row_to_model(row, items)
+        request_lines = [row_to_borrow_item(item) for item in request_item_map.get(int(row.get("id") or 0), [])]
+        model = borrow_request_row_to_model(row, request_lines)
         if status != "all" and model.status != status:
             continue
         if normalized_keyword:
-            item_matches = any((item.item_name or "").lower().find(normalized_keyword) >= 0 for item in model.items)
+            item_matches = any((line.item_name or "").lower().find(normalized_keyword) >= 0 for line in model.request_lines)
             fields = [
                 model.borrower or "",
                 model.department or "",
@@ -1089,7 +1132,7 @@ def list_borrow_requests_api(
                 int(bool(row.is_due_soon)),
                 row.id,
             ),
-            "items": lambda row: (_request_items_sort_key(row.items), row.id),
+            "items": lambda row: (_request_items_sort_key(row.request_lines), row.id),
             "memo": lambda row: (_coerce_str(row.memo).lower(), row.id),
         },
     )
@@ -1103,22 +1146,22 @@ def get_borrow_request_api(request_id: int):
     row = get_borrow_request(request_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Borrow request not found")
-    items = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
+    request_lines = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
     log_inventory_action(action="read", entity="borrow_request", entity_id=request_id, detail={"mode": "single"})
-    return borrow_request_row_to_model(row, items)
+    return borrow_request_row_to_model(row, request_lines)
 
 
 @app.post("/api/borrows", response_model=BorrowRequest, response_model_by_alias=False)
 def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: BackgroundTasks):
-    if not request.items:
-        raise HTTPException(status_code=400, detail="items is required")
-    for item in request.items:
-        if item.quantity != 1:
-            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
+    if not request.request_lines:
+        raise HTTPException(status_code=400, detail="request_lines is required")
     try:
-        request_id = create_borrow_request(borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+        request_id = create_borrow_request(
+            borrow_request_to_db_payload(request),
+            [line.model_dump() for line in request.request_lines],
+        )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_to_http_error_detail(exc)) from exc
     row = get_borrow_request(request_id)
     if row is None:
         log_inventory_action(
@@ -1129,24 +1172,25 @@ def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: Ba
             detail={"reason": "Borrow request created but cannot be loaded"},
         )
         raise HTTPException(status_code=500, detail="Borrow request created but cannot be loaded")
-    items = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
+    request_lines = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
     log_inventory_action(action="create", entity="borrow_request", entity_id=request_id)
     if is_google_sheets_configured():
         background_tasks.add_task(_sync_requests_safe)
-    return borrow_request_row_to_model(row, items)
+    return borrow_request_row_to_model(row, request_lines)
 
 
 @app.put("/api/borrows/{request_id}", response_model=BorrowRequest, response_model_by_alias=False)
 def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, background_tasks: BackgroundTasks):
-    if not request.items:
-        raise HTTPException(status_code=400, detail="items is required")
-    for item in request.items:
-        if item.quantity != 1:
-            raise HTTPException(status_code=400, detail="quantity must be 1 in single-item mode")
+    if not request.request_lines:
+        raise HTTPException(status_code=400, detail="request_lines is required")
     try:
-        updated = update_borrow_request(request_id, borrow_request_to_db_payload(request), [item.model_dump() for item in request.items])
+        updated = update_borrow_request(
+            request_id,
+            borrow_request_to_db_payload(request),
+            [line.model_dump() for line in request.request_lines],
+        )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_to_http_error_detail(exc)) from exc
     if not updated:
         log_inventory_action(
             action="update",
@@ -1166,11 +1210,47 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
             detail={"reason": "Borrow request not found after update"},
         )
         raise HTTPException(status_code=404, detail="Borrow request not found")
-    items = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
+    request_lines = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
     log_inventory_action(action="update", entity="borrow_request", entity_id=request_id)
     if is_google_sheets_configured():
         background_tasks.add_task(_sync_requests_safe)
-    return borrow_request_row_to_model(row, items)
+    return borrow_request_row_to_model(row, request_lines)
+
+
+@app.post("/api/borrows/{request_id}/pickup", response_model=BorrowRequest, response_model_by_alias=False)
+def pickup_borrow_request_api(request_id: int, background_tasks: BackgroundTasks):
+    try:
+        picked = pickup_borrow_request(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_to_http_error_detail(exc)) from exc
+    if not picked:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    row = get_borrow_request(request_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    request_lines = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
+    log_inventory_action(action="pickup", entity="borrow_request", entity_id=request_id)
+    if is_google_sheets_configured():
+        background_tasks.add_task(_sync_requests_safe)
+    return borrow_request_row_to_model(row, request_lines)
+
+
+@app.post("/api/borrows/{request_id}/return", response_model=BorrowRequest, response_model_by_alias=False)
+def return_borrow_request_api(request_id: int, background_tasks: BackgroundTasks):
+    try:
+        returned = return_borrow_request(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_to_http_error_detail(exc)) from exc
+    if not returned:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    row = get_borrow_request(request_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    request_lines = [row_to_borrow_item(item) for item in list_borrow_items(request_id)]
+    log_inventory_action(action="return", entity="borrow_request", entity_id=request_id)
+    if is_google_sheets_configured():
+        background_tasks.add_task(_sync_requests_safe)
+    return borrow_request_row_to_model(row, request_lines)
 
 
 @app.delete("/api/borrows/{request_id}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from db import (
     list_issue_requests,
     list_borrow_items,
     list_borrow_items_map,
+    list_borrow_pickup_candidates,
     list_borrow_reservation_options,
     list_borrow_requests,
     list_donation_items,
@@ -163,6 +164,31 @@ class BorrowRequestLine(BorrowRequestLineCreate):
     quantity: int = 0
     allocated_qty: int = 0
     allocated_item_ids: list[int] = Field(default_factory=list)
+
+
+class BorrowPickupSelection(BaseModel):
+    line_id: int
+    item_ids: list[int] = Field(default_factory=list)
+
+
+class BorrowPickupRequest(BaseModel):
+    selections: list[BorrowPickupSelection] = Field(default_factory=list)
+
+
+class BorrowPickupCandidateItem(BaseModel):
+    id: int
+    n_property_sn: str = ""
+    property_sn: str = ""
+    n_item_sn: str = ""
+    item_sn: str = ""
+
+
+class BorrowPickupCandidateLine(BaseModel):
+    line_id: int
+    item_name: str = ""
+    item_model: str = ""
+    requested_qty: int = 0
+    candidates: list[BorrowPickupCandidateItem] = Field(default_factory=list)
 
 
 class BorrowRequestCreate(BaseModel):
@@ -1151,6 +1177,17 @@ def get_borrow_request_api(request_id: int):
     return borrow_request_row_to_model(row, request_lines)
 
 
+@app.get("/api/borrows/{request_id}/pickup-candidates", response_model=list[BorrowPickupCandidateLine], response_model_by_alias=False)
+def list_borrow_pickup_candidates_api(request_id: int):
+    try:
+        rows = list_borrow_pickup_candidates(request_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if rows is None:
+        raise HTTPException(status_code=404, detail="Borrow request not found")
+    return [BorrowPickupCandidateLine(**row) for row in rows]
+
+
 @app.post("/api/borrows", response_model=BorrowRequest, response_model_by_alias=False)
 def create_borrow_request_api(request: BorrowRequestCreate, background_tasks: BackgroundTasks):
     if not request.request_lines:
@@ -1218,9 +1255,9 @@ def update_borrow_request_api(request_id: int, request: BorrowRequestCreate, bac
 
 
 @app.post("/api/borrows/{request_id}/pickup", response_model=BorrowRequest, response_model_by_alias=False)
-def pickup_borrow_request_api(request_id: int, background_tasks: BackgroundTasks):
+def pickup_borrow_request_api(request_id: int, payload: BorrowPickupRequest, background_tasks: BackgroundTasks):
     try:
-        picked = pickup_borrow_request(request_id)
+        picked = pickup_borrow_request(request_id, [selection.model_dump() for selection in payload.selections])
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=_to_http_error_detail(exc)) from exc
     if not picked:

--- a/backend/main.py
+++ b/backend/main.py
@@ -191,6 +191,8 @@ class BorrowPickupCandidateLine(BaseModel):
     item_name: str = ""
     item_model: str = ""
     requested_qty: int = 0
+    allocated_qty: int = 0
+    remaining_qty: int = 0
     candidates: list[BorrowPickupCandidateItem] = Field(default_factory=list)
 
 
@@ -199,6 +201,8 @@ class BorrowPickupLineSummary(BaseModel):
     item_name: str = ""
     item_model: str = ""
     requested_qty: int = 0
+    allocated_qty: int = 0
+    remaining_qty: int = 0
     candidate_count: int = 0
 
 
@@ -207,6 +211,8 @@ class BorrowPickupLineCandidatePage(BaseModel):
     item_name: str = ""
     item_model: str = ""
     requested_qty: int = 0
+    allocated_qty: int = 0
+    remaining_qty: int = 0
     items: list[BorrowPickupCandidateItem] = Field(default_factory=list)
     page: int
     page_size: int

--- a/backend/tests/test_list_sorting_api.py
+++ b/backend/tests/test_list_sorting_api.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from datetime import date, timedelta
 from pathlib import Path
 
 from fastapi import HTTPException
@@ -146,9 +147,30 @@ class ListSortingApiTests(unittest.TestCase):
         payload = app_main.get_dashboard_data()
         self.assertEqual(payload["status"], "success")
         self.assertIn("totalRecords", payload)
+        self.assertIn("reservedBorrowCount", payload)
         self.assertIn("itemCategoryDistribution", payload)
         self.assertIn("recentActivities", payload)
         self.assertGreaterEqual(payload["totalRecords"], 1)
+
+    def test_dashboard_counts_reserved_borrow_requests(self) -> None:
+        self._create_item(name="Lens")
+        borrow_date = (date.today() + timedelta(days=1)).isoformat()
+        due_date = (date.today() + timedelta(days=5)).isoformat()
+        app_main.create_borrow_request_api(
+            app_main.BorrowRequestCreate(
+                borrower="tester",
+                department="qa",
+                purpose="dash-reserved",
+                borrow_date=borrow_date,
+                due_date=due_date,
+                memo="",
+                request_lines=[{"item_name": "Lens", "item_model": "M1", "requested_qty": 1, "note": ""}],
+            ),
+            app_main.BackgroundTasks(),
+        )
+
+        payload = app_main.get_dashboard_data()
+        self.assertGreaterEqual(payload.get("reservedBorrowCount", 0), 1)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -51,12 +51,14 @@ class RequestApiGuardTests(unittest.TestCase):
 
     @staticmethod
     def _borrow_request(lines: list[dict]) -> app_main.BorrowRequestCreate:
+        borrow_date = (date.today() + timedelta(days=1)).isoformat()
+        due_date = (date.today() + timedelta(days=10)).isoformat()
         return app_main.BorrowRequestCreate(
             borrower='tester',
             department='qa',
             purpose='test',
-            borrow_date='2026-04-10',
-            due_date='2026-04-20',
+            borrow_date=borrow_date,
+            due_date=due_date,
             memo='',
             request_lines=lines,
         )
@@ -122,6 +124,64 @@ class RequestApiGuardTests(unittest.TestCase):
         picked = app_main.pickup_borrow_request_api(created.id, pickup_payload, BackgroundTasks())
         self.assertIn(picked.status, {'borrowed', 'overdue'})
         self.assertEqual(picked.request_lines[0].allocated_qty, 2)
+
+        returned = app_main.return_borrow_request_api(created.id, BackgroundTasks())
+        self.assertEqual(returned.status, 'returned')
+
+    def test_borrow_api_supports_partial_pickup_then_complete(self) -> None:
+        first_item_id = self._create_item(name='筆電', model='B2')
+        second_item_id = self._create_item(name='筆電', model='B2')
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '筆電', 'item_model': 'B2', 'requested_qty': 2, 'note': ''}]),
+            BackgroundTasks(),
+        )
+
+        first_pickup = app_main.BorrowPickupRequest(
+            selections=[
+                app_main.BorrowPickupSelection(
+                    line_id=created.request_lines[0].id,
+                    item_ids=[first_item_id],
+                )
+            ]
+        )
+        partially_picked = app_main.pickup_borrow_request_api(created.id, first_pickup, BackgroundTasks())
+        self.assertEqual(partially_picked.status, 'partial_borrowed')
+        self.assertEqual(partially_picked.request_lines[0].allocated_qty, 1)
+
+        pickup_lines = app_main.list_borrow_pickup_lines_api(created.id)
+        self.assertEqual(len(pickup_lines), 1)
+        self.assertEqual(pickup_lines[0].allocated_qty, 1)
+        self.assertEqual(pickup_lines[0].remaining_qty, 1)
+
+        second_pickup = app_main.BorrowPickupRequest(
+            selections=[
+                app_main.BorrowPickupSelection(
+                    line_id=created.request_lines[0].id,
+                    item_ids=[second_item_id],
+                )
+            ]
+        )
+        fully_picked = app_main.pickup_borrow_request_api(created.id, second_pickup, BackgroundTasks())
+        self.assertIn(fully_picked.status, {'borrowed', 'overdue'})
+        self.assertEqual(fully_picked.request_lines[0].allocated_qty, 2)
+
+    def test_borrow_api_allows_return_from_partial_borrowed(self) -> None:
+        first_item_id = self._create_item(name='平板', model='R2')
+        self._create_item(name='平板', model='R2')
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '平板', 'item_model': 'R2', 'requested_qty': 2, 'note': ''}]),
+            BackgroundTasks(),
+        )
+        partial_pickup = app_main.BorrowPickupRequest(
+            selections=[
+                app_main.BorrowPickupSelection(
+                    line_id=created.request_lines[0].id,
+                    item_ids=[first_item_id],
+                )
+            ]
+        )
+        partially_picked = app_main.pickup_borrow_request_api(created.id, partial_pickup, BackgroundTasks())
+        self.assertEqual(partially_picked.status, 'partial_borrowed')
 
         returned = app_main.return_borrow_request_api(created.id, BackgroundTasks())
         self.assertEqual(returned.status, 'returned')

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -267,6 +267,26 @@ class RequestApiGuardTests(unittest.TestCase):
         fetched = app_main.get_borrow_request_api(created.id)
         self.assertEqual(fetched.status, 'expired')
 
+    def test_borrow_reservation_auto_cancelled_after_3_days(self) -> None:
+        self._create_item(name='相機', model='M3')
+        request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date=(date.today() - timedelta(days=3)).isoformat(),
+            due_date=(date.today() + timedelta(days=3)).isoformat(),
+            memo='',
+            request_lines=[{'item_name': '相機', 'item_model': 'M3', 'requested_qty': 1, 'note': ''}],
+        )
+        created = app_main.create_borrow_request_api(request, BackgroundTasks())
+        fetched = app_main.get_borrow_request_api(created.id)
+        self.assertEqual(fetched.status, 'cancelled')
+
+        logs = db.list_operation_logs(action='auto_cancel_reservation', entity='borrow_request', entity_id=created.id)
+        self.assertGreaterEqual(len(logs), 1)
+        self.assertEqual(logs[0].get('action'), 'auto_cancel_reservation')
+        self.assertEqual(logs[0].get('entity_id'), created.id)
+
     def test_logs_api_rejects_invalid_scope(self) -> None:
         with self.assertRaises(HTTPException) as exc:
             app_main.list_operation_logs_api(scope='archive-only', page=1, page_size=10)

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -16,9 +16,9 @@ class RequestApiGuardTests(unittest.TestCase):
         self._original_lock_path = db.LOCK_PATH
         self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
 
-        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
-        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
-        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.DB_PATH = Path(self._tmpdir.name) / 'inventory.xlsx'
+        db.LOCK_PATH = Path(self._tmpdir.name) / 'inventory.xlsx.lock'
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / 'log_archive'
         db.init_db()
 
     def tearDown(self) -> None:
@@ -27,96 +27,118 @@ class RequestApiGuardTests(unittest.TestCase):
         db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
         self._tmpdir.cleanup()
 
-    def _create_item(self, *, asset_status: str = "0") -> int:
+    def _create_item(self, *, asset_status: str = '0', name: str = '測試品項', model: str = 'M1') -> int:
         return db.create_item(
             {
-                "asset_type": "A1",
-                "asset_status": asset_status,
-                "name": "測試品項",
-                "model": "M1",
-                "count": 1,
+                'asset_type': 'A1',
+                'asset_status': asset_status,
+                'name': name,
+                'model': model,
+                'count': 1,
             }
         )
 
     @staticmethod
     def _issue_request(items: list[dict]) -> app_main.IssueRequestCreate:
         return app_main.IssueRequestCreate(
-            requester="tester",
-            department="qa",
-            purpose="test",
-            request_date="2026-04-10",
-            memo="",
+            requester='tester',
+            department='qa',
+            purpose='test',
+            request_date='2026-04-10',
+            memo='',
             items=items,
         )
 
     @staticmethod
-    def _borrow_request(items: list[dict]) -> app_main.BorrowRequestCreate:
+    def _borrow_request(lines: list[dict]) -> app_main.BorrowRequestCreate:
         return app_main.BorrowRequestCreate(
-            borrower="tester",
-            department="qa",
-            purpose="test",
-            borrow_date="2026-04-10",
-            due_date="2026-04-20",
-            return_date=None,
-            status="borrowed",
-            memo="",
-            items=items,
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date='2026-04-10',
+            due_date='2026-04-20',
+            memo='',
+            request_lines=lines,
         )
 
     def test_issue_api_rejects_duplicate_item_id(self) -> None:
         item_id = self._create_item()
         request = self._issue_request(
             [
-                {"item_id": item_id, "quantity": 1, "note": ""},
-                {"item_id": item_id, "quantity": 1, "note": ""},
+                {'item_id': item_id, 'quantity': 1, 'note': ''},
+                {'item_id': item_id, 'quantity': 1, 'note': ''},
             ]
         )
         with self.assertRaises(HTTPException) as exc:
             app_main.create_issue_request_api(request, BackgroundTasks())
         self.assertEqual(exc.exception.status_code, 400)
-        self.assertEqual(exc.exception.detail, "item_id cannot be duplicated")
+        self.assertEqual(exc.exception.detail, 'item_id cannot be duplicated')
 
     def test_issue_api_rejects_unavailable_item(self) -> None:
-        item_id = self._create_item(asset_status="1")
-        request = self._issue_request([{"item_id": item_id, "quantity": 1, "note": ""}])
+        item_id = self._create_item(asset_status='1')
+        request = self._issue_request([{'item_id': item_id, 'quantity': 1, 'note': ''}])
         with self.assertRaises(HTTPException) as exc:
             app_main.create_issue_request_api(request, BackgroundTasks())
         self.assertEqual(exc.exception.status_code, 400)
-        self.assertEqual(exc.exception.detail, f"item_id {item_id} is unavailable")
+        self.assertEqual(exc.exception.detail, f'item_id {item_id} is unavailable')
 
-    def test_borrow_api_rejects_unavailable_item(self) -> None:
-        item_id = self._create_item(asset_status="2")
-        request = self._borrow_request([{"item_id": item_id, "quantity": 1, "note": ""}])
+    def test_borrow_api_rejects_insufficient_reservable_quantity(self) -> None:
+        self._create_item(name='投影機', model='X1')
+        request = self._borrow_request(
+            [
+                {'item_name': '投影機', 'item_model': 'X1', 'requested_qty': 2, 'note': ''},
+            ]
+        )
         with self.assertRaises(HTTPException) as exc:
             app_main.create_borrow_request_api(request, BackgroundTasks())
         self.assertEqual(exc.exception.status_code, 400)
-        self.assertEqual(exc.exception.detail, f"item_id {item_id} is unavailable")
+        detail = exc.exception.detail
+        self.assertIsInstance(detail, dict)
+        self.assertEqual(detail.get('message'), 'insufficient_reservable_quantity')
+        self.assertEqual(detail.get('shortages')[0]['shortage_qty'], 1)
 
-    def test_borrow_api_overrides_manual_status_and_returns_due_soon_flag(self) -> None:
-        item_id = self._create_item(asset_status="0")
-        due_soon_date = date.today() + timedelta(days=1)
-        request = app_main.BorrowRequestCreate(
-            borrower="tester",
-            department="qa",
-            purpose="test",
-            borrow_date=date.today().isoformat(),
-            due_date=due_soon_date.isoformat(),
-            return_date=None,
-            status="returned",
-            memo="",
-            items=[{"item_id": item_id, "quantity": 1, "note": ""}],
+    def test_borrow_api_creates_reserved_and_pickup_then_return(self) -> None:
+        self._create_item(name='筆電', model='A1')
+        self._create_item(name='筆電', model='A1')
+
+        request = self._borrow_request(
+            [
+                {'item_name': '筆電', 'item_model': 'A1', 'requested_qty': 2, 'note': ''},
+            ]
         )
-
         created = app_main.create_borrow_request_api(request, BackgroundTasks())
-        self.assertEqual(created.status, "borrowed")
-        self.assertTrue(created.is_due_soon)
+        self.assertEqual(created.status, 'reserved')
+        self.assertFalse(created.is_due_soon)
+        self.assertEqual(created.request_lines[0].allocated_qty, 0)
+
+        picked = app_main.pickup_borrow_request_api(created.id, BackgroundTasks())
+        self.assertIn(picked.status, {'borrowed', 'overdue'})
+        self.assertEqual(picked.request_lines[0].allocated_qty, 2)
+
+        returned = app_main.return_borrow_request_api(created.id, BackgroundTasks())
+        self.assertEqual(returned.status, 'returned')
+
+    def test_borrow_expired_reservation_auto_release(self) -> None:
+        self._create_item(name='相機', model='M2')
+        request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date=(date.today() - timedelta(days=1)).isoformat(),
+            due_date=(date.today() + timedelta(days=3)).isoformat(),
+            memo='',
+            request_lines=[{'item_name': '相機', 'item_model': 'M2', 'requested_qty': 1, 'note': ''}],
+        )
+        created = app_main.create_borrow_request_api(request, BackgroundTasks())
+        fetched = app_main.get_borrow_request_api(created.id)
+        self.assertEqual(fetched.status, 'expired')
 
     def test_logs_api_rejects_invalid_scope(self) -> None:
         with self.assertRaises(HTTPException) as exc:
-            app_main.list_operation_logs_api(scope="archive-only", page=1, page_size=10)
+            app_main.list_operation_logs_api(scope='archive-only', page=1, page_size=10)
         self.assertEqual(exc.exception.status_code, 400)
-        self.assertEqual(exc.exception.detail, "scope must be one of: hot, all")
+        self.assertEqual(exc.exception.detail, 'scope must be one of: hot, all')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -126,6 +126,74 @@ class RequestApiGuardTests(unittest.TestCase):
         returned = app_main.return_borrow_request_api(created.id, BackgroundTasks())
         self.assertEqual(returned.status, 'returned')
 
+    def test_borrow_api_rejects_missing_borrow_date(self) -> None:
+        self._create_item(name='筆電', model='A1')
+        request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date=None,
+            due_date='2026-04-20',
+            memo='',
+            request_lines=[{'item_name': '筆電', 'item_model': 'A1', 'requested_qty': 1, 'note': ''}],
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_borrow_request_api(request, BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, 'borrow_date is required')
+
+    def test_borrow_api_rejects_missing_due_date(self) -> None:
+        self._create_item(name='筆電', model='A1')
+        request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date='2026-04-10',
+            due_date=None,
+            memo='',
+            request_lines=[{'item_name': '筆電', 'item_model': 'A1', 'requested_qty': 1, 'note': ''}],
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_borrow_request_api(request, BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, 'due_date is required')
+
+    def test_borrow_api_rejects_date_span_exceeding_30_days(self) -> None:
+        self._create_item(name='筆電', model='A1')
+        request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date='2026-04-10',
+            due_date='2026-05-11',
+            memo='',
+            request_lines=[{'item_name': '筆電', 'item_model': 'A1', 'requested_qty': 1, 'note': ''}],
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_borrow_request_api(request, BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, 'borrow reservation cannot exceed 30 days')
+
+    def test_borrow_update_api_rejects_date_span_exceeding_30_days(self) -> None:
+        self._create_item(name='平板', model='P1')
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '平板', 'item_model': 'P1', 'requested_qty': 1, 'note': ''}]),
+            BackgroundTasks(),
+        )
+        update_request = app_main.BorrowRequestCreate(
+            borrower='tester',
+            department='qa',
+            purpose='test',
+            borrow_date='2026-04-10',
+            due_date='2026-05-11',
+            memo='',
+            request_lines=[{'item_name': '平板', 'item_model': 'P1', 'requested_qty': 1, 'note': ''}],
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.update_borrow_request_api(created.id, update_request, BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, 'borrow reservation cannot exceed 30 days')
+
     def test_borrow_pickup_requires_explicit_selections(self) -> None:
         self._create_item(name='平板', model='P1')
         created = app_main.create_borrow_request_api(
@@ -157,6 +225,32 @@ class RequestApiGuardTests(unittest.TestCase):
             app_main.pickup_borrow_request_api(created.id, payload, BackgroundTasks())
         self.assertEqual(exc.exception.status_code, 400)
         self.assertEqual(exc.exception.detail, f'item_id {wrong_item_id} does not match line_id {created.request_lines[0].id}')
+
+    def test_borrow_pickup_lines_candidates_and_scan_resolve(self) -> None:
+        first_id = self._create_item(name='相機', model='R1')
+        second_id = self._create_item(name='相機', model='R1')
+        self.assertGreater(first_id, 0)
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '相機', 'item_model': 'R1', 'requested_qty': 1, 'note': ''}]),
+            BackgroundTasks(),
+        )
+
+        lines = app_main.list_borrow_pickup_lines_api(created.id)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0].line_id, created.request_lines[0].id)
+        self.assertEqual(lines[0].requested_qty, 1)
+        self.assertGreaterEqual(lines[0].candidate_count, 2)
+
+        page = app_main.list_borrow_pickup_line_candidates_api(created.id, created.request_lines[0].id, keyword='', page=1, page_size=1)
+        self.assertEqual(page.page, 1)
+        self.assertEqual(page.page_size, 1)
+        self.assertEqual(page.total, 2)
+        self.assertEqual(len(page.items), 1)
+
+        serial_code = page.items[0].n_property_sn or page.items[0].property_sn or page.items[0].n_item_sn or page.items[0].item_sn
+        resolved = app_main.resolve_borrow_pickup_scan_api(created.id, app_main.BorrowPickupScanResolveRequest(code=serial_code))
+        self.assertEqual(resolved.item.id, page.items[0].id)
+        self.assertIn(created.request_lines[0].id, resolved.eligible_line_ids)
 
     def test_borrow_expired_reservation_auto_release(self) -> None:
         self._create_item(name='相機', model='M2')

--- a/backend/tests/test_request_api_guards.py
+++ b/backend/tests/test_request_api_guards.py
@@ -98,8 +98,8 @@ class RequestApiGuardTests(unittest.TestCase):
         self.assertEqual(detail.get('shortages')[0]['shortage_qty'], 1)
 
     def test_borrow_api_creates_reserved_and_pickup_then_return(self) -> None:
-        self._create_item(name='筆電', model='A1')
-        self._create_item(name='筆電', model='A1')
+        first_item_id = self._create_item(name='筆電', model='A1')
+        second_item_id = self._create_item(name='筆電', model='A1')
 
         request = self._borrow_request(
             [
@@ -111,12 +111,52 @@ class RequestApiGuardTests(unittest.TestCase):
         self.assertFalse(created.is_due_soon)
         self.assertEqual(created.request_lines[0].allocated_qty, 0)
 
-        picked = app_main.pickup_borrow_request_api(created.id, BackgroundTasks())
+        pickup_payload = app_main.BorrowPickupRequest(
+            selections=[
+                app_main.BorrowPickupSelection(
+                    line_id=created.request_lines[0].id,
+                    item_ids=[first_item_id, second_item_id],
+                )
+            ]
+        )
+        picked = app_main.pickup_borrow_request_api(created.id, pickup_payload, BackgroundTasks())
         self.assertIn(picked.status, {'borrowed', 'overdue'})
         self.assertEqual(picked.request_lines[0].allocated_qty, 2)
 
         returned = app_main.return_borrow_request_api(created.id, BackgroundTasks())
         self.assertEqual(returned.status, 'returned')
+
+    def test_borrow_pickup_requires_explicit_selections(self) -> None:
+        self._create_item(name='平板', model='P1')
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '平板', 'item_model': 'P1', 'requested_qty': 1, 'note': ''}]),
+            BackgroundTasks(),
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.pickup_borrow_request_api(created.id, app_main.BorrowPickupRequest(selections=[]), BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, 'pickup selections are required')
+
+    def test_borrow_pickup_rejects_item_not_matching_line(self) -> None:
+        requested_item_id = self._create_item(name='投影機', model='X1')
+        wrong_item_id = self._create_item(name='相機', model='C1')
+        created = app_main.create_borrow_request_api(
+            self._borrow_request([{'item_name': '投影機', 'item_model': 'X1', 'requested_qty': 1, 'note': ''}]),
+            BackgroundTasks(),
+        )
+        self.assertGreater(requested_item_id, 0)
+        payload = app_main.BorrowPickupRequest(
+            selections=[
+                app_main.BorrowPickupSelection(
+                    line_id=created.request_lines[0].id,
+                    item_ids=[wrong_item_id],
+                )
+            ]
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.pickup_borrow_request_api(created.id, payload, BackgroundTasks())
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, f'item_id {wrong_item_id} does not match line_id {created.request_lines[0].id}')
 
     def test_borrow_expired_reservation_auto_release(self) -> None:
         self._create_item(name='相機', model='M2')

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -126,7 +126,11 @@ class TransactionConsistencyTests(unittest.TestCase):
         self.assertEqual(item_after_reservation_1['asset_status'], '0')
         self.assertEqual(item_after_reservation_2['asset_status'], '0')
 
-        db.pickup_borrow_request(request_id)
+        line_id = db.list_borrow_items(request_id)[0]['id']
+        db.pickup_borrow_request(
+            request_id,
+            [{'line_id': line_id, 'item_ids': [first_id, second_id]}],
+        )
         item_after_pickup_1 = db.get_item_by_id(first_id)
         item_after_pickup_2 = db.get_item_by_id(second_id)
         self.assertEqual(item_after_pickup_1['asset_status'], '2')
@@ -274,7 +278,11 @@ class TransactionConsistencyTests(unittest.TestCase):
             self._borrow_payload(),
             [{'item_name': '測試品項', 'item_model': 'M1', 'requested_qty': 1, 'note': ''}],
         )
-        db.pickup_borrow_request(borrow_request_id)
+        borrow_line_id = db.list_borrow_items(borrow_request_id)[0]['id']
+        db.pickup_borrow_request(
+            borrow_request_id,
+            [{'line_id': borrow_line_id, 'item_ids': [occupied_item_id]}],
+        )
 
         with self.assertRaisesRegex(ValueError, f'item_id {occupied_item_id} is unavailable'):
             db.update_issue_request(

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -44,13 +44,15 @@ class TransactionConsistencyTests(unittest.TestCase):
             'memo': '',
         }
 
-    def _borrow_payload(self, *, borrow_date: str = '2026-04-10', due_date: str = '2026-04-20') -> dict:
+    def _borrow_payload(self, *, borrow_date: str | None = None, due_date: str | None = None) -> dict:
+        resolved_borrow_date = borrow_date or (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
+        resolved_due_date = due_date or (date.today() + timedelta(days=10)).strftime('%Y-%m-%d')
         return {
             'borrower': 'tester',
             'department': 'qa',
             'purpose': 'test',
-            'borrow_date': borrow_date,
-            'due_date': due_date,
+            'borrow_date': resolved_borrow_date,
+            'due_date': resolved_due_date,
             'memo': '',
         }
 

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -1,6 +1,6 @@
 import tempfile
 import unittest
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import db
@@ -13,9 +13,9 @@ class TransactionConsistencyTests(unittest.TestCase):
         self._original_lock_path = db.LOCK_PATH
         self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
 
-        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
-        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
-        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.DB_PATH = Path(self._tmpdir.name) / 'inventory.xlsx'
+        db.LOCK_PATH = Path(self._tmpdir.name) / 'inventory.xlsx.lock'
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / 'log_archive'
         db.init_db()
 
     def tearDown(self) -> None:
@@ -24,74 +24,71 @@ class TransactionConsistencyTests(unittest.TestCase):
         db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
         self._tmpdir.cleanup()
 
-    def _create_item(self, *, asset_status: str = "0", count: int = 1) -> int:
+    def _create_item(self, *, asset_status: str = '0', count: int = 1, name: str = '測試品項', model: str = 'M1') -> int:
         return db.create_item(
             {
-                "asset_type": "A1",
-                "asset_status": asset_status,
-                "name": "測試品項",
-                "model": "M1",
-                "count": count,
+                'asset_type': 'A1',
+                'asset_status': asset_status,
+                'name': name,
+                'model': model,
+                'count': count,
             }
         )
 
     def _issue_payload(self) -> dict:
         return {
-            "requester": "tester",
-            "department": "qa",
-            "purpose": "test",
-            "request_date": "2026-04-10",
-            "memo": "",
+            'requester': 'tester',
+            'department': 'qa',
+            'purpose': 'test',
+            'request_date': '2026-04-10',
+            'memo': '',
         }
 
-    def _borrow_payload(self, *, status: str) -> dict:
-        return_date = "2026-04-12" if status == "returned" else ""
+    def _borrow_payload(self, *, borrow_date: str = '2026-04-10', due_date: str = '2026-04-20') -> dict:
         return {
-            "borrower": "tester",
-            "department": "qa",
-            "purpose": "test",
-            "borrow_date": "2026-04-10",
-            "due_date": "2026-04-20",
-            "return_date": return_date,
-            "status": status,
-            "memo": "",
+            'borrower': 'tester',
+            'department': 'qa',
+            'purpose': 'test',
+            'borrow_date': borrow_date,
+            'due_date': due_date,
+            'memo': '',
         }
 
     def _donation_payload(self) -> dict:
         return {
-            "donor": "tester",
-            "department": "qa",
-            "recipient": "receiver",
-            "purpose": "test",
-            "donation_date": "2026-04-10",
-            "memo": "",
+            'donor': 'tester',
+            'department': 'qa',
+            'recipient': 'receiver',
+            'purpose': 'test',
+            'donation_date': '2026-04-10',
+            'memo': '',
         }
 
     def test_quantity_must_be_one(self) -> None:
         item_id = self._create_item()
-        with self.assertRaisesRegex(ValueError, "quantity must be 1"):
+        with self.assertRaisesRegex(ValueError, 'quantity must be 1'):
             db.create_issue_request(
                 self._issue_payload(),
-                [{"item_id": item_id, "quantity": 2, "note": ""}],
+                [{'item_id': item_id, 'quantity': 2, 'note': ''}],
             )
 
     def test_item_id_cannot_be_duplicated(self) -> None:
         item_id = self._create_item()
-        with self.assertRaisesRegex(ValueError, "item_id cannot be duplicated"):
+        with self.assertRaisesRegex(ValueError, 'item_id cannot be duplicated'):
             db.create_issue_request(
                 self._issue_payload(),
                 [
-                    {"item_id": item_id, "quantity": 1, "note": ""},
-                    {"item_id": item_id, "quantity": 1, "note": ""},
+                    {'item_id': item_id, 'quantity': 1, 'note': ''},
+                    {'item_id': item_id, 'quantity': 1, 'note': ''},
                 ],
             )
 
     def test_create_request_rejects_unavailable_item(self) -> None:
-        unavailable_item_id = self._create_item(asset_status="2")
-        with self.assertRaisesRegex(ValueError, f"item_id {unavailable_item_id} is unavailable"):
+        unavailable_item_id = self._create_item(asset_status='2')
+        with self.assertRaisesRegex(ValueError, f'item_id {unavailable_item_id} is unavailable'):
             db.create_issue_request(
                 self._issue_payload(),
-                [{"item_id": unavailable_item_id, "quantity": 1, "note": ""}],
+                [{'item_id': unavailable_item_id, 'quantity': 1, 'note': ''}],
             )
 
     def test_issue_request_updates_status_only(self) -> None:
@@ -99,146 +96,171 @@ class TransactionConsistencyTests(unittest.TestCase):
 
         request_id = db.create_issue_request(
             self._issue_payload(),
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
+            [{'item_id': item_id, 'quantity': 1, 'note': ''}],
         )
         item_after_create = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_create)
-        self.assertEqual(item_after_create["count"], 1)
-        self.assertEqual(item_after_create["asset_status"], "1")
+        self.assertEqual(item_after_create['count'], 1)
+        self.assertEqual(item_after_create['asset_status'], '1')
 
         db.delete_issue_request(request_id)
         item_after_delete = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_delete)
-        self.assertEqual(item_after_delete["count"], 1)
-        self.assertEqual(item_after_delete["asset_status"], "0")
+        self.assertEqual(item_after_delete['count'], 1)
+        self.assertEqual(item_after_delete['asset_status'], '0')
 
-    def test_borrow_return_flow_updates_status_only(self) -> None:
-        item_id = self._create_item()
+    def test_borrow_reservation_pickup_return_flow_updates_status_only(self) -> None:
+        first_id = self._create_item(name='平板', model='T1')
+        second_id = self._create_item(name='平板', model='T1')
 
         request_id = db.create_borrow_request(
-            self._borrow_payload(status="borrowed"),
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
+            self._borrow_payload(),
+            [{'item_name': '平板', 'item_model': 'T1', 'requested_qty': 2, 'note': ''}],
         )
-        item_after_borrow = db.get_item_by_id(item_id)
-        self.assertIsNotNone(item_after_borrow)
-        self.assertEqual(item_after_borrow["count"], 1)
-        self.assertEqual(item_after_borrow["asset_status"], "2")
+        request = db.get_borrow_request(request_id)
+        self.assertIsNotNone(request)
+        self.assertEqual(request['status'], 'reserved')
 
-        db.update_borrow_request(
-            request_id,
-            self._borrow_payload(status="returned"),
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
-        )
+        item_after_reservation_1 = db.get_item_by_id(first_id)
+        item_after_reservation_2 = db.get_item_by_id(second_id)
+        self.assertEqual(item_after_reservation_1['asset_status'], '0')
+        self.assertEqual(item_after_reservation_2['asset_status'], '0')
+
+        db.pickup_borrow_request(request_id)
+        item_after_pickup_1 = db.get_item_by_id(first_id)
+        item_after_pickup_2 = db.get_item_by_id(second_id)
+        self.assertEqual(item_after_pickup_1['asset_status'], '2')
+        self.assertEqual(item_after_pickup_2['asset_status'], '2')
+
+        db.return_borrow_request(request_id)
+        item_after_return_1 = db.get_item_by_id(first_id)
+        item_after_return_2 = db.get_item_by_id(second_id)
+        self.assertEqual(item_after_return_1['asset_status'], '0')
+        self.assertEqual(item_after_return_2['asset_status'], '0')
+
+    def test_legacy_borrow_items_can_be_returned_without_allocations(self) -> None:
+        item_id = self._create_item(asset_status='2', name='老資料設備', model='L1')
+
+        with db._locked_workbook() as wb:
+            request_ws = wb['borrow_requests']
+            item_ws = wb['borrow_items']
+            request_rows = db._read_rows(request_ws)
+            item_rows = db._read_rows(item_ws)
+            request_id = db._next_id(request_rows)
+            request_rows.append(
+                {
+                    'id': request_id,
+                    'borrower': 'legacy-user',
+                    'department': 'qa',
+                    'purpose': 'legacy test',
+                    'borrow_date': '2026-04-10',
+                    'due_date': '2026-04-20',
+                    'return_date': '',
+                    'status': 'borrowed',
+                    'memo': '',
+                    'created_at': '2026-04-10 10:00:00',
+                }
+            )
+            next_item_row_id = db._next_id(item_rows)
+            item_rows.append(
+                {
+                    'id': next_item_row_id,
+                    'request_id': request_id,
+                    'item_id': item_id,
+                    'quantity': 1,
+                    'note': 'legacy row',
+                }
+            )
+            db._write_rows(request_ws, db.SHEETS['borrow_requests'], request_rows)
+            db._write_rows(item_ws, db.SHEETS['borrow_items'], item_rows)
+            wb.save(db.DB_PATH)
+
+        returned = db.return_borrow_request(request_id)
+        self.assertTrue(returned)
         item_after_return = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_return)
-        self.assertEqual(item_after_return["count"], 1)
-        self.assertEqual(item_after_return["asset_status"], "0")
+        self.assertEqual(item_after_return['asset_status'], '0')
+        request_after_return = db.get_borrow_request(request_id)
+        self.assertIsNotNone(request_after_return)
+        self.assertEqual(request_after_return['status'], 'returned')
 
     def test_borrow_status_is_derived_from_dates(self) -> None:
         self.assertEqual(
-            db._derive_borrow_status(due_date_value="2026-04-20", return_date_value="", today=date(2026, 4, 20)),
-            "borrowed",
+            db._derive_borrow_status(
+                due_date_value='2026-04-20',
+                return_date_value='',
+                status_value='reserved',
+                borrow_date_value='2026-04-21',
+                has_allocations=False,
+                today=date(2026, 4, 20),
+            ),
+            'reserved',
         )
         self.assertEqual(
-            db._derive_borrow_status(due_date_value="2026-04-20", return_date_value="", today=date(2026, 4, 21)),
-            "overdue",
+            db._derive_borrow_status(
+                due_date_value='2026-04-20',
+                return_date_value='',
+                status_value='reserved',
+                borrow_date_value='2026-04-20',
+                has_allocations=True,
+                today=date(2026, 4, 21),
+            ),
+            'overdue',
         )
         self.assertEqual(
-            db._derive_borrow_status(due_date_value="2026-04-20", return_date_value="2026-04-19", today=date(2026, 4, 21)),
-            "returned",
+            db._derive_borrow_status(
+                due_date_value='2026-04-20',
+                return_date_value='2026-04-19',
+                status_value='borrowed',
+                borrow_date_value='2026-04-18',
+                has_allocations=True,
+                today=date(2026, 4, 21),
+            ),
+            'returned',
         )
 
     def test_due_soon_rule_matches_three_day_window(self) -> None:
         self.assertTrue(
-            db._is_due_soon(due_date_value="2026-04-20", return_date_value="", today=date(2026, 4, 17), days=3)
+            db._is_due_soon(due_date_value='2026-04-20', return_date_value='', today=date(2026, 4, 17), days=3)
         )
         self.assertFalse(
-            db._is_due_soon(due_date_value="2026-04-21", return_date_value="", today=date(2026, 4, 17), days=3)
+            db._is_due_soon(due_date_value='2026-04-21', return_date_value='', today=date(2026, 4, 17), days=3)
         )
         self.assertFalse(
-            db._is_due_soon(due_date_value="2026-04-16", return_date_value="", today=date(2026, 4, 17), days=3)
+            db._is_due_soon(due_date_value='2026-04-16', return_date_value='', today=date(2026, 4, 17), days=3)
         )
         self.assertFalse(
-            db._is_due_soon(due_date_value="2026-04-18", return_date_value="2026-04-17", today=date(2026, 4, 17), days=3)
+            db._is_due_soon(due_date_value='2026-04-18', return_date_value='2026-04-17', today=date(2026, 4, 17), days=3)
         )
 
-    def test_create_borrow_request_ignores_manual_status_input(self) -> None:
-        item_id = self._create_item()
+    def test_expired_reservation_releases_hold(self) -> None:
+        self._create_item(name='麥克風', model='M9')
+        past_date = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
         request_id = db.create_borrow_request(
-            {
-                "borrower": "tester",
-                "department": "qa",
-                "purpose": "test",
-                "borrow_date": "2026-04-10",
-                "due_date": "2999-12-31",
-                "return_date": "",
-                "status": "returned",
-                "memo": "",
-            },
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
-        )
-        request = db.get_borrow_request(request_id)
-        self.assertIsNotNone(request)
-        self.assertEqual(request["status"], "borrowed")
-
-        item = db.get_item_by_id(item_id)
-        self.assertIsNotNone(item)
-        self.assertEqual(item["asset_status"], "2")
-
-    def test_update_borrow_request_ignores_manual_status_input(self) -> None:
-        item_id = self._create_item()
-        request_id = db.create_borrow_request(
-            self._borrow_payload(status="borrowed"),
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
-        )
-
-        db.update_borrow_request(
-            request_id,
-            {
-                "borrower": "tester",
-                "department": "qa",
-                "purpose": "test",
-                "borrow_date": "2026-04-10",
-                "due_date": "2999-12-31",
-                "return_date": "",
-                "status": "returned",
-                "memo": "",
-            },
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
+            self._borrow_payload(borrow_date=past_date, due_date=(date.today() + timedelta(days=3)).strftime('%Y-%m-%d')),
+            [{'item_name': '麥克風', 'item_model': 'M9', 'requested_qty': 1, 'note': ''}],
         )
 
         request = db.get_borrow_request(request_id)
         self.assertIsNotNone(request)
-        self.assertEqual(request["status"], "borrowed")
+        self.assertEqual(request['status'], 'expired')
 
-    def test_list_borrow_requests_syncs_stale_status(self) -> None:
-        item_id = self._create_item()
-        request_id = db.create_borrow_request(
+        second_id = db.create_item(
             {
-                "borrower": "tester",
-                "department": "qa",
-                "purpose": "test",
-                "borrow_date": "2020-01-01",
-                "due_date": "2020-01-02",
-                "return_date": "",
-                "status": "borrowed",
-                "memo": "",
-            },
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '麥克風',
+                'model': 'M9',
+                'count': 1,
+            }
         )
+        self.assertGreater(second_id, 0)
 
-        with db._locked_workbook() as wb:
-            ws = wb["borrow_requests"]
-            rows = db._read_rows(ws)
-            for row in rows:
-                if int(row.get("id") or 0) == request_id:
-                    row["status"] = "returned"
-            db._write_rows(ws, db.SHEETS["borrow_requests"], rows)
-            wb.save(db.DB_PATH)
-
-        requests = db.list_borrow_requests()
-        target = next(row for row in requests if int(row.get("id") or 0) == request_id)
-        self.assertEqual(target["status"], "overdue")
+        another_request_id = db.create_borrow_request(
+            self._borrow_payload(),
+            [{'item_name': '麥克風', 'item_model': 'M9', 'requested_qty': 2, 'note': ''}],
+        )
+        self.assertGreater(another_request_id, 0)
 
     def test_issue_update_rejects_unavailable_item_and_keeps_original_status(self) -> None:
         issue_item_id = self._create_item()
@@ -246,45 +268,46 @@ class TransactionConsistencyTests(unittest.TestCase):
 
         issue_request_id = db.create_issue_request(
             self._issue_payload(),
-            [{"item_id": issue_item_id, "quantity": 1, "note": ""}],
+            [{'item_id': issue_item_id, 'quantity': 1, 'note': ''}],
         )
-        db.create_borrow_request(
-            self._borrow_payload(status="borrowed"),
-            [{"item_id": occupied_item_id, "quantity": 1, "note": ""}],
+        borrow_request_id = db.create_borrow_request(
+            self._borrow_payload(),
+            [{'item_name': '測試品項', 'item_model': 'M1', 'requested_qty': 1, 'note': ''}],
         )
+        db.pickup_borrow_request(borrow_request_id)
 
-        with self.assertRaisesRegex(ValueError, f"item_id {occupied_item_id} is unavailable"):
+        with self.assertRaisesRegex(ValueError, f'item_id {occupied_item_id} is unavailable'):
             db.update_issue_request(
                 issue_request_id,
                 self._issue_payload(),
-                [{"item_id": occupied_item_id, "quantity": 1, "note": ""}],
+                [{'item_id': occupied_item_id, 'quantity': 1, 'note': ''}],
             )
 
         issue_item_after = db.get_item_by_id(issue_item_id)
         occupied_item_after = db.get_item_by_id(occupied_item_id)
         self.assertIsNotNone(issue_item_after)
         self.assertIsNotNone(occupied_item_after)
-        self.assertEqual(issue_item_after["asset_status"], "1")
-        self.assertEqual(occupied_item_after["asset_status"], "2")
+        self.assertEqual(issue_item_after['asset_status'], '1')
+        self.assertEqual(occupied_item_after['asset_status'], '2')
 
     def test_donation_sets_status_and_reverts_on_delete(self) -> None:
         item_id = self._create_item()
 
         request_id = db.create_donation_request(
             self._donation_payload(),
-            [{"item_id": item_id, "quantity": 1, "note": ""}],
+            [{'item_id': item_id, 'quantity': 1, 'note': ''}],
         )
         item_after_create = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_create)
-        self.assertEqual(item_after_create["count"], 1)
-        self.assertEqual(item_after_create["asset_status"], "3")
+        self.assertEqual(item_after_create['count'], 1)
+        self.assertEqual(item_after_create['asset_status'], '3')
 
         db.delete_donation_request(request_id)
         item_after_delete = db.get_item_by_id(item_id)
         self.assertIsNotNone(item_after_delete)
-        self.assertEqual(item_after_delete["count"], 1)
-        self.assertEqual(item_after_delete["asset_status"], "0")
+        self.assertEqual(item_after_delete['count'], 1)
+        self.assertEqual(item_after_delete['asset_status'], '0')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -15,10 +15,11 @@ import type { BorrowRequest, PaginatedResponse } from './types'
 
 type BorrowSortKey = 'id' | 'borrow_date' | 'borrower' | 'purpose' | 'return_info' | 'items' | 'memo'
 type SortDirection = 'asc' | 'desc'
-type BorrowStatusFilter = 'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired' | 'cancelled'
+type BorrowStatusFilter = 'all' | 'reserved' | 'partial_borrowed' | 'borrowed' | 'returned' | 'overdue' | 'expired' | 'cancelled'
 
 const statusLabelMap: Record<string, string> = {
   reserved: '已預約',
+  partial_borrowed: '部分借出',
   borrowed: '借出中',
   returned: '已歸還',
   overdue: '逾期',
@@ -28,6 +29,7 @@ const statusLabelMap: Record<string, string> = {
 
 const statusBadgeClassMap: Record<string, string> = {
   reserved: 'border-amber-200 bg-amber-100 text-amber-800',
+  partial_borrowed: 'border-cyan-200 bg-cyan-100 text-cyan-800',
   borrowed: 'border-sky-200 bg-sky-100 text-sky-800',
   returned: 'border-emerald-200 bg-emerald-100 text-emerald-800',
   overdue: 'border-red-200 bg-red-100 text-red-800',
@@ -64,6 +66,7 @@ function readInitialState() {
   const statusParam = params.get('status')
   const status: BorrowStatusFilter =
     statusParam === 'reserved'
+    || statusParam === 'partial_borrowed'
     || statusParam === 'borrowed'
     || statusParam === 'returned'
     || statusParam === 'overdue'
@@ -232,6 +235,7 @@ export function BorrowListPage() {
             >
               <option value="all">全部狀態</option>
               <option value="reserved">已預約</option>
+              <option value="partial_borrowed">部分借出</option>
               <option value="borrowed">借出中</option>
               <option value="returned">已歸還</option>
               <option value="overdue">逾期</option>

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -15,6 +15,7 @@ import type { BorrowRequest, PaginatedResponse } from './types'
 
 type BorrowSortKey = 'id' | 'borrow_date' | 'borrower' | 'purpose' | 'return_info' | 'items' | 'memo'
 type SortDirection = 'asc' | 'desc'
+type BorrowStatusFilter = 'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired' | 'cancelled'
 
 const statusLabelMap: Record<string, string> = {
   reserved: '已預約',
@@ -22,6 +23,7 @@ const statusLabelMap: Record<string, string> = {
   returned: '已歸還',
   overdue: '逾期',
   expired: '預約失效',
+  cancelled: '已取消',
 }
 
 const statusBadgeClassMap: Record<string, string> = {
@@ -30,6 +32,7 @@ const statusBadgeClassMap: Record<string, string> = {
   returned: 'border-emerald-200 bg-emerald-100 text-emerald-800',
   overdue: 'border-red-200 bg-red-100 text-red-800',
   expired: 'border-zinc-300 bg-zinc-100 text-zinc-700',
+  cancelled: 'border-slate-300 bg-slate-100 text-slate-700',
 }
 
 function getStatusBadgeClass(status: string): string {
@@ -59,11 +62,12 @@ function parseBorrowSortKey(value: string | null, fallback: BorrowSortKey): Borr
 function readInitialState() {
   const params = new URLSearchParams(window.location.search)
   const statusParam = params.get('status')
-  const status: 'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired' =
+  const status: BorrowStatusFilter =
     statusParam === 'reserved'
     || statusParam === 'borrowed'
     || statusParam === 'returned'
     || statusParam === 'overdue'
+    || statusParam === 'cancelled'
     || statusParam === 'expired'
       ? statusParam
       : 'all'
@@ -84,7 +88,7 @@ export function BorrowListPage() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
   const [keyword, setKeyword] = useState(initialState.keyword)
-  const [statusFilter, setStatusFilter] = useState<'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired'>(initialState.status)
+  const [statusFilter, setStatusFilter] = useState<BorrowStatusFilter>(initialState.status)
   const [sortBy, setSortBy] = useState<BorrowSortKey>(initialState.sortBy)
   const [sortDir, setSortDir] = useState<SortDirection>(initialState.sortDir)
   const [page, setPage] = useState(initialState.page)
@@ -222,7 +226,7 @@ export function BorrowListPage() {
               id="borrow-status"
               value={statusFilter}
               onChange={(event) => {
-                setStatusFilter(event.target.value as 'all' | 'borrowed' | 'returned' | 'overdue')
+                setStatusFilter(event.target.value as BorrowStatusFilter)
                 setPage(1)
               }}
             >
@@ -232,6 +236,7 @@ export function BorrowListPage() {
               <option value="returned">已歸還</option>
               <option value="overdue">逾期</option>
               <option value="expired">預約失效</option>
+              <option value="cancelled">已取消</option>
             </Select>
           </div>
           <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>

--- a/frontend/src/components/pages/BorrowListPage.tsx
+++ b/frontend/src/components/pages/BorrowListPage.tsx
@@ -17,15 +17,19 @@ type BorrowSortKey = 'id' | 'borrow_date' | 'borrower' | 'purpose' | 'return_inf
 type SortDirection = 'asc' | 'desc'
 
 const statusLabelMap: Record<string, string> = {
+  reserved: '已預約',
   borrowed: '借出中',
   returned: '已歸還',
   overdue: '逾期',
+  expired: '預約失效',
 }
 
 const statusBadgeClassMap: Record<string, string> = {
+  reserved: 'border-amber-200 bg-amber-100 text-amber-800',
   borrowed: 'border-sky-200 bg-sky-100 text-sky-800',
   returned: 'border-emerald-200 bg-emerald-100 text-emerald-800',
   overdue: 'border-red-200 bg-red-100 text-red-800',
+  expired: 'border-zinc-300 bg-zinc-100 text-zinc-700',
 }
 
 function getStatusBadgeClass(status: string): string {
@@ -55,8 +59,14 @@ function parseBorrowSortKey(value: string | null, fallback: BorrowSortKey): Borr
 function readInitialState() {
   const params = new URLSearchParams(window.location.search)
   const statusParam = params.get('status')
-  const status: 'all' | 'borrowed' | 'returned' | 'overdue' =
-    statusParam === 'borrowed' || statusParam === 'returned' || statusParam === 'overdue' ? statusParam : 'all'
+  const status: 'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired' =
+    statusParam === 'reserved'
+    || statusParam === 'borrowed'
+    || statusParam === 'returned'
+    || statusParam === 'overdue'
+    || statusParam === 'expired'
+      ? statusParam
+      : 'all'
 
   return {
     keyword: params.get('keyword') ?? '',
@@ -74,7 +84,7 @@ export function BorrowListPage() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
   const [keyword, setKeyword] = useState(initialState.keyword)
-  const [statusFilter, setStatusFilter] = useState<'all' | 'borrowed' | 'returned' | 'overdue'>(initialState.status)
+  const [statusFilter, setStatusFilter] = useState<'all' | 'reserved' | 'borrowed' | 'returned' | 'overdue' | 'expired'>(initialState.status)
   const [sortBy, setSortBy] = useState<BorrowSortKey>(initialState.sortBy)
   const [sortDir, setSortDir] = useState<SortDirection>(initialState.sortDir)
   const [page, setPage] = useState(initialState.page)
@@ -217,9 +227,11 @@ export function BorrowListPage() {
               }}
             >
               <option value="all">全部狀態</option>
+              <option value="reserved">已預約</option>
               <option value="borrowed">借出中</option>
               <option value="returned">已歸還</option>
               <option value="overdue">逾期</option>
+              <option value="expired">預約失效</option>
             </Select>
           </div>
           <div className="flex items-end text-sm text-[hsl(var(--muted-foreground))]">共 {total} 筆資料</div>
@@ -281,9 +293,9 @@ export function BorrowListPage() {
                         </TableCell>
                         <TableCell>
                           <div className="grid gap-1">
-                            {request.items.map((item) => (
+                            {request.request_lines.map((item) => (
                               <div key={item.id} className="text-xs">
-                                {(item.item_name || `#${item.item_id}`)} x {item.quantity}
+                                {(item.item_name || `#${item.item_id || '--'}`)} / {item.item_model || '--'}：預約 {item.requested_qty}、已領取 {item.allocated_qty}
                               </div>
                             ))}
                           </div>
@@ -319,7 +331,7 @@ export function BorrowListPage() {
                     <p className="mt-0.5 mb-0 text-xs text-[hsl(var(--muted-foreground))]">{request.department || '--'}</p>
                     <p className="mt-2 mb-0 text-sm">借用：{request.borrow_date || '--'} / 歸還：{request.return_date || '--'}</p>
                     <p className="mt-2 mb-0 text-xs text-[hsl(var(--muted-foreground))]">
-                      品項：{request.items.map((item) => `${item.item_name || `#${item.item_id}`} x ${item.quantity}`).join('，') || '--'}
+                      品項：{request.request_lines.map((item) => `${item.item_name || `#${item.item_id || '--'}`} / ${item.item_model || '--'}（預約 ${item.requested_qty}、已領取 ${item.allocated_qty}）`).join('，') || '--'}
                     </p>
                   </article>
                 ))

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -71,6 +71,7 @@ const BORROW_STATUS_LABEL_MAP: Record<string, string> = {
   returned: '已歸還',
   overdue: '逾期',
   expired: '預約失效',
+  cancelled: '已取消',
 }
 
 function parseShortages(detail: unknown): ShortageRow[] {

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -67,6 +67,7 @@ const SCAN_MIN_LENGTH = 4
 const MAX_BORROW_RESERVATION_DAYS = 30
 const BORROW_STATUS_LABEL_MAP: Record<string, string> = {
   reserved: '已預約',
+  partial_borrowed: '部分借出',
   borrowed: '借出中',
   returned: '已歸還',
   overdue: '逾期',
@@ -234,8 +235,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   }, [isEditing, requestId])
 
   const canEditReservation = !isEditing || status === 'reserved' || status === 'expired'
-  const canPickup = isEditing && (status === 'reserved' || status === 'expired')
-  const canReturn = isEditing && (status === 'borrowed' || status === 'overdue')
+  const canPickup = isEditing && (status === 'reserved' || status === 'expired' || status === 'partial_borrowed')
+  const canReturn = isEditing && (status === 'partial_borrowed' || status === 'borrowed' || status === 'overdue')
 
   const totalRequestedQty = useMemo(
     () => lines.reduce((sum, line) => sum + Math.max(0, Number(line.requested_qty) || 0), 0),
@@ -245,10 +246,11 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     () => lines.reduce((sum, line) => sum + Math.max(0, Number(line.allocated_qty) || 0), 0),
     [lines],
   )
-  const pickupSelectionComplete = useMemo(
-    () => pickupLines.length > 0 && pickupLines.every((line) => (pickupSelections[line.line_id] ?? []).length === line.requested_qty),
+  const pickupSelectedTotal = useMemo(
+    () => pickupLines.reduce((sum, line) => sum + (pickupSelections[line.line_id] ?? []).length, 0),
     [pickupLines, pickupSelections],
   )
+  const pickupHasAnySelection = pickupSelectedTotal > 0
 
   useEffect(() => {
     if (!pickupDialogOpen) {
@@ -378,6 +380,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const getPickupLineById = (lineId: number) => pickupLines.find((line) => line.line_id === lineId)
 
   const getPickupSelectedQty = (lineId: number) => (pickupSelections[lineId] ?? []).length
+  const getPickupLineRemainingQty = (line: BorrowPickupLineSummary) => Math.max(line.remaining_qty ?? line.requested_qty, 0)
 
   const getSelectedItemIdsExceptLine = (lineId: number) => {
     const selectedIds = new Set<number>()
@@ -423,7 +426,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       if (current.includes(itemId)) {
         return { ...prev, [lineId]: current.filter((id) => id !== itemId) }
       }
-      if (current.length >= line.requested_qty) {
+      if (current.length >= getPickupLineRemainingQty(line)) {
         return prev
       }
       if (Object.entries(prev).some(([rawLineId, ids]) => Number(rawLineId) !== lineId && ids.includes(itemId))) {
@@ -529,21 +532,23 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       }
 
       const eligibleLineIdSet = new Set(payload.eligible_line_ids)
-      const targetLine = pickupLines.find((line) => eligibleLineIdSet.has(line.line_id) && getPickupSelectedQty(line.line_id) < line.requested_qty)
-      if (!targetLine) {
+      const targetLineWithRemaining = pickupLines.find(
+        (line) => eligibleLineIdSet.has(line.line_id) && getPickupSelectedQty(line.line_id) < getPickupLineRemainingQty(line),
+      )
+      if (!targetLineWithRemaining) {
         setScanFeedback({ type: 'error', message: `條碼 ${rawCode} 對應的預約列已選滿。` })
         return
       }
 
       setPickupSelections((prev) => ({
         ...prev,
-        [targetLine.line_id]: [...(prev[targetLine.line_id] ?? []), payload.item.id],
+        [targetLineWithRemaining.line_id]: [...(prev[targetLineWithRemaining.line_id] ?? []), payload.item.id],
       }))
-      setPickupExpandedLineId(targetLine.line_id)
-      mergeLineCandidateItem(targetLine.line_id, payload.item)
+      setPickupExpandedLineId(targetLineWithRemaining.line_id)
+      mergeLineCandidateItem(targetLineWithRemaining.line_id, payload.item)
       setScanFeedback({
         type: 'success',
-        message: `已加入 ${targetLine.item_name} / ${targetLine.item_model}（${getPickupItemSerialLabel(payload.item)}）`,
+        message: `已加入 ${targetLineWithRemaining.item_name} / ${targetLineWithRemaining.item_model}（${getPickupItemSerialLabel(payload.item)}）`,
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
@@ -676,8 +681,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     if (!requestId) {
       return
     }
-    if (!pickupSelectionComplete) {
-      void toast.fire({ icon: 'error', title: '請先完成每個品項的借出編號選擇。' })
+    if (!pickupHasAnySelection) {
+      void toast.fire({ icon: 'error', title: '請先選擇至少一個借出編號。' })
       return
     }
     setFormError('')
@@ -688,10 +693,12 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          selections: pickupLines.map((line) => ({
+          selections: pickupLines
+            .map((line) => ({
             line_id: line.line_id,
             item_ids: pickupSelections[line.line_id] ?? [],
-          })),
+            }))
+            .filter((selection) => selection.item_ids.length > 0),
         }),
       })
       if (!response.ok) {
@@ -708,7 +715,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       await refreshReservationOptions()
       await refreshCurrentRequest()
       closePickupDialog()
-      void toast.fire({ icon: 'success', title: '已完成領取並分配資產。' })
+      void toast.fire({ icon: 'success', title: '已完成本次領取並分配資產。' })
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
       void toast.fire({ icon: 'error', title: message || '執行領取失敗，請稍後再試。' })
@@ -921,7 +928,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         open={pickupDialogOpen}
         onClose={closePickupDialog}
         title="確認借出編號"
-        description="大量清單可先掃碼，再按列檢查。每個編號只能使用一次。"
+        description="可分批領取。大量清單可先掃碼，再按列檢查；每個編號只能使用一次。"
         panelClassName="max-w-6xl h-[85vh] flex flex-col"
         bodyClassName="min-h-0 flex-1 overflow-hidden"
         actions={
@@ -929,8 +936,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
             <Button type="button" variant="secondary" onClick={closePickupDialog} disabled={submitting}>
               取消
             </Button>
-            <Button type="button" onClick={() => void handlePickup()} disabled={submitting || !pickupSelectionComplete}>
-              {submitting ? '處理中...' : '確認領取'}
+            <Button type="button" onClick={() => void handlePickup()} disabled={submitting || !pickupHasAnySelection}>
+              {submitting ? '處理中...' : '確認本次領取'}
             </Button>
           </>
         }
@@ -941,6 +948,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
             <div className="grid max-h-full gap-2 overflow-y-auto">
               {pickupLines.map((line) => {
                 const selectedQty = getPickupSelectedQty(line.line_id)
+                const allocatedQty = line.allocated_qty ?? 0
+                const remainingQty = getPickupLineRemainingQty(line)
                 const isExpanded = pickupExpandedLineId === line.line_id
                 return (
                   <button
@@ -953,7 +962,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                   >
                     <span className="text-sm font-semibold">{line.item_name} / {line.item_model}</span>
                     <span className="text-xs text-[hsl(var(--muted-foreground))]">
-                      已選 {selectedQty} / {line.requested_qty}，候選約 {line.candidate_count}
+                      已領 {allocatedQty + selectedQty} / {line.requested_qty}（本次可選 {remainingQty}），候選約 {line.candidate_count}
                     </span>
                   </button>
                 )

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -7,17 +7,36 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
-import { buildGroupedItemOptions } from './itemOptionGroups'
-import type { BorrowRequest, InventoryItem, PaginatedResponse } from './types'
+import type { BorrowRequest, BorrowReservationOption } from './types'
 
 type BorrowLine = {
-  item_id: number | ''
-  quantity: number
+  item_name: string
+  item_model: string
+  requested_qty: number
   note: string
+  allocated_qty?: number
+  allocated_item_ids?: number[]
+  name_search: string
+  model_search: string
 }
 
-const emptyLine = (): BorrowLine => ({ item_id: '', quantity: 1, note: '' })
-const GROUP_OPTION_PREFIX = '__group__:'
+type ShortageRow = {
+  item_name: string
+  item_model: string
+  requested_qty: number
+  available_qty: number
+  shortage_qty: number
+}
+
+const emptyLine = (): BorrowLine => ({
+  item_name: '',
+  item_model: '',
+  requested_qty: 1,
+  note: '',
+  name_search: '',
+  model_search: '',
+})
+
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -30,9 +49,36 @@ type BorrowPageProps = {
   requestId?: number
 }
 
+function parseShortages(detail: unknown): ShortageRow[] {
+  if (!detail || typeof detail !== 'object') {
+    return []
+  }
+  const parsed = detail as { shortages?: unknown }
+  if (!Array.isArray(parsed.shortages)) {
+    return []
+  }
+  return parsed.shortages
+    .map((row) => {
+      const candidate = row as Partial<ShortageRow>
+      if (!candidate || typeof candidate !== 'object') {
+        return null
+      }
+      return {
+        item_name: typeof candidate.item_name === 'string' ? candidate.item_name : '',
+        item_model: typeof candidate.item_model === 'string' ? candidate.item_model : '',
+        requested_qty: Number(candidate.requested_qty ?? 0),
+        available_qty: Number(candidate.available_qty ?? 0),
+        shortage_qty: Number(candidate.shortage_qty ?? 0),
+      }
+    })
+    .filter((row): row is ShortageRow => row !== null)
+}
+
 export function BorrowPage({ requestId }: BorrowPageProps) {
-  const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([])
+  const [reservationOptions, setReservationOptions] = useState<BorrowReservationOption[]>([])
   const [loadError, setLoadError] = useState('')
+  const [formError, setFormError] = useState('')
+  const [shortages, setShortages] = useState<ShortageRow[]>([])
 
   const [borrower, setBorrower] = useState('')
   const [department, setDepartment] = useState('')
@@ -40,29 +86,52 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const [borrowDate, setBorrowDate] = useState('')
   const [dueDate, setDueDate] = useState('')
   const [returnDate, setReturnDate] = useState('')
-  const [status, setStatus] = useState('borrowed')
+  const [status, setStatus] = useState('reserved')
   const [memo, setMemo] = useState('')
   const [lines, setLines] = useState<BorrowLine[]>([emptyLine()])
   const [submitting, setSubmitting] = useState(false)
   const isEditing = Number.isInteger(requestId)
 
+  const comboKeySet = useMemo(() => {
+    const keys = new Set<string>()
+    for (const option of reservationOptions) {
+      keys.add(`${option.item_name}__${option.item_model}`)
+    }
+    return keys
+  }, [reservationOptions])
+
+  const nameOptions = useMemo(() => {
+    const names = new Set<string>()
+    for (const option of reservationOptions) {
+      names.add(option.item_name)
+    }
+    return Array.from(names).sort((a, b) => a.localeCompare(b))
+  }, [reservationOptions])
+
+  const refreshReservationOptions = async () => {
+    const searchParams = new URLSearchParams()
+    if (isEditing && requestId) {
+      searchParams.set('request_id', String(requestId))
+    }
+    const query = searchParams.toString()
+    const response = await fetch(apiUrl(`/api/lookups/borrow-reservations${query ? `?${query}` : ''}`))
+    if (!response.ok) {
+      throw new Error('無法載入可預約品項')
+    }
+    const payload = (await response.json()) as BorrowReservationOption[]
+    setReservationOptions(payload)
+  }
+
   useEffect(() => {
-    const loadData = async () => {
-      setLoadError('')
+    const loadOptions = async () => {
       try {
-        const itemsResponse = await fetch(apiUrl('/api/items?page=1&page_size=100000'))
-        if (!itemsResponse.ok) {
-          throw new Error('無法載入資料')
-        }
-        const itemsPayload = (await itemsResponse.json()) as PaginatedResponse<InventoryItem>
-        setInventoryItems(itemsPayload.items)
+        await refreshReservationOptions()
       } catch {
-        setLoadError('目前無法讀取借用資料，請稍後重試。')
+        setLoadError('目前無法讀取可預約品項，請稍後重試。')
       }
     }
-
-    void loadData()
-  }, [])
+    void loadOptions()
+  }, [isEditing, requestId])
 
   useEffect(() => {
     if (!isEditing || !requestId) {
@@ -84,15 +153,20 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         setBorrowDate(payload.borrow_date ?? '')
         setDueDate(payload.due_date ?? '')
         setReturnDate(payload.return_date ?? '')
-        setStatus(payload.status ?? 'borrowed')
+        setStatus(payload.status ?? 'reserved')
         setMemo(payload.memo ?? '')
         setLines(
-          payload.items.length > 0
-            ? payload.items.map((item) => ({
-              item_id: item.item_id,
-              quantity: item.quantity,
-              note: item.note ?? '',
-            }))
+          payload.request_lines.length > 0
+            ? payload.request_lines.map((line) => ({
+                item_name: line.item_name ?? '',
+                item_model: line.item_model ?? '',
+                requested_qty: line.requested_qty,
+                note: line.note ?? '',
+                allocated_qty: line.allocated_qty,
+                allocated_item_ids: line.allocated_item_ids,
+                name_search: '',
+                model_search: '',
+              }))
             : [emptyLine()],
         )
       } catch {
@@ -103,47 +177,65 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     void loadRequest()
   }, [isEditing, requestId])
 
-  const selectedItemIds = useMemo(
-    () => new Set(lines.map((line) => line.item_id).filter((itemId): itemId is number => itemId !== '')),
+  const canEditReservation = !isEditing || status === 'reserved' || status === 'expired'
+  const canPickup = isEditing && (status === 'reserved' || status === 'expired')
+  const canReturn = isEditing && (status === 'borrowed' || status === 'overdue')
+
+  const totalRequestedQty = useMemo(
+    () => lines.reduce((sum, line) => sum + Math.max(0, Number(line.requested_qty) || 0), 0),
+    [lines],
+  )
+  const totalAllocatedQty = useMemo(
+    () => lines.reduce((sum, line) => sum + Math.max(0, Number(line.allocated_qty) || 0), 0),
     [lines],
   )
 
-  const selectableItems = useMemo(() => {
-    return inventoryItems.filter((item) => {
-      if (item.asset_status === '0') {
-        return true
-      }
-      return isEditing && selectedItemIds.has(item.id)
-    })
-  }, [inventoryItems, isEditing, selectedItemIds])
+  const getModelOptionsByName = (itemName: string, searchKeyword: string) => {
+    const keyword = searchKeyword.trim().toLowerCase()
+    return reservationOptions
+      .filter((option) => option.item_name === itemName)
+      .filter((option) => !keyword || option.item_model.toLowerCase().includes(keyword))
+      .sort((a, b) => a.item_model.localeCompare(b.item_model))
+  }
 
-  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
+  const getFilteredNames = (searchKeyword: string) => {
+    const keyword = searchKeyword.trim().toLowerCase()
+    return nameOptions.filter((name) => !keyword || name.toLowerCase().includes(keyword))
+  }
 
   const handleLineChange = (index: number, patch: Partial<BorrowLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
   }
 
-  const handleItemSelectChange = (index: number, rawValue: string) => {
-    if (!rawValue) {
-      handleLineChange(index, { item_id: '' })
-      return
-    }
-    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
-      return
-    }
-    handleLineChange(index, { item_id: Number(rawValue) })
+  const handleNameChange = (index: number, nextName: string) => {
+    const line = lines[index]
+    const modelOptions = reservationOptions.filter((option) => option.item_name === nextName)
+    const modelStillValid = modelOptions.some((option) => option.item_model === line.item_model)
+    handleLineChange(index, {
+      item_name: nextName,
+      item_model: modelStillValid ? line.item_model : '',
+      name_search: '',
+      model_search: '',
+    })
   }
 
   const getLineValidationError = () => {
     if (lines.length === 0) {
-      return '請至少新增一筆借用品項。'
+      return '請至少新增一筆預約品項。'
     }
-    if (!lines.every((line) => line.item_id !== '' && line.quantity === 1)) {
-      return '單件模式下，每筆借用品項數量必須為 1。'
-    }
-    const pickedIds = lines.map((line) => line.item_id).filter((itemId): itemId is number => itemId !== '')
-    if (new Set(pickedIds).size !== pickedIds.length) {
-      return '同一張借用單不可重複選取同一品項。'
+    for (const line of lines) {
+      if (!line.item_name.trim()) {
+        return '請選擇品名。'
+      }
+      if (!line.item_model.trim()) {
+        return '請選擇型號。'
+      }
+      if (!Number.isInteger(line.requested_qty) || line.requested_qty <= 0) {
+        return '每筆預約數量需為正整數。'
+      }
+      if (!comboKeySet.has(`${line.item_name}__${line.item_model}`)) {
+        return `品項 ${line.item_name} / ${line.item_model} 不在可選清單。`
+      }
     }
     return null
   }
@@ -152,15 +244,42 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
   const getDateValidationError = () => {
     if (borrowDate && dueDate && borrowDate > dueDate) {
-      return '預計歸還日期不可早於借用日期。'
-    }
-    if (borrowDate && returnDate && returnDate < borrowDate) {
-      return '實際歸還日期不可早於借用日期。'
+      return '預計歸還日期不可早於領用日期。'
     }
     return null
   }
 
+  const refreshCurrentRequest = async () => {
+    if (!requestId) {
+      return
+    }
+    const response = await fetch(apiUrl(`/api/borrows/${requestId}`))
+    if (!response.ok) {
+      return
+    }
+    const payload = (await response.json()) as BorrowRequest
+    setReturnDate(payload.return_date ?? '')
+    setStatus(payload.status ?? 'reserved')
+    setLines(
+      payload.request_lines.length > 0
+        ? payload.request_lines.map((line) => ({
+            item_name: line.item_name ?? '',
+            item_model: line.item_model ?? '',
+            requested_qty: line.requested_qty,
+            note: line.note ?? '',
+            allocated_qty: line.allocated_qty,
+            allocated_item_ids: line.allocated_item_ids,
+            name_search: '',
+            model_search: '',
+          }))
+        : [emptyLine()],
+    )
+  }
+
   const handleSubmit = async () => {
+    setFormError('')
+    setShortages([])
+
     const validationError = getLineValidationError()
     if (validationError) {
       void toast.fire({ icon: 'error', title: validationError })
@@ -185,12 +304,11 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           purpose,
           borrow_date: normalizeDate(borrowDate),
           due_date: normalizeDate(dueDate),
-          return_date: normalizeDate(returnDate),
-          status,
           memo,
-          items: lines.map((line) => ({
-            item_id: line.item_id,
-            quantity: 1,
+          request_lines: lines.map((line) => ({
+            item_name: line.item_name,
+            item_model: line.item_model,
+            requested_qty: Number(line.requested_qty),
             note: line.note,
           })),
         }),
@@ -198,13 +316,22 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
-        const detail = typeof payload?.detail === 'string' ? payload.detail : null
-        throw new Error(detail ?? '建立失敗')
+        const detail = payload?.detail
+        const shortageRows = parseShortages(detail)
+        if (shortageRows.length > 0) {
+          setFormError('可預約量不足，請調整預約內容。')
+          setShortages(shortageRows)
+          return
+        }
+        const detailText = typeof detail === 'string' ? detail : null
+        throw new Error(detailText ?? (isEditing ? '更新預約失敗' : '建立預約失敗'))
       }
 
       await response.json()
+      await refreshReservationOptions()
       if (isEditing) {
-        void toast.fire({ icon: 'success', title: '借用單已更新。' })
+        void toast.fire({ icon: 'success', title: '借用預約已更新。' })
+        await refreshCurrentRequest()
       } else {
         setBorrower('')
         setDepartment('')
@@ -212,17 +339,73 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         setBorrowDate('')
         setDueDate('')
         setReturnDate('')
-        setStatus('borrowed')
+        setStatus('reserved')
         setMemo('')
         setLines([emptyLine()])
-        void toast.fire({ icon: 'success', title: '借用單已建立。' })
+        void toast.fire({ icon: 'success', title: '借用預約已建立。' })
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
       void toast.fire({
         icon: 'error',
-        title: message || (isEditing ? '更新借用單失敗，請稍後再試。' : '建立借用單失敗，請稍後再試。'),
+        title: message || (isEditing ? '更新預約失敗，請稍後再試。' : '建立預約失敗，請稍後再試。'),
       })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handlePickup = async () => {
+    if (!requestId) {
+      return
+    }
+    setFormError('')
+    setShortages([])
+    setSubmitting(true)
+    try {
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup`), { method: 'POST' })
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const shortageRows = parseShortages(payload?.detail)
+        if (shortageRows.length > 0) {
+          setFormError('可領取數量不足，請確認目前庫存。')
+          setShortages(shortageRows)
+          return
+        }
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? '執行領取失敗')
+      }
+      await refreshReservationOptions()
+      await refreshCurrentRequest()
+      void toast.fire({ icon: 'success', title: '已完成領取並分配資產。' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      void toast.fire({ icon: 'error', title: message || '執行領取失敗，請稍後再試。' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleReturnAll = async () => {
+    if (!requestId) {
+      return
+    }
+    setFormError('')
+    setShortages([])
+    setSubmitting(true)
+    try {
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/return`), { method: 'POST' })
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? '全數歸還失敗')
+      }
+      await refreshReservationOptions()
+      await refreshCurrentRequest()
+      void toast.fire({ icon: 'success', title: '已完成全數歸還。' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      void toast.fire({ icon: 'error', title: message || '全數歸還失敗，請稍後再試。' })
     } finally {
       setSubmitting(false)
     }
@@ -230,132 +413,171 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
 
   return (
     <div className="grid gap-4">
-        <SectionCard title="基本資料">
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="grid gap-1.5">
-              <Label>借用人</Label>
-              <Input value={borrower} onChange={(event) => setBorrower(event.target.value)} />
-            </div>
-            <div className="grid gap-1.5">
-              <Label>單位</Label>
-              <Input value={department} onChange={(event) => setDepartment(event.target.value)} />
-            </div>
-            <div className="grid gap-1.5 md:col-span-2">
-              <Label>用途</Label>
-              <Input value={purpose} onChange={(event) => setPurpose(event.target.value)} />
-            </div>
-            <div className="grid gap-1.5">
-              <Label>借用日期</Label>
-              <Input
-                type="date"
-                value={borrowDate}
-                max={returnDate || dueDate || undefined}
-                onChange={(event) => setBorrowDate(event.target.value)}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label>預計歸還</Label>
-              <Input
-                type="date"
-                value={dueDate}
-                min={borrowDate || undefined}
-                max={returnDate || undefined}
-                onChange={(event) => setDueDate(event.target.value)}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label>實際歸還</Label>
-              <Input
-                type="date"
-                value={returnDate}
-                min={borrowDate || undefined}
-                onChange={(event) => setReturnDate(event.target.value)}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label>狀態</Label>
-              <Select value={status} onChange={(event) => setStatus(event.target.value)}>
-                <option value="borrowed">借出中</option>
-                <option value="returned">已歸還</option>
-                <option value="overdue">逾期</option>
-              </Select>
-              <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">送出後會由系統依預計歸還日與實際歸還日自動判定狀態。</p>
-            </div>
-            <div className="grid gap-1.5 md:col-span-2">
-              <Label>備註</Label>
-              <Textarea rows={3} value={memo} onChange={(event) => setMemo(event.target.value)} />
-            </div>
+      <SectionCard title="基本資料">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="grid gap-1.5">
+            <Label>借用人</Label>
+            <Input value={borrower} onChange={(event) => setBorrower(event.target.value)} disabled={!canEditReservation || submitting} />
           </div>
-        </SectionCard>
+          <div className="grid gap-1.5">
+            <Label>單位</Label>
+            <Input value={department} onChange={(event) => setDepartment(event.target.value)} disabled={!canEditReservation || submitting} />
+          </div>
+          <div className="grid gap-1.5 md:col-span-2">
+            <Label>用途</Label>
+            <Input value={purpose} onChange={(event) => setPurpose(event.target.value)} disabled={!canEditReservation || submitting} />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>領用日</Label>
+            <Input type="date" value={borrowDate} onChange={(event) => setBorrowDate(event.target.value)} disabled={!canEditReservation || submitting} />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>預計歸還</Label>
+            <Input type="date" value={dueDate} min={borrowDate || undefined} onChange={(event) => setDueDate(event.target.value)} disabled={!canEditReservation || submitting} />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>狀態</Label>
+            <Input value={status || '--'} disabled />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>實際歸還</Label>
+            <Input type="date" value={returnDate} disabled />
+          </div>
+          <div className="grid gap-1.5 md:col-span-2">
+            <Label>備註</Label>
+            <Textarea rows={3} value={memo} onChange={(event) => setMemo(event.target.value)} disabled={!canEditReservation || submitting} />
+          </div>
+        </div>
+      </SectionCard>
 
-        <SectionCard title="借用品項">
-          <div className="grid gap-3">
-            {lines.map((line, index) => {
-              const selectedByOtherLines = new Set(
-                lines
-                  .filter((_, idx) => idx !== index)
-                  .map((itemLine) => itemLine.item_id)
-                  .filter((itemId): itemId is number => itemId !== ''),
-              )
-              return (
-              <article key={`borrow-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+      <SectionCard title="預約品項（品名 + 型號 + 數量）">
+        <div className="grid gap-3">
+          {lines.map((line, index) => {
+            const filteredNames = getFilteredNames(line.name_search)
+            const filteredModels = getModelOptionsByName(line.item_name, line.model_search)
+
+            return (
+              <article key={`borrow-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,2fr,1fr,2fr,auto]">
                 <div className="grid gap-1.5">
-                  <Label>品項</Label>
+                  <Label>品名</Label>
+                  <Input
+                    placeholder="搜尋品名..."
+                    value={line.name_search}
+                    onChange={(event) => handleLineChange(index, { name_search: event.target.value })}
+                    disabled={!canEditReservation || submitting}
+                  />
                   <Select
-                    value={line.item_id}
-                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
+                    value={line.item_name}
+                    onChange={(event) => handleNameChange(index, event.target.value)}
+                    disabled={!canEditReservation || submitting}
                   >
-                    <option value="">請選擇品項</option>
-                    {itemOptionGroups.flatMap((group) => [
-                      <option
-                        key={`group-${group.groupLabel}`}
-                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
-                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
-                      >
-                        {`==== ${group.groupLabel} ====`}
-                      </option>,
-                      ...group.options.map((option) => (
-                        <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
-                          {`  ${option.label}`}
-                        </option>
-                      )),
-                    ])}
+                    <option value="">請選擇品名</option>
+                    {filteredNames.map((name) => (
+                      <option key={name} value={name}>
+                        {name}
+                      </option>
+                    ))}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">
-                  <Label>數量</Label>
+                  <Label>型號</Label>
+                  <Input
+                    placeholder="搜尋型號..."
+                    value={line.model_search}
+                    onChange={(event) => handleLineChange(index, { model_search: event.target.value })}
+                    disabled={!canEditReservation || submitting || !line.item_name}
+                  />
+                  <Select
+                    value={line.item_model}
+                    onChange={(event) => handleLineChange(index, { item_model: event.target.value })}
+                    disabled={!canEditReservation || submitting || !line.item_name}
+                  >
+                    <option value="">請選擇型號</option>
+                    {filteredModels.map((option) => (
+                      <option
+                        key={`${option.item_name}__${option.item_model}`}
+                        value={option.item_model}
+                        disabled={!option.selectable && line.item_model !== option.item_model}
+                      >
+                        {`${option.item_model}（可預約 ${option.reservable_qty} / 在庫 ${option.available_qty} / 已預約 ${option.reserved_qty}）`}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>預約數量</Label>
                   <Input
                     type="number"
                     min={1}
-                    max={1}
-                    value={1}
-                    disabled
+                    value={line.requested_qty}
+                    onChange={(event) => handleLineChange(index, { requested_qty: Number(event.target.value) || 0 })}
+                    disabled={!canEditReservation || submitting}
                   />
                 </div>
                 <div className="grid gap-1.5">
                   <Label>備註</Label>
-                  <Input value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} />
+                  <Input value={line.note} onChange={(event) => handleLineChange(index, { note: event.target.value })} disabled={!canEditReservation || submitting} />
+                  {isEditing ? (
+                    <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">
+                      已分配：{line.allocated_qty ?? 0} / {line.requested_qty}
+                      {line.allocated_item_ids && line.allocated_item_ids.length > 0 ? `（ID: ${line.allocated_item_ids.join(', ')}）` : ''}
+                    </p>
+                  ) : null}
                 </div>
                 <div className="flex items-end">
-                  <Button type="button" variant="secondary" onClick={() => setLines((prev) => prev.filter((_, idx) => idx !== index))} disabled={lines.length <= 1}>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setLines((prev) => prev.filter((_, idx) => idx !== index))}
+                    disabled={!canEditReservation || submitting || lines.length <= 1}
+                  >
                     移除
                   </Button>
                 </div>
               </article>
-              )
-            })}
-          </div>
+            )
+          })}
 
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
-            <Button type="button" variant="secondary" onClick={() => setLines((prev) => [...prev, emptyLine()])}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="secondary" onClick={() => setLines((prev) => [...prev, emptyLine()])} disabled={!canEditReservation || submitting}>
               新增品項
             </Button>
-            <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
-              {submitting ? (isEditing ? '更新中...' : '建立中...') : (isEditing ? '更新借用單' : '建立借用單')}
-            </Button>
+            <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">預約總數：{totalRequestedQty}；已分配總數：{totalAllocatedQty}</p>
           </div>
-          {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
-        </SectionCard>
+        </div>
+      </SectionCard>
+
+      {loadError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</p> : null}
+      {formError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <p className="m-0 font-semibold">{formError}</p>
+          {shortages.length > 0 ? (
+            <ul className="mt-2 mb-0 list-disc pl-5">
+              {shortages.map((row) => (
+                <li key={`${row.item_name}-${row.item_model}`}>
+                  {row.item_name} / {row.item_model}：需求 {row.requested_qty}，可用 {row.available_qty}，缺口 {row.shortage_qty}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" onClick={() => void handleSubmit()} disabled={submitting || !canEditReservation}>
+          {submitting ? '儲存中...' : isEditing ? '更新預約' : '建立預約'}
+        </Button>
+        {canPickup ? (
+          <Button type="button" variant="secondary" onClick={() => void handlePickup()} disabled={submitting}>
+            {submitting ? '處理中...' : '執行領取'}
+          </Button>
+        ) : null}
+        {canReturn ? (
+          <Button type="button" variant="secondary" onClick={() => void handleReturnAll()} disabled={submitting}>
+            {submitting ? '處理中...' : '全數歸還'}
+          </Button>
+        ) : null}
       </div>
+    </div>
   )
 }

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
@@ -8,7 +8,14 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
-import type { BorrowPickupCandidateItem, BorrowPickupCandidateLine, BorrowRequest, BorrowReservationOption } from './types'
+import type {
+  BorrowPickupCandidateItem,
+  BorrowPickupLineCandidatePage,
+  BorrowPickupLineSummary,
+  BorrowPickupScanResolveResponse,
+  BorrowRequest,
+  BorrowReservationOption,
+} from './types'
 
 type BorrowLine = {
   item_name: string
@@ -50,6 +57,22 @@ type BorrowPageProps = {
   requestId?: number
 }
 
+type ScanBuffer = {
+  value: string
+  lastTs: number
+}
+
+const SCAN_MAX_KEY_INTERVAL_MS = 45
+const SCAN_MIN_LENGTH = 4
+const MAX_BORROW_RESERVATION_DAYS = 30
+const BORROW_STATUS_LABEL_MAP: Record<string, string> = {
+  reserved: '已預約',
+  borrowed: '借出中',
+  returned: '已歸還',
+  overdue: '逾期',
+  expired: '預約失效',
+}
+
 function parseShortages(detail: unknown): ShortageRow[] {
   if (!detail || typeof detail !== 'object') {
     return []
@@ -75,6 +98,24 @@ function parseShortages(detail: unknown): ShortageRow[] {
     .filter((row): row is ShortageRow => row !== null)
 }
 
+function parseDateInput(value: string): Date | null {
+  if (!value) {
+    return null
+  }
+  const [year, month, day] = value.split('-').map((part) => Number(part))
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null
+  }
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+function formatDateInput(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 export function BorrowPage({ requestId }: BorrowPageProps) {
   const [reservationOptions, setReservationOptions] = useState<BorrowReservationOption[]>([])
   const [loadError, setLoadError] = useState('')
@@ -82,8 +123,14 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const [shortages, setShortages] = useState<ShortageRow[]>([])
   const [pickupDialogOpen, setPickupDialogOpen] = useState(false)
   const [pickupLoading, setPickupLoading] = useState(false)
-  const [pickupCandidates, setPickupCandidates] = useState<BorrowPickupCandidateLine[]>([])
+  const [pickupLines, setPickupLines] = useState<BorrowPickupLineSummary[]>([])
+  const [pickupExpandedLineId, setPickupExpandedLineId] = useState<number | null>(null)
+  const [pickupLineCandidates, setPickupLineCandidates] = useState<Record<number, BorrowPickupLineCandidatePage>>({})
+  const [pickupLineCandidatesLoading, setPickupLineCandidatesLoading] = useState<Record<number, boolean>>({})
+  const [pickupCandidateKeyword, setPickupCandidateKeyword] = useState('')
   const [pickupSelections, setPickupSelections] = useState<Record<number, number[]>>({})
+  const [scanInputValue, setScanInputValue] = useState('')
+  const [scanFeedback, setScanFeedback] = useState<{ type: 'success' | 'error' | 'info'; message: string } | null>(null)
 
   const [borrower, setBorrower] = useState('')
   const [department, setDepartment] = useState('')
@@ -95,7 +142,10 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const [memo, setMemo] = useState('')
   const [lines, setLines] = useState<BorrowLine[]>([emptyLine()])
   const [submitting, setSubmitting] = useState(false)
+  const scanInputRef = useRef<HTMLInputElement | null>(null)
+  const scanBufferRef = useRef<ScanBuffer>({ value: '', lastTs: 0 })
   const isEditing = Number.isInteger(requestId)
+  const statusLabel = BORROW_STATUS_LABEL_MAP[status] || status || '--'
 
   const comboKeySet = useMemo(() => {
     const keys = new Set<string>()
@@ -195,9 +245,19 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     [lines],
   )
   const pickupSelectionComplete = useMemo(
-    () => pickupCandidates.every((line) => (pickupSelections[line.line_id] ?? []).length === line.requested_qty),
-    [pickupCandidates, pickupSelections],
+    () => pickupLines.length > 0 && pickupLines.every((line) => (pickupSelections[line.line_id] ?? []).length === line.requested_qty),
+    [pickupLines, pickupSelections],
   )
+
+  useEffect(() => {
+    if (!pickupDialogOpen) {
+      return
+    }
+    const timerId = window.setTimeout(() => {
+      scanInputRef.current?.focus()
+    }, 0)
+    return () => window.clearTimeout(timerId)
+  }, [pickupDialogOpen, pickupExpandedLineId])
 
   const getModelOptionsByName = (itemName: string, searchKeyword: string) => {
     const keyword = searchKeyword.trim().toLowerCase()
@@ -252,11 +312,36 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const normalizeDate = (value: string) => (value ? value : null)
 
   const getDateValidationError = () => {
+    if (!borrowDate) {
+      return '請填寫領用日。'
+    }
+    if (!dueDate) {
+      return '請填寫預計歸還日期。'
+    }
     if (borrowDate && dueDate && borrowDate > dueDate) {
       return '預計歸還日期不可早於領用日期。'
     }
+    const borrowDateValue = parseDateInput(borrowDate)
+    const dueDateValue = parseDateInput(dueDate)
+    if (!borrowDateValue || !dueDateValue) {
+      return '日期格式錯誤，請重新選擇。'
+    }
+    const days = Math.floor((dueDateValue.getTime() - borrowDateValue.getTime()) / (1000 * 60 * 60 * 24))
+    if (days > MAX_BORROW_RESERVATION_DAYS) {
+      return `借用預約不可超過 ${MAX_BORROW_RESERVATION_DAYS} 天。`
+    }
     return null
   }
+
+  const dueDateMax = useMemo(() => {
+    const borrowDateValue = parseDateInput(borrowDate)
+    if (!borrowDateValue) {
+      return undefined
+    }
+    const maxDueDate = new Date(borrowDateValue)
+    maxDueDate.setUTCDate(maxDueDate.getUTCDate() + MAX_BORROW_RESERVATION_DAYS)
+    return formatDateInput(maxDueDate)
+  }, [borrowDate])
 
   const refreshCurrentRequest = async () => {
     if (!requestId) {
@@ -289,6 +374,10 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     return candidate.n_property_sn || candidate.property_sn || candidate.n_item_sn || candidate.item_sn || `ID ${candidate.id}`
   }
 
+  const getPickupLineById = (lineId: number) => pickupLines.find((line) => line.line_id === lineId)
+
+  const getPickupSelectedQty = (lineId: number) => (pickupSelections[lineId] ?? []).length
+
   const getSelectedItemIdsExceptLine = (lineId: number) => {
     const selectedIds = new Set<number>()
     Object.entries(pickupSelections).forEach(([rawLineId, itemIds]) => {
@@ -300,8 +389,31 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     return selectedIds
   }
 
+  const isAnyLineSelectingItem = (itemId: number) => {
+    return Object.values(pickupSelections).some((ids) => ids.includes(itemId))
+  }
+
+  const mergeLineCandidateItem = (lineId: number, item: BorrowPickupCandidateItem) => {
+    setPickupLineCandidates((prev) => {
+      const current = prev[lineId]
+      if (!current) {
+        return prev
+      }
+      if (current.items.some((candidate) => candidate.id === item.id)) {
+        return prev
+      }
+      return {
+        ...prev,
+        [lineId]: {
+          ...current,
+          items: [item, ...current.items],
+        },
+      }
+    })
+  }
+
   const togglePickupSelection = (lineId: number, itemId: number) => {
-    const line = pickupCandidates.find((candidateLine) => candidateLine.line_id === lineId)
+    const line = getPickupLineById(lineId)
     if (!line) {
       return
     }
@@ -313,8 +425,46 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       if (current.length >= line.requested_qty) {
         return prev
       }
+      if (Object.entries(prev).some(([rawLineId, ids]) => Number(rawLineId) !== lineId && ids.includes(itemId))) {
+        return prev
+      }
       return { ...prev, [lineId]: [...current, itemId] }
     })
+  }
+
+  const loadPickupLineCandidates = async (lineId: number, nextKeyword: string, nextPage: number) => {
+    if (!requestId) {
+      return
+    }
+    const params = new URLSearchParams({
+      page: String(nextPage),
+      page_size: '50',
+    })
+    if (nextKeyword.trim()) {
+      params.set('keyword', nextKeyword.trim())
+    }
+    setPickupLineCandidatesLoading((prev) => ({ ...prev, [lineId]: true }))
+    try {
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup-lines/${lineId}/candidates?${params.toString()}`))
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? '無法載入可領取候選清單')
+      }
+      const payload = (await response.json()) as BorrowPickupLineCandidatePage
+      setPickupLineCandidates((prev) => ({ ...prev, [lineId]: payload }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      setScanFeedback({ type: 'error', message: message || '無法載入候選清單' })
+    } finally {
+      setPickupLineCandidatesLoading((prev) => ({ ...prev, [lineId]: false }))
+    }
+  }
+
+  const handleExpandPickupLine = async (lineId: number) => {
+    setPickupExpandedLineId(lineId)
+    setPickupCandidateKeyword('')
+    await loadPickupLineCandidates(lineId, '', 1)
   }
 
   const openPickupDialog = async () => {
@@ -325,25 +475,121 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     setShortages([])
     setPickupLoading(true)
     try {
-      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup-candidates`))
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup-lines`))
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
         const detail = typeof payload?.detail === 'string' ? payload.detail : null
         throw new Error(detail ?? '無法載入可領取編號')
       }
-      const payload = (await response.json()) as BorrowPickupCandidateLine[]
+      const payload = (await response.json()) as BorrowPickupLineSummary[]
       if (payload.length === 0) {
         throw new Error('目前沒有可領取的預約品項')
       }
-      setPickupCandidates(payload)
+      setPickupLines(payload)
+      setPickupExpandedLineId(payload[0].line_id)
+      setPickupLineCandidates({})
+      setPickupLineCandidatesLoading({})
+      setPickupCandidateKeyword('')
       setPickupSelections(Object.fromEntries(payload.map((line) => [line.line_id, []])))
+      setScanInputValue('')
+      setScanFeedback(null)
+      scanBufferRef.current = { value: '', lastTs: 0 }
       setPickupDialogOpen(true)
+      await loadPickupLineCandidates(payload[0].line_id, '', 1)
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
       void toast.fire({ icon: 'error', title: message || '無法載入可領取編號' })
     } finally {
       setPickupLoading(false)
     }
+  }
+
+  const applyScanCode = async (rawCode: string) => {
+    const normalizedCode = rawCode.trim()
+    if (!normalizedCode || !requestId) {
+      return
+    }
+    setScanInputValue('')
+    try {
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup-resolve-scan`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: normalizedCode }),
+      })
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? `查無條碼：${rawCode}`)
+      }
+      const payload = (await response.json()) as BorrowPickupScanResolveResponse
+      if (isAnyLineSelectingItem(payload.item.id)) {
+        setScanFeedback({ type: 'info', message: `條碼 ${rawCode} 已在領取清單中。` })
+        return
+      }
+
+      const eligibleLineIdSet = new Set(payload.eligible_line_ids)
+      const targetLine = pickupLines.find((line) => eligibleLineIdSet.has(line.line_id) && getPickupSelectedQty(line.line_id) < line.requested_qty)
+      if (!targetLine) {
+        setScanFeedback({ type: 'error', message: `條碼 ${rawCode} 對應的預約列已選滿。` })
+        return
+      }
+
+      setPickupSelections((prev) => ({
+        ...prev,
+        [targetLine.line_id]: [...(prev[targetLine.line_id] ?? []), payload.item.id],
+      }))
+      setPickupExpandedLineId(targetLine.line_id)
+      mergeLineCandidateItem(targetLine.line_id, payload.item)
+      setScanFeedback({
+        type: 'success',
+        message: `已加入 ${targetLine.item_name} / ${targetLine.item_model}（${getPickupItemSerialLabel(payload.item)}）`,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      setScanFeedback({ type: 'error', message: message || `查無條碼：${rawCode}` })
+    } finally {
+      setScanInputValue('')
+    }
+  }
+
+  const handleScanInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const now = Date.now()
+    const buffer = scanBufferRef.current
+    const key = event.key
+
+    if (key === 'Enter') {
+      event.preventDefault()
+      const scanValue = buffer.value.length >= SCAN_MIN_LENGTH ? buffer.value : scanInputValue
+      buffer.value = ''
+      buffer.lastTs = 0
+      void applyScanCode(scanValue)
+      return
+    }
+    if (key.length !== 1) {
+      return
+    }
+    if (buffer.lastTs > 0 && now - buffer.lastTs > SCAN_MAX_KEY_INTERVAL_MS) {
+      buffer.value = key
+    } else {
+      buffer.value += key
+    }
+    buffer.lastTs = now
+  }
+
+  const closePickupDialog = () => {
+    if (submitting) {
+      return
+    }
+    setPickupDialogOpen(false)
+    setPickupLines([])
+    setPickupExpandedLineId(null)
+    setPickupLineCandidates({})
+    setPickupLineCandidatesLoading({})
+    setPickupCandidateKeyword('')
+    setPickupSelections({})
+    setScanInputValue('')
+    setScanFeedback(null)
+    scanBufferRef.current = { value: '', lastTs: 0 }
   }
 
   const handleSubmit = async () => {
@@ -441,7 +687,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          selections: pickupCandidates.map((line) => ({
+          selections: pickupLines.map((line) => ({
             line_id: line.line_id,
             item_ids: pickupSelections[line.line_id] ?? [],
           })),
@@ -460,9 +706,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       }
       await refreshReservationOptions()
       await refreshCurrentRequest()
-      setPickupDialogOpen(false)
-      setPickupCandidates([])
-      setPickupSelections({})
+      closePickupDialog()
       void toast.fire({ icon: 'success', title: '已完成領取並分配資產。' })
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
@@ -515,15 +759,23 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           </div>
           <div className="grid gap-1.5">
             <Label>領用日</Label>
-            <Input type="date" value={borrowDate} onChange={(event) => setBorrowDate(event.target.value)} disabled={!canEditReservation || submitting} />
+            <Input type="date" value={borrowDate} required onChange={(event) => setBorrowDate(event.target.value)} disabled={!canEditReservation || submitting} />
           </div>
           <div className="grid gap-1.5">
             <Label>預計歸還</Label>
-            <Input type="date" value={dueDate} min={borrowDate || undefined} onChange={(event) => setDueDate(event.target.value)} disabled={!canEditReservation || submitting} />
+            <Input
+              type="date"
+              value={dueDate}
+              required
+              min={borrowDate || undefined}
+              max={dueDateMax}
+              onChange={(event) => setDueDate(event.target.value)}
+              disabled={!canEditReservation || submitting}
+            />
           </div>
           <div className="grid gap-1.5">
             <Label>狀態</Label>
-            <Input value={status || '--'} disabled />
+            <Input value={statusLabel} disabled />
           </div>
           <div className="grid gap-1.5">
             <Label>實際歸還</Label>
@@ -666,16 +918,14 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       </div>
       <Dialog
         open={pickupDialogOpen}
-        onClose={() => {
-          if (!submitting) {
-            setPickupDialogOpen(false)
-          }
-        }}
+        onClose={closePickupDialog}
         title="確認借出編號"
-        description="請為每個預約品項指定實際借出的資產編號。每個編號只能使用一次。"
+        description="大量清單可先掃碼，再按列檢查。每個編號只能使用一次。"
+        panelClassName="max-w-6xl h-[85vh] flex flex-col"
+        bodyClassName="min-h-0 flex-1 overflow-hidden"
         actions={
           <>
-            <Button type="button" variant="secondary" onClick={() => setPickupDialogOpen(false)} disabled={submitting}>
+            <Button type="button" variant="secondary" onClick={closePickupDialog} disabled={submitting}>
               取消
             </Button>
             <Button type="button" onClick={() => void handlePickup()} disabled={submitting || !pickupSelectionComplete}>
@@ -684,43 +934,159 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           </>
         }
       >
-        <div className="grid max-h-[60vh] gap-3 overflow-y-auto pr-1">
-          {pickupCandidates.map((line) => {
-            const selected = pickupSelections[line.line_id] ?? []
-            const selectedByOtherLines = getSelectedItemIdsExceptLine(line.line_id)
-            return (
-              <div key={line.line_id} className="rounded-md border border-[hsl(var(--border))] p-3">
-                <p className="m-0 text-sm font-semibold">
-                  {line.item_name} / {line.item_model}
-                </p>
-                <p className="mt-1 mb-2 text-xs text-[hsl(var(--muted-foreground))]">
-                  需選擇 {line.requested_qty} 個，目前已選 {selected.length} 個
-                </p>
-                <div className="grid gap-1">
-                  {line.candidates.length === 0 ? (
-                    <p className="m-0 text-xs text-red-700">目前無可領取資產。</p>
-                  ) : (
-                    line.candidates.map((candidate) => {
-                      const checked = selected.includes(candidate.id)
-                      const disabled = !checked && selectedByOtherLines.has(candidate.id)
-                      return (
-                        <label key={candidate.id} className="flex items-center gap-2 text-sm">
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            disabled={disabled || submitting}
-                            onChange={() => togglePickupSelection(line.line_id, candidate.id)}
-                          />
-                          <span>{getPickupItemSerialLabel(candidate)}</span>
-                          <span className="text-xs text-[hsl(var(--muted-foreground))]">（ID: {candidate.id}）</span>
-                        </label>
-                      )
-                    })
-                  )}
-                </div>
+        <div className="grid h-full min-h-0 gap-3 lg:grid-cols-[320px,1fr]">
+          <div className="min-h-0 rounded-md border border-[hsl(var(--border))] p-3">
+            <p className="mt-0 mb-2 text-sm font-semibold">待領取品項</p>
+            <div className="grid max-h-full gap-2 overflow-y-auto">
+              {pickupLines.map((line) => {
+                const selectedQty = getPickupSelectedQty(line.line_id)
+                const isExpanded = pickupExpandedLineId === line.line_id
+                return (
+                  <button
+                    key={line.line_id}
+                    type="button"
+                    className={`grid gap-1 rounded-md border p-2 text-left ${
+                      isExpanded ? 'border-[hsl(var(--primary))] bg-[hsl(var(--card-soft))]' : 'border-[hsl(var(--border))]'
+                    }`}
+                    onClick={() => void handleExpandPickupLine(line.line_id)}
+                  >
+                    <span className="text-sm font-semibold">{line.item_name} / {line.item_model}</span>
+                    <span className="text-xs text-[hsl(var(--muted-foreground))]">
+                      已選 {selectedQty} / {line.requested_qty}，候選約 {line.candidate_count}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="grid min-h-0 gap-3">
+            <div className="rounded-md border border-[hsl(var(--border))] p-3">
+              <Label htmlFor="borrow-pickup-scan">掃碼輸入</Label>
+              <div className="mt-1 flex gap-2">
+                <Input
+                  id="borrow-pickup-scan"
+                  ref={scanInputRef}
+                  value={scanInputValue}
+                  onChange={(event) => setScanInputValue(event.target.value)}
+                  onKeyDown={handleScanInputKeyDown}
+                  placeholder="掃描條碼後按 Enter"
+                  disabled={submitting}
+                />
+                <Button type="button" variant="secondary" onClick={() => void applyScanCode(scanInputValue)} disabled={submitting || !scanInputValue.trim()}>
+                  加入
+                </Button>
               </div>
-            )
-          })}
+              {scanFeedback ? (
+                <p className={`mt-2 mb-0 text-xs ${scanFeedback.type === 'success' ? 'text-green-700' : scanFeedback.type === 'error' ? 'text-red-700' : 'text-[hsl(var(--muted-foreground))]'}`}>
+                  {scanFeedback.message}
+                </p>
+              ) : (
+                <p className="mt-2 mb-0 text-xs text-[hsl(var(--muted-foreground))]">掃碼後會自動補到第一個尚未選滿的相符預約列。</p>
+              )}
+            </div>
+
+            <div className="grid min-h-0 rounded-md border border-[hsl(var(--border))] p-3">
+              {pickupExpandedLineId ? (
+                <>
+                  <div className="flex flex-wrap items-end gap-2">
+                    <div className="min-w-[220px] flex-1">
+                      <Label>候選搜尋</Label>
+                      <Input
+                        value={pickupCandidateKeyword}
+                        onChange={(event) => setPickupCandidateKeyword(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault()
+                            void loadPickupLineCandidates(pickupExpandedLineId, pickupCandidateKeyword, 1)
+                          }
+                        }}
+                        placeholder="輸入編號關鍵字後 Enter"
+                        disabled={submitting}
+                      />
+                    </div>
+                    <Button type="button" variant="secondary" onClick={() => void loadPickupLineCandidates(pickupExpandedLineId, pickupCandidateKeyword, 1)} disabled={submitting}>
+                      查詢
+                    </Button>
+                  </div>
+
+                  <div className="mt-3 min-h-0 overflow-y-auto">
+                    {pickupLineCandidatesLoading[pickupExpandedLineId] ? (
+                      <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">候選載入中...</p>
+                    ) : (
+                      <>
+                        {(pickupLineCandidates[pickupExpandedLineId]?.items ?? []).length === 0 ? (
+                          <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有候選資料。</p>
+                        ) : (
+                          (pickupLineCandidates[pickupExpandedLineId]?.items ?? []).map((candidate) => {
+                            const checked = (pickupSelections[pickupExpandedLineId] ?? []).includes(candidate.id)
+                            const disabled = !checked && getSelectedItemIdsExceptLine(pickupExpandedLineId).has(candidate.id)
+                            return (
+                              <label key={candidate.id} className="mb-1 flex items-center gap-2 rounded-sm text-sm">
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  disabled={disabled || submitting}
+                                  onChange={() => togglePickupSelection(pickupExpandedLineId, candidate.id)}
+                                />
+                                <span>{getPickupItemSerialLabel(candidate)}</span>
+                                <span className="text-xs text-[hsl(var(--muted-foreground))]">（ID: {candidate.id}）</span>
+                              </label>
+                            )
+                          })
+                        )}
+                      </>
+                    )}
+                  </div>
+
+                  <div className="mt-3 flex items-center justify-between text-xs text-[hsl(var(--muted-foreground))]">
+                    <span>
+                      第 {pickupLineCandidates[pickupExpandedLineId]?.page ?? 1} / {pickupLineCandidates[pickupExpandedLineId]?.total_pages ?? 1} 頁，
+                      共 {pickupLineCandidates[pickupExpandedLineId]?.total ?? 0} 筆
+                    </span>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={() =>
+                          void loadPickupLineCandidates(
+                            pickupExpandedLineId,
+                            pickupCandidateKeyword,
+                            Math.max((pickupLineCandidates[pickupExpandedLineId]?.page ?? 1) - 1, 1),
+                          )
+                        }
+                        disabled={submitting || (pickupLineCandidates[pickupExpandedLineId]?.page ?? 1) <= 1}
+                      >
+                        上一頁
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={() =>
+                          void loadPickupLineCandidates(
+                            pickupExpandedLineId,
+                            pickupCandidateKeyword,
+                            Math.min(
+                              (pickupLineCandidates[pickupExpandedLineId]?.page ?? 1) + 1,
+                              pickupLineCandidates[pickupExpandedLineId]?.total_pages ?? 1,
+                            ),
+                          )
+                        }
+                        disabled={
+                          submitting
+                          || (pickupLineCandidates[pickupExpandedLineId]?.page ?? 1) >= (pickupLineCandidates[pickupExpandedLineId]?.total_pages ?? 1)
+                        }
+                      >
+                        下一頁
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">請先選擇左側預約列。</p>
+              )}
+            </div>
+          </div>
         </div>
       </Dialog>
     </div>

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
+import { Dialog } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
-import type { BorrowRequest, BorrowReservationOption } from './types'
+import type { BorrowPickupCandidateItem, BorrowPickupCandidateLine, BorrowRequest, BorrowReservationOption } from './types'
 
 type BorrowLine = {
   item_name: string
@@ -79,6 +80,10 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const [loadError, setLoadError] = useState('')
   const [formError, setFormError] = useState('')
   const [shortages, setShortages] = useState<ShortageRow[]>([])
+  const [pickupDialogOpen, setPickupDialogOpen] = useState(false)
+  const [pickupLoading, setPickupLoading] = useState(false)
+  const [pickupCandidates, setPickupCandidates] = useState<BorrowPickupCandidateLine[]>([])
+  const [pickupSelections, setPickupSelections] = useState<Record<number, number[]>>({})
 
   const [borrower, setBorrower] = useState('')
   const [department, setDepartment] = useState('')
@@ -189,6 +194,10 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     () => lines.reduce((sum, line) => sum + Math.max(0, Number(line.allocated_qty) || 0), 0),
     [lines],
   )
+  const pickupSelectionComplete = useMemo(
+    () => pickupCandidates.every((line) => (pickupSelections[line.line_id] ?? []).length === line.requested_qty),
+    [pickupCandidates, pickupSelections],
+  )
 
   const getModelOptionsByName = (itemName: string, searchKeyword: string) => {
     const keyword = searchKeyword.trim().toLowerCase()
@@ -276,6 +285,67 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     )
   }
 
+  const getPickupItemSerialLabel = (candidate: BorrowPickupCandidateItem) => {
+    return candidate.n_property_sn || candidate.property_sn || candidate.n_item_sn || candidate.item_sn || `ID ${candidate.id}`
+  }
+
+  const getSelectedItemIdsExceptLine = (lineId: number) => {
+    const selectedIds = new Set<number>()
+    Object.entries(pickupSelections).forEach(([rawLineId, itemIds]) => {
+      if (Number(rawLineId) === lineId) {
+        return
+      }
+      itemIds.forEach((itemId) => selectedIds.add(itemId))
+    })
+    return selectedIds
+  }
+
+  const togglePickupSelection = (lineId: number, itemId: number) => {
+    const line = pickupCandidates.find((candidateLine) => candidateLine.line_id === lineId)
+    if (!line) {
+      return
+    }
+    setPickupSelections((prev) => {
+      const current = prev[lineId] ?? []
+      if (current.includes(itemId)) {
+        return { ...prev, [lineId]: current.filter((id) => id !== itemId) }
+      }
+      if (current.length >= line.requested_qty) {
+        return prev
+      }
+      return { ...prev, [lineId]: [...current, itemId] }
+    })
+  }
+
+  const openPickupDialog = async () => {
+    if (!requestId) {
+      return
+    }
+    setFormError('')
+    setShortages([])
+    setPickupLoading(true)
+    try {
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup-candidates`))
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail = typeof payload?.detail === 'string' ? payload.detail : null
+        throw new Error(detail ?? '無法載入可領取編號')
+      }
+      const payload = (await response.json()) as BorrowPickupCandidateLine[]
+      if (payload.length === 0) {
+        throw new Error('目前沒有可領取的預約品項')
+      }
+      setPickupCandidates(payload)
+      setPickupSelections(Object.fromEntries(payload.map((line) => [line.line_id, []])))
+      setPickupDialogOpen(true)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      void toast.fire({ icon: 'error', title: message || '無法載入可領取編號' })
+    } finally {
+      setPickupLoading(false)
+    }
+  }
+
   const handleSubmit = async () => {
     setFormError('')
     setShortages([])
@@ -359,11 +429,24 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     if (!requestId) {
       return
     }
+    if (!pickupSelectionComplete) {
+      void toast.fire({ icon: 'error', title: '請先完成每個品項的借出編號選擇。' })
+      return
+    }
     setFormError('')
     setShortages([])
     setSubmitting(true)
     try {
-      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup`), { method: 'POST' })
+      const response = await fetch(apiUrl(`/api/borrows/${requestId}/pickup`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selections: pickupCandidates.map((line) => ({
+            line_id: line.line_id,
+            item_ids: pickupSelections[line.line_id] ?? [],
+          })),
+        }),
+      })
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
         const shortageRows = parseShortages(payload?.detail)
@@ -377,6 +460,9 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       }
       await refreshReservationOptions()
       await refreshCurrentRequest()
+      setPickupDialogOpen(false)
+      setPickupCandidates([])
+      setPickupSelections({})
       void toast.fire({ icon: 'success', title: '已完成領取並分配資產。' })
     } catch (error) {
       const message = error instanceof Error ? error.message : ''
@@ -568,8 +654,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           {submitting ? '儲存中...' : isEditing ? '更新預約' : '建立預約'}
         </Button>
         {canPickup ? (
-          <Button type="button" variant="secondary" onClick={() => void handlePickup()} disabled={submitting}>
-            {submitting ? '處理中...' : '執行領取'}
+          <Button type="button" variant="secondary" onClick={() => void openPickupDialog()} disabled={submitting || pickupLoading}>
+            {pickupLoading ? '載入中...' : '執行領取'}
           </Button>
         ) : null}
         {canReturn ? (
@@ -578,6 +664,65 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           </Button>
         ) : null}
       </div>
+      <Dialog
+        open={pickupDialogOpen}
+        onClose={() => {
+          if (!submitting) {
+            setPickupDialogOpen(false)
+          }
+        }}
+        title="確認借出編號"
+        description="請為每個預約品項指定實際借出的資產編號。每個編號只能使用一次。"
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setPickupDialogOpen(false)} disabled={submitting}>
+              取消
+            </Button>
+            <Button type="button" onClick={() => void handlePickup()} disabled={submitting || !pickupSelectionComplete}>
+              {submitting ? '處理中...' : '確認領取'}
+            </Button>
+          </>
+        }
+      >
+        <div className="grid max-h-[60vh] gap-3 overflow-y-auto pr-1">
+          {pickupCandidates.map((line) => {
+            const selected = pickupSelections[line.line_id] ?? []
+            const selectedByOtherLines = getSelectedItemIdsExceptLine(line.line_id)
+            return (
+              <div key={line.line_id} className="rounded-md border border-[hsl(var(--border))] p-3">
+                <p className="m-0 text-sm font-semibold">
+                  {line.item_name} / {line.item_model}
+                </p>
+                <p className="mt-1 mb-2 text-xs text-[hsl(var(--muted-foreground))]">
+                  需選擇 {line.requested_qty} 個，目前已選 {selected.length} 個
+                </p>
+                <div className="grid gap-1">
+                  {line.candidates.length === 0 ? (
+                    <p className="m-0 text-xs text-red-700">目前無可領取資產。</p>
+                  ) : (
+                    line.candidates.map((candidate) => {
+                      const checked = selected.includes(candidate.id)
+                      const disabled = !checked && selectedByOtherLines.has(candidate.id)
+                      return (
+                        <label key={candidate.id} className="flex items-center gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={disabled || submitting}
+                            onChange={() => togglePickupSelection(line.line_id, candidate.id)}
+                          />
+                          <span>{getPickupItemSerialLabel(candidate)}</span>
+                          <span className="text-xs text-[hsl(var(--muted-foreground))]">（ID: {candidate.id}）</span>
+                        </label>
+                      )
+                    })
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -60,6 +60,7 @@ export function DashboardPage() {
 
   const pendingFixCount = dashboardData?.pendingFix ?? 0
   const totalRecords = dashboardData?.totalRecords ?? 0
+  const reservedBorrowCount = dashboardData?.reservedBorrowCount ?? 0
   const overdueBorrowCount = dashboardData?.overdueBorrowCount ?? 0
   const dueSoonBorrowCount = dashboardData?.dueSoonBorrowCount ?? 0
   const donatedItemsCount = dashboardData?.donatedItemsCount ?? 0
@@ -124,7 +125,7 @@ export function DashboardPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center justify-between">
               <div>
-                <CardTitle>異常提醒</CardTitle>
+                <CardTitle>重點提醒</CardTitle>
                 <CardDescription>優先處理可能造成資料錯誤或流程延遲的項目。</CardDescription>
               </div>
               <AlertTriangle className="size-5 text-[hsl(var(--muted-foreground))]" />
@@ -133,6 +134,9 @@ export function DashboardPage() {
           <CardContent className="grid gap-2">
             <div className="rounded-lg border border-amber-300 bg-amber-100 px-3 py-2 text-sm font-medium text-amber-900">
               待修正資產資料：<strong>{pendingFixCount}</strong> 筆
+            </div>
+            <div className="rounded-lg border border-blue-300 bg-blue-100 px-3 py-2 text-sm font-medium text-blue-800">
+              預約借用：<strong>{reservedBorrowCount}</strong> 筆
             </div>
             <div className="rounded-lg border border-red-300 bg-red-100 px-3 py-2 text-sm font-medium text-red-800">
               逾期借用：<strong>{overdueBorrowCount}</strong> 筆

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -86,8 +86,11 @@ export type IssueRequest = {
 
 export type BorrowItem = {
   id: number
-  item_id: number
+  item_id?: number | null
   quantity: number
+  requested_qty: number
+  allocated_qty: number
+  allocated_item_ids: number[]
   note: string
   item_name?: string | null
   item_model?: string | null
@@ -104,7 +107,16 @@ export type BorrowRequest = {
   status: string
   is_due_soon: boolean
   memo: string
-  items: BorrowItem[]
+  request_lines: BorrowItem[]
+}
+
+export type BorrowReservationOption = {
+  item_name: string
+  item_model: string
+  available_qty: number
+  reserved_qty: number
+  reservable_qty: number
+  selectable: boolean
 }
 
 export type DonationItem = {

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -127,12 +127,40 @@ export type BorrowPickupCandidateItem = {
   item_sn: string
 }
 
+export type BorrowPickupLineSummary = {
+  line_id: number
+  item_name: string
+  item_model: string
+  requested_qty: number
+  candidate_count: number
+}
+
 export type BorrowPickupCandidateLine = {
   line_id: number
   item_name: string
   item_model: string
   requested_qty: number
   candidates: BorrowPickupCandidateItem[]
+}
+
+export type BorrowPickupLineCandidatePage = {
+  line_id: number
+  item_name: string
+  item_model: string
+  requested_qty: number
+  items: BorrowPickupCandidateItem[]
+  page: number
+  page_size: number
+  total: number
+  total_pages: number
+}
+
+export type BorrowPickupScanResolveResponse = {
+  item: BorrowPickupCandidateItem & {
+    item_name: string
+    item_model: string
+  }
+  eligible_line_ids: number[]
 }
 
 export type DonationItem = {

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -4,6 +4,7 @@ export type DashboardPayload = {
   items: number
   pendingFix: number
   totalRecords?: number
+  reservedBorrowCount?: number
   overdueBorrowCount?: number
   dueSoonBorrowCount?: number
   donatedItemsCount?: number
@@ -132,6 +133,8 @@ export type BorrowPickupLineSummary = {
   item_name: string
   item_model: string
   requested_qty: number
+  allocated_qty: number
+  remaining_qty: number
   candidate_count: number
 }
 
@@ -140,6 +143,8 @@ export type BorrowPickupCandidateLine = {
   item_name: string
   item_model: string
   requested_qty: number
+  allocated_qty: number
+  remaining_qty: number
   candidates: BorrowPickupCandidateItem[]
 }
 
@@ -148,6 +153,8 @@ export type BorrowPickupLineCandidatePage = {
   item_name: string
   item_model: string
   requested_qty: number
+  allocated_qty: number
+  remaining_qty: number
   items: BorrowPickupCandidateItem[]
   page: number
   page_size: number

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -119,6 +119,22 @@ export type BorrowReservationOption = {
   selectable: boolean
 }
 
+export type BorrowPickupCandidateItem = {
+  id: number
+  n_property_sn: string
+  property_sn: string
+  n_item_sn: string
+  item_sn: string
+}
+
+export type BorrowPickupCandidateLine = {
+  line_id: number
+  item_name: string
+  item_model: string
+  requested_qty: number
+  candidates: BorrowPickupCandidateItem[]
+}
+
 export type DonationItem = {
   id: number
   item_id: number

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -9,9 +9,11 @@ type DialogProps = {
   description?: string
   children?: React.ReactNode
   actions?: React.ReactNode
+  panelClassName?: string
+  bodyClassName?: string
 }
 
-export function Dialog({ open, onClose, title, description, children, actions }: DialogProps) {
+export function Dialog({ open, onClose, title, description, children, actions, panelClassName, bodyClassName }: DialogProps) {
   if (!open) {
     return null
   }
@@ -21,12 +23,12 @@ export function Dialog({ open, onClose, title, description, children, actions }:
       <div
         role="dialog"
         aria-modal="true"
-        className={cn('w-full max-w-md rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-xl')}
+        className={cn('w-full max-w-md rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-xl', panelClassName)}
         onClick={(event) => event.stopPropagation()}
       >
         <h3 className="m-0 text-base font-semibold text-[hsl(var(--foreground))]">{title}</h3>
         {description ? <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">{description}</p> : null}
-        {children ? <div className="mt-4">{children}</div> : null}
+        {children ? <div className={cn('mt-4', bodyClassName)}>{children}</div> : null}
         {actions ? <div className="mt-5 flex justify-end gap-2">{actions}</div> : null}
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- support partial pickup for borrow requests with new `partial_borrowed` status
- allow multi-round pickup and return from partial-borrowed requests
- add dashboard reserved-borrow counter and UI reminder
- rename dashboard section title from 異常提醒 to 重點提醒

## Validation
- backend: `uv run python -m unittest tests.test_request_api_guards tests.test_transaction_consistency tests.test_list_sorting_api`
- frontend: `npm run build`

Closes #19