### PR TITLE
feat: issue/donation cascade select and keeper sync on issue/borrow

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1626,6 +1626,35 @@ def _set_inventory_status(row: dict[str, Any], status: str) -> None:
     row["updated_by"] = "system"
 
 
+def _set_issue_keeper_for_create_issue(
+    *,
+    row: dict[str, Any],
+    requester: str,
+) -> None:
+    normalized_requester = requester.strip()
+    if not normalized_requester:
+        return
+    row["keeper"] = normalized_requester
+
+
+def _set_item_keeper_from_actor(
+    *,
+    row: dict[str, Any],
+    actor: str,
+) -> None:
+    normalized_actor = actor.strip()
+    if not normalized_actor:
+        return
+    row["keeper"] = normalized_actor
+
+
+def _clear_item_keeper(
+    *,
+    row: dict[str, Any],
+) -> None:
+    row["keeper"] = ""
+
+
 def _validate_item_status(
     *,
     inventory_map: dict[int, dict[str, Any]],
@@ -1653,6 +1682,7 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
         selected_item_ids = _normalize_request_item_ids(items)
         inventory_map = _active_inventory_rows_map(inventory_rows)
         request_id = _next_id(request_rows)
+        requester = _to_str(request_data.get("requester"))
         for item_id in selected_item_ids:
             row = _validate_item_status(inventory_map=inventory_map, item_id=item_id, allowed_statuses={"0"})
             _set_inventory_status_with_movement(
@@ -1664,6 +1694,7 @@ def create_issue_request(request_data: dict[str, Any], items: list[dict[str, Any
                 entity="issue_request",
                 entity_id=request_id,
             )
+            _set_issue_keeper_for_create_issue(row=row, requester=requester)
         request_rows.append(
             {
                 "id": request_id,
@@ -3196,6 +3227,7 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
         request_row = next((row for row in request_rows if _to_int(row.get("id")) == request_id), None)
         if request_row is None:
             return False
+        borrower = _to_str(request_row.get("borrower"))
         status = _to_str(request_row.get("status")).strip().lower()
         if status not in {"reserved", "expired", "partial_borrowed"}:
             raise ValueError("only reserved request can be picked up")
@@ -3277,6 +3309,7 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
                     entity="borrow_request",
                     entity_id=request_id,
                 )
+                _set_item_keeper_from_actor(row=inventory_row, actor=borrower)
                 created_allocations.append(
                     {
                         "id": next_allocation_id + len(created_allocations),
@@ -3367,6 +3400,7 @@ def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> 
                 entity="borrow_request",
                 entity_id=request_id,
             )
+            _clear_item_keeper(row=row)
 
         normalized_return_date = _parse_request_date(return_date_value) or date.today()
         request_row["return_date"] = normalized_return_date.strftime("%Y/%m/%d")

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -111,12 +111,80 @@ class TransactionConsistencyTests(unittest.TestCase):
         self.assertEqual(item_after_delete['count'], 1)
         self.assertEqual(item_after_delete['asset_status'], '0')
 
+    def test_issue_request_sets_keeper_to_requester_for_asset(self) -> None:
+        item_id = db.create_item(
+            {
+                'asset_type': '11',
+                'asset_status': '0',
+                'name': '財產設備',
+                'model': 'A-1',
+                'count': 1,
+                'keeper': '原保管人',
+            }
+        )
+
+        db.create_issue_request(
+            {
+                **self._issue_payload(),
+                'requester': '新領用人',
+            },
+            [{'item_id': item_id, 'quantity': 1, 'note': ''}],
+        )
+
+        item_after_create = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_create)
+        self.assertEqual(item_after_create['asset_status'], '1')
+        self.assertEqual(item_after_create['keeper'], '新領用人')
+
+    def test_issue_request_sets_keeper_to_requester_for_non_asset(self) -> None:
+        item_id = db.create_item(
+            {
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '耗材',
+                'model': 'I-1',
+                'count': 1,
+                'keeper': '原保管人',
+            }
+        )
+
+        db.create_issue_request(
+            {
+                **self._issue_payload(),
+                'requester': '新領用人',
+            },
+            [{'item_id': item_id, 'quantity': 1, 'note': ''}],
+        )
+
+        item_after_create = db.get_item_by_id(item_id)
+        self.assertIsNotNone(item_after_create)
+        self.assertEqual(item_after_create['asset_status'], '1')
+        self.assertEqual(item_after_create['keeper'], '新領用人')
+
     def test_borrow_reservation_pickup_return_flow_updates_status_only(self) -> None:
-        first_id = self._create_item(name='平板', model='T1')
-        second_id = self._create_item(name='平板', model='T1')
+        first_id = db.create_item(
+            {
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '平板',
+                'model': 'T1',
+                'count': 1,
+                'keeper': '原保管人A',
+            }
+        )
+        second_id = db.create_item(
+            {
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '平板',
+                'model': 'T1',
+                'count': 1,
+                'keeper': '原保管人B',
+            }
+        )
 
         request_id = db.create_borrow_request(
-            self._borrow_payload(),
+            {**self._borrow_payload(), 'borrower': '借用人A'},
             [{'item_name': '平板', 'item_model': 'T1', 'requested_qty': 2, 'note': ''}],
         )
         request = db.get_borrow_request(request_id)
@@ -137,12 +205,61 @@ class TransactionConsistencyTests(unittest.TestCase):
         item_after_pickup_2 = db.get_item_by_id(second_id)
         self.assertEqual(item_after_pickup_1['asset_status'], '2')
         self.assertEqual(item_after_pickup_2['asset_status'], '2')
+        self.assertEqual(item_after_pickup_1['keeper'], '借用人A')
+        self.assertEqual(item_after_pickup_2['keeper'], '借用人A')
 
         db.return_borrow_request(request_id)
         item_after_return_1 = db.get_item_by_id(first_id)
         item_after_return_2 = db.get_item_by_id(second_id)
         self.assertEqual(item_after_return_1['asset_status'], '0')
         self.assertEqual(item_after_return_2['asset_status'], '0')
+        self.assertEqual(item_after_return_1['keeper'], '')
+        self.assertEqual(item_after_return_2['keeper'], '')
+
+    def test_partial_pickup_updates_keeper_only_for_picked_items(self) -> None:
+        first_id = db.create_item(
+            {
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '相機',
+                'model': 'C1',
+                'count': 1,
+                'keeper': '原保管人A',
+            }
+        )
+        second_id = db.create_item(
+            {
+                'asset_type': 'A1',
+                'asset_status': '0',
+                'name': '相機',
+                'model': 'C1',
+                'count': 1,
+                'keeper': '原保管人B',
+            }
+        )
+
+        request_id = db.create_borrow_request(
+            {**self._borrow_payload(), 'borrower': '借用人B'},
+            [{'item_name': '相機', 'item_model': 'C1', 'requested_qty': 2, 'note': ''}],
+        )
+        line_id = db.list_borrow_items(request_id)[0]['id']
+        db.pickup_borrow_request(
+            request_id,
+            [{'line_id': line_id, 'item_ids': [first_id]}],
+        )
+
+        request_after_pickup = db.get_borrow_request(request_id)
+        self.assertIsNotNone(request_after_pickup)
+        self.assertEqual(request_after_pickup['status'], 'partial_borrowed')
+
+        picked_item = db.get_item_by_id(first_id)
+        unpicked_item = db.get_item_by_id(second_id)
+        self.assertIsNotNone(picked_item)
+        self.assertIsNotNone(unpicked_item)
+        self.assertEqual(picked_item['asset_status'], '2')
+        self.assertEqual(picked_item['keeper'], '借用人B')
+        self.assertEqual(unpicked_item['asset_status'], '0')
+        self.assertEqual(unpicked_item['keeper'], '原保管人B')
 
     def test_legacy_borrow_items_can_be_returned_without_allocations(self) -> None:
         item_id = self._create_item(asset_status='2', name='老資料設備', model='L1')

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -7,19 +7,31 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
-import { buildGroupedItemOptions } from './itemOptionGroups'
+import {
+  EMPTY_MODEL_LABEL,
+  EMPTY_NAME_LABEL,
+  buildItemOptions,
+  buildModelOptions,
+  buildNameOptions,
+  decodeSelectValue,
+  encodeSelectValue,
+  getItemModelValue,
+  getItemNameValue,
+  getItemSerialLabel,
+} from './itemCascadeOptions'
 import type { DonationRequest, InventoryItem, PaginatedResponse } from './types'
 
 type DonationLine = {
   item_id: number | ''
   quantity: number
   note: string
+  selected_name: string | null
+  selected_model: string | null
 }
 
 const FIXED_DONOR = '固定捐贈人'
 const FIXED_DEPARTMENT = '固定單位'
-const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '' })
-const GROUP_OPTION_PREFIX = '__group__:'
+const emptyLine = (): DonationLine => ({ item_id: '', quantity: 1, note: '', selected_name: null, selected_model: null })
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -91,6 +103,8 @@ export function DonationPage({ requestId }: DonationPageProps) {
               item_id: item.item_id,
               quantity: item.quantity,
               note: item.note ?? '',
+              selected_name: null,
+              selected_model: null,
             }))
             : [emptyLine()],
         )
@@ -115,11 +129,53 @@ export function DonationPage({ requestId }: DonationPageProps) {
     })
   }, [inventoryItems, isEditing, requestId])
 
-  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
+  const nameOptions = useMemo(() => buildNameOptions(selectableItems), [selectableItems])
   const selectableItemIdSet = useMemo(() => new Set(selectableItems.map((item) => item.id)), [selectableItems])
+  const selectableItemMap = useMemo(() => new Map(selectableItems.map((item) => [item.id, item])), [selectableItems])
+
+  useEffect(() => {
+    setLines((prev) => {
+      let changed = false
+      const next = prev.map((line) => {
+        if (line.item_id === '') {
+          return line
+        }
+        const item = selectableItemMap.get(line.item_id)
+        if (!item) {
+          return line
+        }
+        const selectedName = getItemNameValue(item)
+        const selectedModel = getItemModelValue(item)
+        if (line.selected_name === selectedName && line.selected_model === selectedModel) {
+          return line
+        }
+        changed = true
+        return { ...line, selected_name: selectedName, selected_model: selectedModel }
+      })
+      return changed ? next : prev
+    })
+  }, [selectableItemMap])
 
   const handleLineChange = (index: number, patch: Partial<DonationLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleNameSelectChange = (index: number, rawValue: string) => {
+    const decoded = decodeSelectValue(rawValue)
+    if (decoded === null) {
+      handleLineChange(index, { selected_name: null, selected_model: null, item_id: '' })
+      return
+    }
+    handleLineChange(index, { selected_name: decoded, selected_model: null, item_id: '' })
+  }
+
+  const handleModelSelectChange = (index: number, rawValue: string) => {
+    const decoded = decodeSelectValue(rawValue)
+    if (decoded === null) {
+      handleLineChange(index, { selected_model: null, item_id: '' })
+      return
+    }
+    handleLineChange(index, { selected_model: decoded, item_id: '' })
   }
 
   const handleItemSelectChange = (index: number, rawValue: string) => {
@@ -127,10 +183,19 @@ export function DonationPage({ requestId }: DonationPageProps) {
       handleLineChange(index, { item_id: '' })
       return
     }
-    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
+    const itemId = Number(rawValue)
+    if (!Number.isInteger(itemId)) {
       return
     }
-    handleLineChange(index, { item_id: Number(rawValue) })
+    const item = selectableItemMap.get(itemId)
+    if (!item) {
+      return
+    }
+    handleLineChange(index, {
+      item_id: itemId,
+      selected_name: getItemNameValue(item),
+      selected_model: getItemModelValue(item),
+    })
   }
 
   const normalizeScanCode = (value: string) => value.trim().toLowerCase()
@@ -147,21 +212,22 @@ export function DonationPage({ requestId }: DonationPageProps) {
   }
 
   const assignScannedItem = (itemId: number) => {
+    const matchedItem = inventoryItems.find((item) => item.id === itemId)
+    const selectedName = matchedItem ? getItemNameValue(matchedItem) : null
+    const selectedModel = matchedItem ? getItemModelValue(matchedItem) : null
     setLines((prev) => {
       const emptyIndex = prev.findIndex((line) => line.item_id === '')
       if (emptyIndex >= 0) {
-        return prev.map((line, index) => (index === emptyIndex ? { ...line, item_id: itemId } : line))
+        return prev.map((line, index) => (
+          index === emptyIndex ? { ...line, item_id: itemId, selected_name: selectedName, selected_model: selectedModel } : line
+        ))
       }
-      return [...prev, { ...emptyLine(), item_id: itemId }]
+      return [...prev, { ...emptyLine(), item_id: itemId, selected_name: selectedName, selected_model: selectedModel }]
     })
   }
 
-  const getItemSerialLabel = (item: InventoryItem) => {
-    return item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn || `ID ${item.id}`
-  }
-
   const getItemScanOptionLabel = (item: InventoryItem) => {
-    const base = `${item.name || '未命名'} / ${item.model || '未填型號'}（${getItemSerialLabel(item)}）`
+    const base = `${item.name || EMPTY_NAME_LABEL} / ${item.model || EMPTY_MODEL_LABEL}（${getItemSerialLabel(item)}）`
     if (lines.some((line) => line.item_id === item.id)) {
       return `${base} [已在單內]`
     }
@@ -259,9 +325,16 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
   const validateLines = () => {
     if (lines.length === 0) {
-      return false
+      return '請至少新增一筆捐贈品項。'
     }
-    return lines.every((line) => line.item_id !== '' && line.quantity === 1)
+    if (!lines.every((line) => line.item_id !== '' && line.quantity === 1)) {
+      return '單件模式下，每筆捐贈品項數量必須為 1。'
+    }
+    const pickedIds = lines.map((line) => line.item_id).filter((itemId): itemId is number => itemId !== '')
+    if (new Set(pickedIds).size !== pickedIds.length) {
+      return '同一張捐贈單不可重複選取同一品項。'
+    }
+    return null
   }
 
   const handleSubmit = async () => {
@@ -269,8 +342,9 @@ export function DonationPage({ requestId }: DonationPageProps) {
       void toast.fire({ icon: 'error', title: '請填寫受贈對象。' })
       return
     }
-    if (!validateLines()) {
-      void toast.fire({ icon: 'error', title: '單件模式下，每筆捐贈品項數量必須為 1。' })
+    const validationError = validateLines()
+    if (validationError) {
+      void toast.fire({ icon: 'error', title: validationError })
       return
     }
 
@@ -375,29 +449,62 @@ export function DonationPage({ requestId }: DonationPageProps) {
             />
           </div>
           <div className="grid gap-3">
-            {lines.map((line, index) => (
-              <article key={`donation-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+            {lines.map((line, index) => {
+              const selectedByOtherLines = new Set(
+                lines
+                  .filter((_, idx) => idx !== index)
+                  .map((itemLine) => itemLine.item_id)
+                  .filter((itemId): itemId is number => itemId !== ''),
+              )
+              const modelOptions = line.selected_name === null ? [] : buildModelOptions(selectableItems, line.selected_name)
+              const itemOptions =
+                line.selected_name === null || line.selected_model === null
+                  ? []
+                  : buildItemOptions(selectableItems, line.selected_name, line.selected_model)
+              return (
+              <article key={`donation-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[1.2fr,1.2fr,1.6fr,1fr,2fr,auto]">
                 <div className="grid gap-1.5">
-                  <Label>品項</Label>
+                  <Label>品名</Label>
                   <Select
-                    value={line.item_id}
-                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
+                    value={line.selected_name === null ? '' : encodeSelectValue(line.selected_name)}
+                    onChange={(event) => handleNameSelectChange(index, event.target.value)}
                   >
-                    <option value="">請選擇品項</option>
-                    {itemOptionGroups.flatMap((group) => [
-                      <option
-                        key={`group-${group.groupLabel}`}
-                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
-                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
-                      >
-                        {`==== ${group.groupLabel} ====`}
-                      </option>,
-                      ...group.options.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {`  ${option.label}`}
-                        </option>
-                      )),
-                    ])}
+                    <option value="">請選擇品名</option>
+                    {nameOptions.map((option) => (
+                      <option key={`donation-name-${option.value || '__empty__'}`} value={encodeSelectValue(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>型號</Label>
+                  <Select
+                    value={line.selected_model === null ? '' : encodeSelectValue(line.selected_model)}
+                    onChange={(event) => handleModelSelectChange(index, event.target.value)}
+                    disabled={line.selected_name === null}
+                  >
+                    <option value="">請選擇型號</option>
+                    {modelOptions.map((option) => (
+                      <option key={`donation-model-${option.value || '__empty__'}`} value={encodeSelectValue(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>編號</Label>
+                  <Select
+                    value={line.item_id === '' ? '' : String(line.item_id)}
+                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
+                    disabled={line.selected_name === null || line.selected_model === null}
+                  >
+                    <option value="">請選擇編號</option>
+                    {itemOptions.map((option) => (
+                      <option key={`donation-item-${option.value}`} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">
@@ -420,7 +527,8 @@ export function DonationPage({ requestId }: DonationPageProps) {
                   </Button>
                 </div>
               </article>
-            ))}
+              )
+            })}
           </div>
 
           <div className="mt-4 flex flex-wrap items-center justify-between gap-2">

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -7,17 +7,29 @@ import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
-import { buildGroupedItemOptions } from './itemOptionGroups'
+import {
+  EMPTY_MODEL_LABEL,
+  EMPTY_NAME_LABEL,
+  buildItemOptions,
+  buildModelOptions,
+  buildNameOptions,
+  decodeSelectValue,
+  encodeSelectValue,
+  getItemModelValue,
+  getItemNameValue,
+  getItemSerialLabel,
+} from './itemCascadeOptions'
 import type { InventoryItem, IssueRequest, PaginatedResponse } from './types'
 
 type IssueLine = {
   item_id: number | ''
   quantity: number
   note: string
+  selected_name: string | null
+  selected_model: string | null
 }
 
-const emptyLine = (): IssueLine => ({ item_id: '', quantity: 1, note: '' })
-const GROUP_OPTION_PREFIX = '__group__:'
+const emptyLine = (): IssueLine => ({ item_id: '', quantity: 1, note: '', selected_name: null, selected_model: null })
 const toast = Swal.mixin({
   toast: true,
   position: 'top-end',
@@ -87,6 +99,8 @@ export function IssuePage({ requestId }: IssuePageProps) {
               item_id: item.item_id,
               quantity: item.quantity,
               note: item.note ?? '',
+              selected_name: null,
+              selected_model: null,
             }))
             : [emptyLine()],
         )
@@ -112,11 +126,53 @@ export function IssuePage({ requestId }: IssuePageProps) {
     })
   }, [inventoryItems, isEditing, selectedItemIds])
 
-  const itemOptionGroups = useMemo(() => buildGroupedItemOptions(selectableItems), [selectableItems])
+  const nameOptions = useMemo(() => buildNameOptions(selectableItems), [selectableItems])
   const selectableItemIdSet = useMemo(() => new Set(selectableItems.map((item) => item.id)), [selectableItems])
+  const selectableItemMap = useMemo(() => new Map(selectableItems.map((item) => [item.id, item])), [selectableItems])
+
+  useEffect(() => {
+    setLines((prev) => {
+      let changed = false
+      const next = prev.map((line) => {
+        if (line.item_id === '') {
+          return line
+        }
+        const item = selectableItemMap.get(line.item_id)
+        if (!item) {
+          return line
+        }
+        const selectedName = getItemNameValue(item)
+        const selectedModel = getItemModelValue(item)
+        if (line.selected_name === selectedName && line.selected_model === selectedModel) {
+          return line
+        }
+        changed = true
+        return { ...line, selected_name: selectedName, selected_model: selectedModel }
+      })
+      return changed ? next : prev
+    })
+  }, [selectableItemMap])
 
   const handleLineChange = (index: number, patch: Partial<IssueLine>) => {
     setLines((prev) => prev.map((line, idx) => (idx === index ? { ...line, ...patch } : line)))
+  }
+
+  const handleNameSelectChange = (index: number, rawValue: string) => {
+    const decoded = decodeSelectValue(rawValue)
+    if (decoded === null) {
+      handleLineChange(index, { selected_name: null, selected_model: null, item_id: '' })
+      return
+    }
+    handleLineChange(index, { selected_name: decoded, selected_model: null, item_id: '' })
+  }
+
+  const handleModelSelectChange = (index: number, rawValue: string) => {
+    const decoded = decodeSelectValue(rawValue)
+    if (decoded === null) {
+      handleLineChange(index, { selected_model: null, item_id: '' })
+      return
+    }
+    handleLineChange(index, { selected_model: decoded, item_id: '' })
   }
 
   const handleItemSelectChange = (index: number, rawValue: string) => {
@@ -124,10 +180,20 @@ export function IssuePage({ requestId }: IssuePageProps) {
       handleLineChange(index, { item_id: '' })
       return
     }
-    if (rawValue.startsWith(GROUP_OPTION_PREFIX)) {
+
+    const itemId = Number(rawValue)
+    if (!Number.isInteger(itemId)) {
       return
     }
-    handleLineChange(index, { item_id: Number(rawValue) })
+    const item = selectableItemMap.get(itemId)
+    if (!item) {
+      return
+    }
+    handleLineChange(index, {
+      item_id: itemId,
+      selected_name: getItemNameValue(item),
+      selected_model: getItemModelValue(item),
+    })
   }
 
   const normalizeScanCode = (value: string) => value.trim().toLowerCase()
@@ -144,21 +210,22 @@ export function IssuePage({ requestId }: IssuePageProps) {
   }
 
   const assignScannedItem = (itemId: number) => {
+    const matchedItem = inventoryItems.find((item) => item.id === itemId)
+    const selectedName = matchedItem ? getItemNameValue(matchedItem) : null
+    const selectedModel = matchedItem ? getItemModelValue(matchedItem) : null
     setLines((prev) => {
       const emptyIndex = prev.findIndex((line) => line.item_id === '')
       if (emptyIndex >= 0) {
-        return prev.map((line, index) => (index === emptyIndex ? { ...line, item_id: itemId } : line))
+        return prev.map((line, index) => (
+          index === emptyIndex ? { ...line, item_id: itemId, selected_name: selectedName, selected_model: selectedModel } : line
+        ))
       }
-      return [...prev, { ...emptyLine(), item_id: itemId }]
+      return [...prev, { ...emptyLine(), item_id: itemId, selected_name: selectedName, selected_model: selectedModel }]
     })
   }
 
-  const getItemSerialLabel = (item: InventoryItem) => {
-    return item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn || `ID ${item.id}`
-  }
-
   const getItemScanOptionLabel = (item: InventoryItem) => {
-    const base = `${item.name || '未命名'} / ${item.model || '未填型號'}（${getItemSerialLabel(item)}）`
+    const base = `${item.name || EMPTY_NAME_LABEL} / ${item.model || EMPTY_MODEL_LABEL}（${getItemSerialLabel(item)}）`
     if (lines.some((line) => line.item_id === item.id)) {
       return `${base} [已在單內]`
     }
@@ -376,29 +443,55 @@ export function IssuePage({ requestId }: IssuePageProps) {
                   .map((itemLine) => itemLine.item_id)
                   .filter((itemId): itemId is number => itemId !== ''),
               )
+              const modelOptions = line.selected_name === null ? [] : buildModelOptions(selectableItems, line.selected_name)
+              const itemOptions =
+                line.selected_name === null || line.selected_model === null
+                  ? []
+                  : buildItemOptions(selectableItems, line.selected_name, line.selected_model)
               return (
-              <article key={`issue-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[2fr,1fr,2fr,auto]">
+              <article key={`issue-line-${index}`} className="grid gap-2 rounded-lg border border-[hsl(var(--border))] p-3 md:grid-cols-[1.2fr,1.2fr,1.6fr,1fr,2fr,auto]">
                 <div className="grid gap-1.5">
-                  <Label>品項</Label>
+                  <Label>品名</Label>
                   <Select
-                    value={line.item_id}
-                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
+                    value={line.selected_name === null ? '' : encodeSelectValue(line.selected_name)}
+                    onChange={(event) => handleNameSelectChange(index, event.target.value)}
                   >
-                    <option value="">請選擇品項</option>
-                    {itemOptionGroups.flatMap((group) => [
-                      <option
-                        key={`group-${group.groupLabel}`}
-                        value={`${GROUP_OPTION_PREFIX}${group.groupLabel}`}
-                        style={{ color: 'hsl(var(--foreground))', fontWeight: 700 }}
-                      >
-                        {`==== ${group.groupLabel} ====`}
-                      </option>,
-                      ...group.options.map((option) => (
-                        <option key={option.value} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
-                          {`  ${option.label}`}
-                        </option>
-                      )),
-                    ])}
+                    <option value="">請選擇品名</option>
+                    {nameOptions.map((option) => (
+                      <option key={`issue-name-${option.value || '__empty__'}`} value={encodeSelectValue(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>型號</Label>
+                  <Select
+                    value={line.selected_model === null ? '' : encodeSelectValue(line.selected_model)}
+                    onChange={(event) => handleModelSelectChange(index, event.target.value)}
+                    disabled={line.selected_name === null}
+                  >
+                    <option value="">請選擇型號</option>
+                    {modelOptions.map((option) => (
+                      <option key={`issue-model-${option.value || '__empty__'}`} value={encodeSelectValue(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>編號</Label>
+                  <Select
+                    value={line.item_id === '' ? '' : String(line.item_id)}
+                    onChange={(event) => handleItemSelectChange(index, event.target.value)}
+                    disabled={line.selected_name === null || line.selected_model === null}
+                  >
+                    <option value="">請選擇編號</option>
+                    {itemOptions.map((option) => (
+                      <option key={`issue-item-${option.value}`} value={option.value} disabled={selectedByOtherLines.has(option.value)}>
+                        {option.label}
+                      </option>
+                    ))}
                   </Select>
                 </div>
                 <div className="grid gap-1.5">

--- a/frontend/src/components/pages/itemCascadeOptions.ts
+++ b/frontend/src/components/pages/itemCascadeOptions.ts
@@ -1,0 +1,79 @@
+import type { InventoryItem } from './types'
+
+export type StringOption = {
+  value: string
+  label: string
+}
+
+export type ItemOption = {
+  value: number
+  label: string
+}
+
+export const EMPTY_NAME_LABEL = '未命名'
+export const EMPTY_MODEL_LABEL = '未填型號'
+
+const LOCALE = 'zh-TW'
+const COLLATOR_OPTIONS: Intl.CollatorOptions = { numeric: true, sensitivity: 'base' }
+
+export function encodeSelectValue(value: string): string {
+  return `v:${encodeURIComponent(value)}`
+}
+
+export function decodeSelectValue(value: string): string | null {
+  if (!value || !value.startsWith('v:')) {
+    return null
+  }
+  return decodeURIComponent(value.slice(2))
+}
+
+export function getItemNameValue(item: InventoryItem): string {
+  return item.name ?? ''
+}
+
+export function getItemModelValue(item: InventoryItem): string {
+  return item.model ?? ''
+}
+
+export function getItemSerialLabel(item: InventoryItem): string {
+  return item.n_property_sn || item.property_sn || item.n_item_sn || item.item_sn || `ID ${item.id}`
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right, LOCALE, COLLATOR_OPTIONS)
+}
+
+function displayLabel(value: string, emptyLabel: string): string {
+  return value.trim() ? value : emptyLabel
+}
+
+function uniqueValues(values: string[]): string[] {
+  return Array.from(new Set(values))
+}
+
+export function buildNameOptions(items: InventoryItem[]): StringOption[] {
+  return uniqueValues(items.map((item) => getItemNameValue(item)))
+    .sort((left, right) => compareText(displayLabel(left, EMPTY_NAME_LABEL), displayLabel(right, EMPTY_NAME_LABEL)))
+    .map((value) => ({ value, label: displayLabel(value, EMPTY_NAME_LABEL) }))
+}
+
+export function buildModelOptions(items: InventoryItem[], nameValue: string): StringOption[] {
+  return uniqueValues(
+    items.filter((item) => getItemNameValue(item) === nameValue).map((item) => getItemModelValue(item)),
+  )
+    .sort((left, right) => compareText(displayLabel(left, EMPTY_MODEL_LABEL), displayLabel(right, EMPTY_MODEL_LABEL)))
+    .map((value) => ({ value, label: displayLabel(value, EMPTY_MODEL_LABEL) }))
+}
+
+export function buildItemOptions(items: InventoryItem[], nameValue: string, modelValue: string): ItemOption[] {
+  return items
+    .filter((item) => getItemNameValue(item) === nameValue && getItemModelValue(item) === modelValue)
+    .sort((left, right) => {
+      const serialDiff = compareText(getItemSerialLabel(left), getItemSerialLabel(right))
+      if (serialDiff !== 0) {
+        return serialDiff
+      }
+      return left.id - right.id
+    })
+    .map((item) => ({ value: item.id, label: `${getItemSerialLabel(item)}（ID ${item.id}）` }))
+}


### PR DESCRIPTION
## Summary
- frontend: switch issue/donation item selection to 品名 -> 型號 -> 編號 cascade flow
- backend: sync keeper to requester/borrower on issue creation and borrow pickup (including partial pickup)
- backend: clear keeper on borrow return
- add backend consistency tests for keeper behavior

## Validation
- uv run python -m unittest tests.test_transaction_consistency -q
- uv run python -m unittest tests.test_request_api_guards -q

Closes #22