### PR TITLE
feat: complete restore flow and borrow/inventory form alignment (closes #26)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -54,6 +54,7 @@ uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 - `POST /api/items`
 - `PUT /api/items/{item_id}`
 - `DELETE /api/items/{item_id}`
+- `POST /api/items/{item_id}/restore`
 
 ### 領用
 
@@ -94,6 +95,7 @@ uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 - 捐贈單建立與更新時 `recipient` 必填
 - API 會驗證 item 可用性，避免重複占用
 - 刪除採軟刪除，超過 6 個月自動清除
+- `GET /api/items` 可用 `deleted_scope=active|deleted` 篩選是否查詢已軟刪除資料（預設 `active`）
 
 ## Excel 欄位需求
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -13,7 +13,6 @@ from openpyxl import Workbook, load_workbook
 BASE_DIR = Path(__file__).resolve().parent
 DB_PATH = BASE_DIR / "inventory.xlsx"
 LOCK_PATH = BASE_DIR / "inventory.xlsx.lock"
-ASSET_CATEGORY_NAME_PATH = BASE_DIR.parent / "asset_category_name.xlsx"
 LOG_ARCHIVE_DIR = BASE_DIR / "log_archive"
 HOT_LOG_RETENTION_DAYS = 90
 MAX_BORROW_RESERVATION_DAYS = 30
@@ -25,6 +24,7 @@ SHEETS: dict[str, list[str]] = {
         "id",
         "asset_type",
         "asset_status",
+        "condition_status",
         "key",
         "n_property_sn",
         "property_sn",
@@ -44,8 +44,14 @@ SHEETS: dict[str, list[str]] = {
         "memo",
         "memo2",
         "keeper",
+        "borrower",
+        "start_date",
+        "create_at",
+        "create_by",
         "created_at",
         "created_by",
+        "update_at",
+        "update_by",
         "updated_at",
         "updated_by",
         "deleted_at",
@@ -60,6 +66,28 @@ SHEETS: dict[str, list[str]] = {
         "description",
         "created_at",
         "updated_at",
+    ],
+    "condition_status_code": [
+        "condition_status",
+        "description",
+    ],
+    "asset_category_name": [
+        "name_code",
+        "asset_category_name",
+        "name_code2",
+        "description",
+    ],
+    "inventory_items_schema": [
+        "field",
+        "description",
+    ],
+    "transaction_log": [
+        "timestamp",
+        "key_value",
+        "log_action",
+        "log_content",
+        "user_email",
+        "mode",
     ],
     "operation_logs": [
         "id",
@@ -154,6 +182,7 @@ STRING_FIELDS: dict[str, list[str]] = {
     "inventory_items": [
         "asset_type",
         "asset_status",
+        "condition_status",
         "key",
         "n_property_sn",
         "property_sn",
@@ -173,8 +202,14 @@ STRING_FIELDS: dict[str, list[str]] = {
         "memo",
         "memo2",
         "keeper",
+        "borrower",
+        "start_date",
+        "create_at",
+        "create_by",
         "created_at",
         "created_by",
+        "update_at",
+        "update_by",
         "updated_at",
         "updated_by",
         "deleted_at",
@@ -207,6 +242,10 @@ STRING_FIELDS: dict[str, list[str]] = {
     ],
     "donation_items": ["note"],
     "asset_status_codes": ["code", "description", "created_at", "updated_at"],
+    "condition_status_code": ["condition_status", "description"],
+    "asset_category_name": ["name_code", "asset_category_name", "name_code2", "description"],
+    "inventory_items_schema": ["field", "description"],
+    "transaction_log": ["timestamp", "key_value", "log_action", "log_content", "user_email", "mode"],
     "movement_ledger": ["from_status", "to_status", "action", "entity", "operator", "created_at"],
 }
 
@@ -260,6 +299,54 @@ DEFAULT_ASSET_STATUS_CODES: list[tuple[str, str]] = [
     ("4", "減損"),
     ("5", "報廢"),
 ]
+DEFAULT_CONDITION_STATUS_CODES: list[tuple[str, str]] = [
+    ("0", "良好"),
+    ("1", "損壞"),
+    ("2", "報廢"),
+]
+DEFAULT_ASSET_CATEGORY_ROWS: list[tuple[str, str, str, str]] = [
+    ("01", "筆記型電腦", "01", "商務系列"),
+    ("01", "筆記型電腦", "99", ""),
+    ("02", "桌上型電腦", "01", "一般用途"),
+    ("02", "桌上型電腦", "99", ""),
+]
+INVENTORY_ITEM_SCHEMA_DESCRIPTION_BY_FIELD: dict[str, str] = {
+    "id": "ID",
+    "asset_type": "資產類型",
+    "asset_status": "資產狀態",
+    "condition_status": "物料狀況",
+    "key": "資產編號",
+    "n_property_sn": "財產序號",
+    "property_sn": "財產條碼",
+    "n_item_sn": "物品序號",
+    "item_sn": "物品條碼",
+    "name": "品名",
+    "name_code": "主分類代碼",
+    "name_code2": "次分類代碼",
+    "model": "型號",
+    "specification": "規格描述",
+    "unit": "單位",
+    "count": "數量",
+    "purchase_date": "採購日期",
+    "due_date": "借用到期日",
+    "return_date": "歸還日",
+    "location": "地點",
+    "memo": "備忘錄",
+    "memo2": "備忘錄2",
+    "keeper": "保管人",
+    "borrower": "借用人",
+    "start_date": "起始日期",
+    "create_at": "建立時間",
+    "create_by": "建立人員",
+    "created_at": "建立時間",
+    "created_by": "建立人員",
+    "update_at": "更新時間",
+    "update_by": "更新人員",
+    "updated_at": "更新時間",
+    "updated_by": "更新人員",
+    "deleted_at": "刪除時間",
+    "deleted_by": "刪除人員",
+}
 ASSET_TYPE_TO_KIND = {value: key for key, value in KIND_TO_ASSET_TYPE.items()}
 VALID_NAME_CODE_PAIRS: set[tuple[str, str]] = set()
 ASSET_CATEGORY_MAPPING_LOADED = False
@@ -289,36 +376,33 @@ def _normalize_name_code_value(value: Any) -> str:
 def _normalize_name_codes(name_code: Any, name_code2: Any) -> tuple[str, str]:
     normalized_code = _normalize_name_code_value(name_code)
     normalized_code2 = _normalize_name_code_value(name_code2)
+    if not normalized_code and not normalized_code2:
+        return "", ""
     if not normalized_code or not normalized_code2:
-        return "", ""
+        raise ValueError("name_code and name_code2 must be provided together")
     if not VALID_NAME_CODE_PAIRS:
-        return "", ""
+        raise ValueError("asset_category_name lookup is empty")
     if (normalized_code, normalized_code2) not in VALID_NAME_CODE_PAIRS:
-        return "", ""
+        raise ValueError("invalid name_code/name_code2 pair")
     return normalized_code, normalized_code2
 
 
-def _load_asset_category_mapping() -> None:
+def _normalize_asset_category_text(value: Any) -> str:
+    return _to_str(value).strip()
+
+
+def _refresh_valid_name_code_pairs(wb: Workbook) -> None:
     global ASSET_CATEGORY_MAPPING_LOADED
-    if ASSET_CATEGORY_MAPPING_LOADED:
-        return
 
     pairs: set[tuple[str, str]] = set()
-    if ASSET_CATEGORY_NAME_PATH.exists():
-        try:
-            wb = load_workbook(ASSET_CATEGORY_NAME_PATH, read_only=True, data_only=True)
-            ws = wb["asset_category_name"] if "asset_category_name" in wb.sheetnames else wb.active
-            rows = ws.iter_rows(min_row=2, values_only=True)
-            for row in rows:
-                if not row:
-                    continue
-                name_code = _normalize_name_code_value(row[0] if len(row) > 0 else "")
-                name_code2 = _normalize_name_code_value(row[1] if len(row) > 1 else "")
-                if not name_code or not name_code2:
-                    continue
-                pairs.add((name_code, name_code2))
-        except Exception:  # noqa: BLE001
-            pairs = set()
+    if "asset_category_name" in wb.sheetnames:
+        rows = _read_rows(wb["asset_category_name"])
+        for row in rows:
+            name_code = _normalize_name_code_value(row.get("name_code"))
+            name_code2 = _normalize_name_code_value(row.get("name_code2"))
+            if not name_code or not name_code2:
+                continue
+            pairs.add((name_code, name_code2))
 
     VALID_NAME_CODE_PAIRS.clear()
     VALID_NAME_CODE_PAIRS.update(pairs)
@@ -370,6 +454,7 @@ def _to_inventory_create_row(new_id: int, item_data: dict[str, Any], property_nu
         "id": new_id,
         "asset_type": asset_type,
         "asset_status": _to_str(item_data.get("asset_status")).strip() or "0",
+        "condition_status": _to_str(item_data.get("condition_status")).strip() or "0",
         "key": _inventory_key(row_for_key, serial_for_key),
         "n_property_sn": n_property_sn,
         "property_sn": property_sn,
@@ -389,8 +474,14 @@ def _to_inventory_create_row(new_id: int, item_data: dict[str, Any], property_nu
         "memo": _to_str(item_data.get("memo")),
         "memo2": _to_str(item_data.get("memo2")),
         "keeper": _to_str(item_data.get("keeper")),
+        "borrower": _to_str(item_data.get("borrower")),
+        "start_date": _to_str(item_data.get("start_date")),
+        "create_at": now,
+        "create_by": "system",
         "created_at": now,
         "created_by": "system",
+        "update_at": "",
+        "update_by": "",
         "updated_at": "",
         "updated_by": "",
         "deleted_at": "",
@@ -414,6 +505,7 @@ def _to_inventory_api_row(
         "id": item_id,
         "asset_type": _to_str(row.get("asset_type")),
         "asset_status": _to_str(row.get("asset_status")),
+        "condition_status": _to_str(row.get("condition_status")),
         "key": _to_str(row.get("key")),
         "n_property_sn": _to_str(row.get("n_property_sn")),
         "property_sn": _to_str(row.get("property_sn")),
@@ -433,8 +525,14 @@ def _to_inventory_api_row(
         "memo": _to_str(row.get("memo")),
         "memo2": _to_str(row.get("memo2")),
         "keeper": _to_str(row.get("keeper")),
+        "borrower": _to_str(row.get("borrower")),
+        "start_date": _to_str(row.get("start_date")),
+        "create_at": _to_str(row.get("create_at")),
+        "create_by": _to_str(row.get("create_by")),
         "created_at": _to_str(row.get("created_at")),
         "created_by": _to_str(row.get("created_by")),
+        "update_at": _to_str(row.get("update_at")),
+        "update_by": _to_str(row.get("update_by")),
         "updated_at": _to_str(row.get("updated_at")),
         "updated_by": _to_str(row.get("updated_by")),
         "deleted_at": _to_str(row.get("deleted_at")),
@@ -463,6 +561,9 @@ def _create_workbook() -> Workbook:
 
     _seed_order_sn(wb["order_sn"])
     _seed_asset_status_codes(wb["asset_status_codes"])
+    _seed_condition_status_codes(wb["condition_status_code"])
+    _seed_asset_category_name(wb["asset_category_name"])
+    _seed_inventory_items_schema(wb["inventory_items_schema"])
     return wb
 
 
@@ -489,6 +590,54 @@ def _seed_asset_status_codes(ws) -> bool:
     return added
 
 
+def _seed_condition_status_codes(ws) -> bool:
+    existing_rows = _read_rows(ws)
+    existing_codes = {_to_str(row.get("condition_status")).strip() for row in existing_rows if not _is_blank(row.get("condition_status"))}
+    added = False
+    for code, description in DEFAULT_CONDITION_STATUS_CODES:
+        if code in existing_codes:
+            continue
+        ws.append([code, description])
+        added = True
+    return added
+
+
+def _seed_asset_category_name(ws) -> bool:
+    existing_rows = _read_rows(ws)
+    existing_pairs = {
+        (
+            _normalize_name_code_value(row.get("name_code")),
+            _normalize_name_code_value(row.get("name_code2")),
+        )
+        for row in existing_rows
+    }
+    added = False
+    for name_code, category_name, name_code2, description in DEFAULT_ASSET_CATEGORY_ROWS:
+        normalized_pair = (
+            _normalize_name_code_value(name_code),
+            _normalize_name_code_value(name_code2),
+        )
+        if normalized_pair in existing_pairs:
+            continue
+        ws.append([normalized_pair[0], category_name, normalized_pair[1], description])
+        existing_pairs.add(normalized_pair)
+        added = True
+    return added
+
+
+def _seed_inventory_items_schema(ws) -> bool:
+    existing_rows = _read_rows(ws)
+    existing_fields = {_to_str(row.get("field")).strip() for row in existing_rows if not _is_blank(row.get("field"))}
+    added = False
+    for field in SHEETS["inventory_items"]:
+        if field in existing_fields:
+            continue
+        description = INVENTORY_ITEM_SCHEMA_DESCRIPTION_BY_FIELD.get(field, field)
+        ws.append([field, description])
+        added = True
+    return added
+
+
 def _ensure_sheet(wb: Workbook, sheet_name: str, headers: list[str]) -> bool:
     changed = False
     if sheet_name not in wb.sheetnames:
@@ -499,7 +648,7 @@ def _ensure_sheet(wb: Workbook, sheet_name: str, headers: list[str]) -> bool:
     ws = wb[sheet_name]
     existing_headers = [cell.value for cell in ws[1]] if ws.max_row >= 1 else []
     if existing_headers != headers:
-        rows = _read_rows(ws, existing_headers) if sheet_name != "inventory_items" else []
+        rows = _read_rows(ws, existing_headers)
         ws.delete_rows(1, ws.max_row or 1)
         ws.append(headers)
         for row in rows:
@@ -511,6 +660,15 @@ def _ensure_sheet(wb: Workbook, sheet_name: str, headers: list[str]) -> bool:
             changed = True
     elif sheet_name == "asset_status_codes":
         if _seed_asset_status_codes(ws):
+            changed = True
+    elif sheet_name == "condition_status_code":
+        if _seed_condition_status_codes(ws):
+            changed = True
+    elif sheet_name == "asset_category_name":
+        if _seed_asset_category_name(ws):
+            changed = True
+    elif sheet_name == "inventory_items_schema":
+        if _seed_inventory_items_schema(ws):
             changed = True
 
     return changed
@@ -557,12 +715,14 @@ def _ensure_workbook(wb: Workbook) -> bool:
 def _load_workbook() -> Workbook:
     if not DB_PATH.exists():
         wb = _create_workbook()
+        _refresh_valid_name_code_pairs(wb)
         wb.save(DB_PATH)
         return wb
 
     wb = load_workbook(DB_PATH)
     if _ensure_workbook(wb):
         wb.save(DB_PATH)
+    _refresh_valid_name_code_pairs(wb)
     return wb
 
 
@@ -628,10 +788,10 @@ def _next_id(rows: list[dict[str, Any]]) -> int:
 
 
 def init_db() -> None:
-    _load_asset_category_mapping()
     with _locked_workbook() as wb:
         if _ensure_workbook(wb):
             wb.save(DB_PATH)
+        _refresh_valid_name_code_pairs(wb)
 
 
 def _normalize_asset_status_code(value: Any) -> str:
@@ -647,6 +807,10 @@ def _asset_status_sort_key(code: str) -> tuple[int, int | str]:
     if stripped.isdigit():
         return (0, int(stripped))
     return (1, stripped)
+
+
+def _asset_category_sort_key(name_code: str, name_code2: str) -> tuple[tuple[int, int | str], tuple[int, int | str]]:
+    return (_asset_status_sort_key(name_code), _asset_status_sort_key(name_code2))
 
 
 def list_asset_status_codes() -> list[dict[str, Any]]:
@@ -665,6 +829,183 @@ def list_asset_status_codes() -> list[dict[str, Any]]:
             }
         )
     return sorted(results, key=lambda row: _asset_status_sort_key(row["code"]))
+
+
+def list_asset_categories() -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["asset_category_name"])
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        name_code = _normalize_name_code_value(row.get("name_code"))
+        name_code2 = _normalize_name_code_value(row.get("name_code2"))
+        if not name_code or not name_code2:
+            continue
+        results.append(
+            {
+                "name_code": name_code,
+                "asset_category_name": _normalize_asset_category_text(row.get("asset_category_name")),
+                "name_code2": name_code2,
+                "description": _normalize_asset_category_text(row.get("description")),
+            }
+        )
+    return sorted(results, key=lambda row: _asset_category_sort_key(row["name_code"], row["name_code2"]))
+
+
+def create_asset_category(name_code: str, category_name: str, name_code2: str, description: str) -> dict[str, Any]:
+    normalized_code = _normalize_name_code_value(name_code)
+    normalized_code2 = _normalize_name_code_value(name_code2)
+    normalized_category_name = _normalize_asset_category_text(category_name)
+    normalized_description = _normalize_asset_category_text(description)
+    if not normalized_code:
+        raise ValueError("name_code is required")
+    if not normalized_code2:
+        raise ValueError("name_code2 is required")
+    if not normalized_category_name:
+        raise ValueError("asset_category_name is required")
+
+    with _locked_workbook() as wb:
+        ws = wb["asset_category_name"]
+        rows = _read_rows(ws)
+        for row in rows:
+            existing_code = _normalize_name_code_value(row.get("name_code"))
+            existing_code2 = _normalize_name_code_value(row.get("name_code2"))
+            if (existing_code, existing_code2) == (normalized_code, normalized_code2):
+                raise ValueError("asset_category pair already exists")
+        rows.append(
+            {
+                "name_code": normalized_code,
+                "asset_category_name": normalized_category_name,
+                "name_code2": normalized_code2,
+                "description": normalized_description,
+            }
+        )
+        _write_rows(ws, SHEETS["asset_category_name"], rows)
+        _refresh_valid_name_code_pairs(wb)
+        wb.save(DB_PATH)
+    return {
+        "name_code": normalized_code,
+        "asset_category_name": normalized_category_name,
+        "name_code2": normalized_code2,
+        "description": normalized_description,
+    }
+
+
+def update_asset_category(
+    name_code: str,
+    name_code2: str,
+    next_name_code: str,
+    next_name_code2: str,
+    category_name: str,
+    description: str,
+) -> dict[str, Any]:
+    normalized_code = _normalize_name_code_value(name_code)
+    normalized_code2 = _normalize_name_code_value(name_code2)
+    normalized_next_code = _normalize_name_code_value(next_name_code)
+    normalized_next_code2 = _normalize_name_code_value(next_name_code2)
+    normalized_category_name = _normalize_asset_category_text(category_name)
+    normalized_description = _normalize_asset_category_text(description)
+
+    if not normalized_code:
+        raise ValueError("name_code is required")
+    if not normalized_code2:
+        raise ValueError("name_code2 is required")
+    if not normalized_next_code:
+        raise ValueError("name_code is required")
+    if not normalized_next_code2:
+        raise ValueError("name_code2 is required")
+    if not normalized_category_name:
+        raise ValueError("asset_category_name is required")
+
+    with _locked_workbook() as wb:
+        category_ws = wb["asset_category_name"]
+        inventory_ws = wb["inventory_items"]
+        category_rows = _read_rows(category_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        target_row: dict[str, Any] | None = None
+        for row in category_rows:
+            existing_code = _normalize_name_code_value(row.get("name_code"))
+            existing_code2 = _normalize_name_code_value(row.get("name_code2"))
+            if (existing_code, existing_code2) == (normalized_code, normalized_code2):
+                target_row = row
+                break
+        if target_row is None:
+            raise ValueError("asset_category pair not found")
+
+        if (normalized_next_code, normalized_next_code2) != (normalized_code, normalized_code2):
+            for row in category_rows:
+                existing_code = _normalize_name_code_value(row.get("name_code"))
+                existing_code2 = _normalize_name_code_value(row.get("name_code2"))
+                if (existing_code, existing_code2) == (normalized_next_code, normalized_next_code2):
+                    raise ValueError("asset_category pair already exists")
+
+        target_row["name_code"] = normalized_next_code
+        target_row["name_code2"] = normalized_next_code2
+        target_row["asset_category_name"] = normalized_category_name
+        target_row["description"] = normalized_description
+
+        if (normalized_next_code, normalized_next_code2) != (normalized_code, normalized_code2):
+            for row in inventory_rows:
+                existing_code = _normalize_name_code_value(row.get("name_code"))
+                existing_code2 = _normalize_name_code_value(row.get("name_code2"))
+                if (existing_code, existing_code2) == (normalized_code, normalized_code2):
+                    row["name_code"] = normalized_next_code
+                    row["name_code2"] = normalized_next_code2
+
+        _write_rows(category_ws, SHEETS["asset_category_name"], category_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        _refresh_valid_name_code_pairs(wb)
+        wb.save(DB_PATH)
+
+    return {
+        "name_code": normalized_next_code,
+        "asset_category_name": normalized_category_name,
+        "name_code2": normalized_next_code2,
+        "description": normalized_description,
+    }
+
+
+def delete_asset_category(name_code: str, name_code2: str) -> None:
+    normalized_code = _normalize_name_code_value(name_code)
+    normalized_code2 = _normalize_name_code_value(name_code2)
+    if not normalized_code:
+        raise ValueError("name_code is required")
+    if not normalized_code2:
+        raise ValueError("name_code2 is required")
+
+    with _locked_workbook() as wb:
+        category_ws = wb["asset_category_name"]
+        inventory_ws = wb["inventory_items"]
+        category_rows = _read_rows(category_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        remaining_rows = [
+            row
+            for row in category_rows
+            if (
+                _normalize_name_code_value(row.get("name_code")),
+                _normalize_name_code_value(row.get("name_code2")),
+            )
+            != (normalized_code, normalized_code2)
+        ]
+        if len(remaining_rows) == len(category_rows):
+            raise ValueError("asset_category pair not found")
+
+        in_use = any(
+            _is_blank(row.get("deleted_at"))
+            and (
+                _normalize_name_code_value(row.get("name_code")),
+                _normalize_name_code_value(row.get("name_code2")),
+            )
+            == (normalized_code, normalized_code2)
+            for row in inventory_rows
+        )
+        if in_use:
+            raise ValueError("asset_category pair is in use")
+
+        _write_rows(category_ws, SHEETS["asset_category_name"], remaining_rows)
+        _refresh_valid_name_code_pairs(wb)
+        wb.save(DB_PATH)
 
 
 def create_asset_status_code(code: str, description: str) -> dict[str, Any]:
@@ -1044,6 +1385,7 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
         updated = False
         for row in rows:
             if _to_int(row.get("id")) == item_id and _is_blank(row.get("deleted_at")):
+                now = _now_str()
                 asset_type = _normalize_asset_type_input(item_data.get("asset_type"))
                 n_property_sn = _to_str(item_data.get("n_property_sn")).strip()
                 property_sn = _to_str(item_data.get("property_sn")).strip()
@@ -1053,6 +1395,10 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
                 name_code, name_code2 = _normalize_name_codes(item_data.get("name_code"), item_data.get("name_code2"))
                 count = 1
                 next_key = _to_str(item_data.get("key")).strip()
+                next_condition_status = _to_str(item_data.get("condition_status", row.get("condition_status"))).strip()
+                next_condition_status = next_condition_status or _to_str(row.get("condition_status")).strip() or "0"
+                next_borrower = _to_str(item_data.get("borrower", row.get("borrower")))
+                next_start_date = _to_str(item_data.get("start_date", row.get("start_date")))
                 if not next_key:
                     tmp_row = {
                         "id": row.get("id"),
@@ -1067,6 +1413,7 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
                     {
                         "asset_type": asset_type,
                         "asset_status": _to_str(item_data.get("asset_status")).strip() or "0",
+                        "condition_status": next_condition_status,
                         "key": next_key,
                         "n_property_sn": n_property_sn,
                         "property_sn": property_sn,
@@ -1086,8 +1433,12 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
                         "keeper": _to_str(item_data.get("keeper")),
                         "memo": _to_str(item_data.get("memo")),
                         "memo2": _to_str(item_data.get("memo2")),
-                        "updated_at": _now_str(),
+                        "updated_at": now,
                         "updated_by": "system",
+                        "borrower": next_borrower,
+                        "start_date": next_start_date,
+                        "update_at": now,
+                        "update_by": "system",
                     }
                 )
                 updated = True

--- a/backend/db.py
+++ b/backend/db.py
@@ -2149,7 +2149,7 @@ def _set_issue_keeper_for_create_issue(
     row["keeper"] = normalized_requester
 
 
-def _set_item_keeper_from_actor(
+def _set_item_borrower_from_actor(
     *,
     row: dict[str, Any],
     actor: str,
@@ -2157,14 +2157,14 @@ def _set_item_keeper_from_actor(
     normalized_actor = actor.strip()
     if not normalized_actor:
         return
-    row["keeper"] = normalized_actor
+    row["borrower"] = normalized_actor
 
 
-def _clear_item_keeper(
+def _clear_item_borrower(
     *,
     row: dict[str, Any],
 ) -> None:
-    row["keeper"] = ""
+    row["borrower"] = ""
 
 
 def _validate_item_status(
@@ -3821,7 +3821,7 @@ def pickup_borrow_request(request_id: int, selections_data: list[dict[str, Any]]
                     entity="borrow_request",
                     entity_id=request_id,
                 )
-                _set_item_keeper_from_actor(row=inventory_row, actor=borrower)
+                _set_item_borrower_from_actor(row=inventory_row, actor=borrower)
                 created_allocations.append(
                     {
                         "id": next_allocation_id + len(created_allocations),
@@ -3912,7 +3912,7 @@ def return_borrow_request(request_id: int, *, return_date_value: Any = None) -> 
                 entity="borrow_request",
                 entity_id=request_id,
             )
-            _clear_item_keeper(row=row)
+            _clear_item_borrower(row=row)
 
         normalized_return_date = _parse_request_date(return_date_value) or date.today()
         request_row["return_date"] = normalized_return_date.strftime("%Y/%m/%d")

--- a/backend/db.py
+++ b/backend/db.py
@@ -604,6 +604,8 @@ def _seed_condition_status_codes(ws) -> bool:
 
 def _seed_asset_category_name(ws) -> bool:
     existing_rows = _read_rows(ws)
+    if existing_rows:
+        return False
     existing_pairs = {
         (
             _normalize_name_code_value(row.get("name_code")),

--- a/backend/db.py
+++ b/backend/db.py
@@ -804,6 +804,14 @@ def _normalize_asset_status_description(value: Any) -> str:
     return _to_str(value).strip()
 
 
+def _normalize_condition_status_code(value: Any) -> str:
+    return _to_str(value).strip()
+
+
+def _normalize_condition_status_description(value: Any) -> str:
+    return _to_str(value).strip()
+
+
 def _asset_status_sort_key(code: str) -> tuple[int, int | str]:
     stripped = code.strip()
     if stripped.isdigit():
@@ -822,6 +830,24 @@ def list_asset_status_codes() -> list[dict[str, Any]]:
     for row in rows:
         code = _normalize_asset_status_code(row.get("code"))
         description = _normalize_asset_status_description(row.get("description"))
+        if not code:
+            continue
+        results.append(
+            {
+                "code": code,
+                "description": description,
+            }
+        )
+    return sorted(results, key=lambda row: _asset_status_sort_key(row["code"]))
+
+
+def list_condition_status_codes() -> list[dict[str, Any]]:
+    with _locked_workbook() as wb:
+        rows = _read_rows(wb["condition_status_code"])
+    results = []
+    for row in rows:
+        code = _normalize_condition_status_code(row.get("condition_status"))
+        description = _normalize_condition_status_description(row.get("description"))
         if not code:
             continue
         results.append(
@@ -1115,6 +1141,107 @@ def delete_asset_status_code(code: str) -> bool:
     return True
 
 
+def create_condition_status_code(code: str, description: str) -> dict[str, Any]:
+    normalized_code = _normalize_condition_status_code(code)
+    normalized_description = _normalize_condition_status_description(description)
+    if not normalized_code:
+        raise ValueError("condition_status code is required")
+    if not normalized_description:
+        raise ValueError("condition_status description is required")
+
+    with _locked_workbook() as wb:
+        ws = wb["condition_status_code"]
+        rows = _read_rows(ws)
+        existing_codes = {_normalize_condition_status_code(row.get("condition_status")) for row in rows}
+        if normalized_code in existing_codes:
+            raise ValueError("condition_status code already exists")
+
+        rows.append(
+            {
+                "condition_status": normalized_code,
+                "description": normalized_description,
+            }
+        )
+        _write_rows(ws, SHEETS["condition_status_code"], rows)
+        wb.save(DB_PATH)
+    return {"code": normalized_code, "description": normalized_description}
+
+
+def update_condition_status_code(code: str, next_code: str, description: str) -> dict[str, Any]:
+    normalized_code = _normalize_condition_status_code(code)
+    normalized_next_code = _normalize_condition_status_code(next_code)
+    normalized_description = _normalize_condition_status_description(description)
+    if not normalized_code:
+        raise ValueError("condition_status code is required")
+    if not normalized_next_code:
+        raise ValueError("condition_status code is required")
+    if not normalized_description:
+        raise ValueError("condition_status description is required")
+
+    with _locked_workbook() as wb:
+        code_ws = wb["condition_status_code"]
+        inventory_ws = wb["inventory_items"]
+        code_rows = _read_rows(code_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        target_row: dict[str, Any] | None = None
+        for row in code_rows:
+            if _normalize_condition_status_code(row.get("condition_status")) == normalized_code:
+                target_row = row
+                break
+        if target_row is None:
+            raise ValueError("condition_status code not found")
+
+        if normalized_next_code != normalized_code:
+            for row in code_rows:
+                if _normalize_condition_status_code(row.get("condition_status")) == normalized_next_code:
+                    raise ValueError("condition_status code already exists")
+
+        now = _now_str()
+        target_row["condition_status"] = normalized_next_code
+        target_row["description"] = normalized_description
+
+        if normalized_next_code != normalized_code:
+            for row in inventory_rows:
+                if _is_blank(row.get("deleted_at")) and _normalize_condition_status_code(row.get("condition_status")) == normalized_code:
+                    row["condition_status"] = normalized_next_code
+                    row["updated_at"] = now
+                    row["updated_by"] = "system"
+
+        _write_rows(code_ws, SHEETS["condition_status_code"], code_rows)
+        _write_rows(inventory_ws, SHEETS["inventory_items"], inventory_rows)
+        wb.save(DB_PATH)
+    return {"code": normalized_next_code, "description": normalized_description}
+
+
+def delete_condition_status_code(code: str) -> bool:
+    normalized_code = _normalize_condition_status_code(code)
+    if not normalized_code:
+        raise ValueError("condition_status code is required")
+
+    with _locked_workbook() as wb:
+        code_ws = wb["condition_status_code"]
+        inventory_ws = wb["inventory_items"]
+        code_rows = _read_rows(code_ws)
+        inventory_rows = _read_rows(inventory_ws)
+
+        remaining_rows = [row for row in code_rows if _normalize_condition_status_code(row.get("condition_status")) != normalized_code]
+        deleted = len(remaining_rows) != len(code_rows)
+        if not deleted:
+            raise ValueError("condition_status code not found")
+
+        is_in_use = any(
+            _is_blank(row.get("deleted_at")) and _normalize_condition_status_code(row.get("condition_status")) == normalized_code
+            for row in inventory_rows
+        )
+        if is_in_use:
+            raise ValueError("condition_status code is in use")
+
+        _write_rows(code_ws, SHEETS["condition_status_code"], remaining_rows)
+        wb.save(DB_PATH)
+    return True
+
+
 def get_items_count() -> int:
     with _locked_workbook() as wb:
         rows = _read_rows(wb["inventory_items"])
@@ -1282,7 +1409,11 @@ def get_dashboard_snapshot() -> dict[str, Any]:
     }
 
 
-def list_items(*, include_donated: bool = False) -> list[dict[str, Any]]:
+def list_items(*, include_donated: bool = False, deleted_scope: str = "active") -> list[dict[str, Any]]:
+    normalized_deleted_scope = _to_str(deleted_scope).strip().lower() or "active"
+    if normalized_deleted_scope not in {"active", "deleted"}:
+        raise ValueError("invalid deleted_scope")
+
     with _locked_workbook() as wb:
         rows = _read_rows(wb["inventory_items"])
         donation_rows = _read_rows(wb["donation_items"])
@@ -1291,7 +1422,10 @@ def list_items(*, include_donated: bool = False) -> list[dict[str, Any]]:
     donation_map = _donation_map(donation_rows, donation_request_rows)
     results = []
     for row in rows:
-        if not _is_blank(row.get("deleted_at")):
+        is_deleted = not _is_blank(row.get("deleted_at"))
+        if normalized_deleted_scope == "active" and is_deleted:
+            continue
+        if normalized_deleted_scope == "deleted" and not is_deleted:
             continue
         donation_info = donation_map.get(_to_int(row.get("id")))
         if not include_donated and _is_item_donated(row, donation_info=donation_info):
@@ -1466,6 +1600,31 @@ def delete_item(item_id: int) -> bool:
             _write_rows(ws, SHEETS["inventory_items"], rows)
             wb.save(DB_PATH)
         return deleted
+
+
+def restore_item(item_id: int) -> dict[str, str] | None:
+    with _locked_workbook() as wb:
+        ws = wb["inventory_items"]
+        rows = _read_rows(ws)
+        restored_meta: dict[str, str] | None = None
+        for row in rows:
+            if _to_int(row.get("id")) != item_id:
+                continue
+            deleted_at = _to_str(row.get("deleted_at")).strip()
+            deleted_by = _to_str(row.get("deleted_by")).strip()
+            if not deleted_at:
+                return None
+            row["deleted_at"] = ""
+            row["deleted_by"] = ""
+            restored_meta = {
+                "deleted_at": deleted_at,
+                "deleted_by": deleted_by,
+            }
+            break
+        if restored_meta is not None:
+            _write_rows(ws, SHEETS["inventory_items"], rows)
+            wb.save(DB_PATH)
+        return restored_meta
 
 
 def purge_soft_deleted_items() -> int:

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,12 +11,14 @@ from pydantic import BaseModel, Field
 
 from db import (
     archive_old_logs,
+    create_asset_category,
     create_asset_status_code,
     create_item,
     create_items_bulk,
     create_issue_request,
     create_borrow_request,
     create_donation_request,
+    delete_asset_category,
     delete_asset_status_code,
     delete_item,
     delete_issue_request,
@@ -28,6 +30,7 @@ from db import (
     get_donation_request,
     get_dashboard_snapshot,
     init_db,
+    list_asset_categories,
     list_asset_status_codes,
     list_issue_items,
     list_issue_items_map,
@@ -51,6 +54,7 @@ from db import (
     resolve_borrow_pickup_scan,
     return_borrow_request,
     update_asset_status_code,
+    update_asset_category,
     update_item,
     update_issue_request,
     update_borrow_request,
@@ -80,6 +84,7 @@ app.add_middleware(
 class InventoryItemCreate(BaseModel):
     asset_type: str = ""
     asset_status: str = ""
+    condition_status: str = ""
     key: str = ""
     n_property_sn: str = ""
     property_sn: str = ""
@@ -99,12 +104,18 @@ class InventoryItemCreate(BaseModel):
     memo: str = ""
     memo2: str = ""
     keeper: str = ""
+    borrower: str = ""
+    start_date: date | None = None
 
 
 class InventoryItem(InventoryItemCreate):
     id: int
+    create_at: datetime | None = None
+    create_by: str = ""
     created_at: datetime | None = None
     created_by: str = ""
+    update_at: datetime | None = None
+    update_by: str = ""
     updated_at: datetime | None = None
     updated_by: str = ""
     deleted_at: datetime | None = None
@@ -125,6 +136,27 @@ class AssetStatusCodeCreate(BaseModel):
 
 class AssetStatusCodeUpdate(BaseModel):
     code: str = ""
+    description: str = ""
+
+
+class AssetCategoryLookup(BaseModel):
+    name_code: str
+    asset_category_name: str
+    name_code2: str
+    description: str
+
+
+class AssetCategoryLookupCreate(BaseModel):
+    name_code: str = ""
+    asset_category_name: str = ""
+    name_code2: str = ""
+    description: str = ""
+
+
+class AssetCategoryLookupUpdate(BaseModel):
+    name_code: str = ""
+    name_code2: str = ""
+    asset_category_name: str = ""
     description: str = ""
 
 
@@ -384,6 +416,10 @@ def _parse_purchase_date(value: str) -> date:
 def _parse_datetime(value: str) -> datetime | None:
     if not value:
         return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
 
 
 def _parse_datetime_filter_value(value: str, *, field_name: str, is_end: bool = False) -> datetime | None:
@@ -411,10 +447,6 @@ def _parse_datetime_range_filters(start_at: str, end_at: str) -> tuple[datetime 
     if start_time and end_time and start_time > end_time:
         raise HTTPException(status_code=400, detail="start_at must be earlier than or equal to end_at")
     return start_time, end_time
-    try:
-        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-    except ValueError:
-        return None
 
 
 def _resolve_frontend_index() -> Path | None:
@@ -445,6 +477,7 @@ def to_db_payload(item: InventoryItemCreate) -> dict:
     return {
         "asset_type": item.asset_type,
         "asset_status": item.asset_status,
+        "condition_status": item.condition_status,
         "key": item.key,
         "n_property_sn": item.n_property_sn,
         "property_sn": item.property_sn,
@@ -464,6 +497,8 @@ def to_db_payload(item: InventoryItemCreate) -> dict:
         "memo": item.memo,
         "memo2": item.memo2,
         "keeper": item.keeper,
+        "borrower": item.borrower,
+        "start_date": _format_date(item.start_date),
     }
 
 
@@ -583,6 +618,7 @@ def row_to_item(row) -> InventoryItem:
         id=row["id"],
         asset_type=_coerce_str(row.get("asset_type")),
         asset_status=_coerce_str(row.get("asset_status")),
+        condition_status=_coerce_str(row.get("condition_status")),
         key=_coerce_str(row.get("key")),
         n_property_sn=_coerce_str(row.get("n_property_sn")),
         property_sn=_coerce_str(row.get("property_sn")),
@@ -602,8 +638,14 @@ def row_to_item(row) -> InventoryItem:
         memo=_coerce_str(row.get("memo")),
         memo2=_coerce_str(row.get("memo2")),
         keeper=_coerce_str(row.get("keeper")),
+        borrower=_coerce_str(row.get("borrower")),
+        start_date=_parse_purchase_date(_coerce_str(row.get("start_date"))) if _coerce_str(row.get("start_date")) else None,
+        create_at=_parse_datetime(_coerce_str(row.get("create_at"))),
+        create_by=_coerce_str(row.get("create_by")),
         created_at=_parse_datetime(_coerce_str(row.get("created_at"))),
         created_by=_coerce_str(row.get("created_by")),
+        update_at=_parse_datetime(_coerce_str(row.get("update_at"))),
+        update_by=_coerce_str(row.get("update_by")),
         updated_at=_parse_datetime(_coerce_str(row.get("updated_at"))),
         updated_by=_coerce_str(row.get("updated_by")),
         deleted_at=_parse_datetime(_coerce_str(row.get("deleted_at"))),
@@ -852,6 +894,73 @@ def delete_asset_status_code_api(code: str):
     return {"success": True}
 
 
+@app.get("/api/lookups/asset-category", response_model=list[AssetCategoryLookup], response_model_by_alias=False)
+def list_asset_categories_api():
+    rows = list_asset_categories()
+    return [AssetCategoryLookup(**row) for row in rows]
+
+
+@app.post("/api/lookups/asset-category", response_model=AssetCategoryLookup, response_model_by_alias=False)
+def create_asset_category_api(payload: AssetCategoryLookupCreate):
+    try:
+        row = create_asset_category(
+            payload.name_code,
+            payload.asset_category_name,
+            payload.name_code2,
+            payload.description,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 409 if "already exists" in message else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
+
+    log_inventory_action(action="create", entity="asset_category_name", detail=row)
+    return AssetCategoryLookup(**row)
+
+
+@app.put("/api/lookups/asset-category/{name_code}/{name_code2}", response_model=AssetCategoryLookup, response_model_by_alias=False)
+def update_asset_category_api(name_code: str, name_code2: str, payload: AssetCategoryLookupUpdate):
+    try:
+        row = update_asset_category(
+            name_code,
+            name_code2,
+            payload.name_code or name_code,
+            payload.name_code2 or name_code2,
+            payload.asset_category_name,
+            payload.description,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        if "not found" in message:
+            raise HTTPException(status_code=404, detail=message) from exc
+        if "already exists" in message:
+            raise HTTPException(status_code=409, detail=message) from exc
+        raise HTTPException(status_code=400, detail=message) from exc
+
+    log_inventory_action(
+        action="update",
+        entity="asset_category_name",
+        detail={"from_name_code": name_code, "from_name_code2": name_code2, **row},
+    )
+    return AssetCategoryLookup(**row)
+
+
+@app.delete("/api/lookups/asset-category/{name_code}/{name_code2}")
+def delete_asset_category_api(name_code: str, name_code2: str):
+    try:
+        delete_asset_category(name_code, name_code2)
+    except ValueError as exc:
+        message = str(exc)
+        if "not found" in message:
+            raise HTTPException(status_code=404, detail=message) from exc
+        if "in use" in message:
+            raise HTTPException(status_code=409, detail=message) from exc
+        raise HTTPException(status_code=400, detail=message) from exc
+
+    log_inventory_action(action="delete", entity="asset_category_name", detail={"name_code": name_code, "name_code2": name_code2})
+    return {"success": True}
+
+
 @app.get("/api/lookups/borrow-reservations", response_model=list[BorrowReservationOption], response_model_by_alias=False)
 def list_borrow_reservation_options_api(request_id: int | None = None):
     rows = list_borrow_reservation_options(exclude_request_id=request_id)
@@ -936,7 +1045,10 @@ def get_inventory_item_api(item_id: int):
 @app.post("/api/items", response_model=InventoryItem, response_model_by_alias=False)
 def create_inventory_item_api(item: InventoryItemCreate):
     item_data = to_db_payload(item)
-    item_id = create_item(item_data)
+    try:
+        item_id = create_item(item_data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     row = get_item_by_id(item_id)
     if row is None:
         log_inventory_action(
@@ -955,7 +1067,10 @@ def create_inventory_item_api(item: InventoryItemCreate):
 @app.put("/api/items/{item_id}", response_model=InventoryItem, response_model_by_alias=False)
 def update_inventory_item_api(item_id: int, item: InventoryItemCreate):
     item_data = to_db_payload(item)
-    updated = update_item(item_id, item_data)
+    try:
+        updated = update_item(item_id, item_data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not updated:
         log_inventory_action(
             action="update",

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from db import (
     archive_old_logs,
     create_asset_category,
+    create_condition_status_code,
     create_asset_status_code,
     create_item,
     create_items_bulk,
@@ -19,6 +20,7 @@ from db import (
     create_borrow_request,
     create_donation_request,
     delete_asset_category,
+    delete_condition_status_code,
     delete_asset_status_code,
     delete_item,
     delete_issue_request,
@@ -31,6 +33,7 @@ from db import (
     get_dashboard_snapshot,
     init_db,
     list_asset_categories,
+    list_condition_status_codes,
     list_asset_status_codes,
     list_issue_items,
     list_issue_items_map,
@@ -51,9 +54,11 @@ from db import (
     log_inventory_action,
     pickup_borrow_request,
     purge_soft_deleted_items,
+    restore_item,
     resolve_borrow_pickup_scan,
     return_borrow_request,
     update_asset_status_code,
+    update_condition_status_code,
     update_asset_category,
     update_item,
     update_issue_request,
@@ -135,6 +140,21 @@ class AssetStatusCodeCreate(BaseModel):
 
 
 class AssetStatusCodeUpdate(BaseModel):
+    code: str = ""
+    description: str = ""
+
+
+class ConditionStatusCode(BaseModel):
+    code: str
+    description: str
+
+
+class ConditionStatusCodeCreate(BaseModel):
+    code: str = ""
+    description: str = ""
+
+
+class ConditionStatusCodeUpdate(BaseModel):
     code: str = ""
     description: str = ""
 
@@ -894,6 +914,57 @@ def delete_asset_status_code_api(code: str):
     return {"success": True}
 
 
+@app.get("/api/lookups/condition-status", response_model=list[ConditionStatusCode], response_model_by_alias=False)
+def list_condition_status_codes_api():
+    rows = list_condition_status_codes()
+    return [ConditionStatusCode(code=_coerce_str(row.get("code")), description=_coerce_str(row.get("description"))) for row in rows]
+
+
+@app.post("/api/lookups/condition-status", response_model=ConditionStatusCode, response_model_by_alias=False)
+def create_condition_status_code_api(payload: ConditionStatusCodeCreate):
+    try:
+        row = create_condition_status_code(payload.code, payload.description)
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 409 if "already exists" in message else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
+
+    log_inventory_action(action="create", entity="condition_status_code", detail=row)
+    return ConditionStatusCode(code=_coerce_str(row.get("code")), description=_coerce_str(row.get("description")))
+
+
+@app.put("/api/lookups/condition-status/{code}", response_model=ConditionStatusCode, response_model_by_alias=False)
+def update_condition_status_code_api(code: str, payload: ConditionStatusCodeUpdate):
+    try:
+        row = update_condition_status_code(code, payload.code or code, payload.description)
+    except ValueError as exc:
+        message = str(exc)
+        if "not found" in message:
+            raise HTTPException(status_code=404, detail=message) from exc
+        if "already exists" in message:
+            raise HTTPException(status_code=409, detail=message) from exc
+        raise HTTPException(status_code=400, detail=message) from exc
+
+    log_inventory_action(action="update", entity="condition_status_code", detail={"from_code": code, **row})
+    return ConditionStatusCode(code=_coerce_str(row.get("code")), description=_coerce_str(row.get("description")))
+
+
+@app.delete("/api/lookups/condition-status/{code}")
+def delete_condition_status_code_api(code: str):
+    try:
+        delete_condition_status_code(code)
+    except ValueError as exc:
+        message = str(exc)
+        if "not found" in message:
+            raise HTTPException(status_code=404, detail=message) from exc
+        if "in use" in message:
+            raise HTTPException(status_code=409, detail=message) from exc
+        raise HTTPException(status_code=400, detail=message) from exc
+
+    log_inventory_action(action="delete", entity="condition_status_code", detail={"code": code})
+    return {"success": True}
+
+
 @app.get("/api/lookups/asset-category", response_model=list[AssetCategoryLookup], response_model_by_alias=False)
 def list_asset_categories_api():
     rows = list_asset_categories()
@@ -970,6 +1041,7 @@ def list_borrow_reservation_options_api(request_id: int | None = None):
 @app.get("/api/items", response_model=InventoryItemListResponse, response_model_by_alias=False)
 def get_inventory_items(
     include_donated: bool = False,
+    deleted_scope: str = "active",
     keyword: str = "",
     asset_type: str = "all",
     correction_status: str = "all",
@@ -980,7 +1052,10 @@ def get_inventory_items(
 ):
     page, page_size = _normalize_pagination(page, page_size)
     normalized_sort_dir = _normalize_sort_direction(sort_dir)
-    rows = [row_to_item(row) for row in list_items(include_donated=include_donated)]
+    try:
+        rows = [row_to_item(row) for row in list_items(include_donated=include_donated, deleted_scope=deleted_scope)]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     normalized_keyword = keyword.strip().lower()
     filtered_rows: list[InventoryItem] = []
@@ -1116,6 +1191,32 @@ def delete_inventory_item_api(item_id: int):
         raise HTTPException(status_code=404, detail="Item not found")
 
     log_inventory_action(action="soft_delete", entity="inventory_item", entity_id=item_id)
+    return {"success": True}
+
+
+@app.post("/api/items/{item_id}/restore")
+def restore_inventory_item_api(item_id: int):
+    restored_meta = restore_item(item_id)
+    if restored_meta is None:
+        log_inventory_action(
+            action="restore",
+            entity="inventory_item",
+            entity_id=item_id,
+            status="failed",
+            detail={"reason": "Item not found"},
+        )
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    log_inventory_action(
+        action="restore",
+        entity="inventory_item",
+        entity_id=item_id,
+        detail={
+            "deleted_at": restored_meta.get("deleted_at", ""),
+            "deleted_by": restored_meta.get("deleted_by", ""),
+            "restored_by": "system",
+        },
+    )
     return {"success": True}
 
 

--- a/backend/tests/test_asset_category_lookup_api.py
+++ b/backend/tests/test_asset_category_lookup_api.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+
+import db
+import main as app_main
+
+
+class AssetCategoryLookupApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
+        self._tmpdir.cleanup()
+
+    def test_asset_category_lookup_crud(self) -> None:
+        created = app_main.create_asset_category_api(
+            app_main.AssetCategoryLookupCreate(
+                name_code="3",
+                asset_category_name="螢幕",
+                name_code2="1",
+                description="27吋以上",
+            )
+        )
+        self.assertEqual(created.name_code, "03")
+        self.assertEqual(created.name_code2, "01")
+
+        rows = app_main.list_asset_categories_api()
+        self.assertTrue(any(row.name_code == "03" and row.name_code2 == "01" for row in rows))
+
+        updated = app_main.update_asset_category_api(
+            "03",
+            "01",
+            app_main.AssetCategoryLookupUpdate(
+                name_code="03",
+                name_code2="02",
+                asset_category_name="螢幕",
+                description="24吋以下",
+            ),
+        )
+        self.assertEqual(updated.name_code2, "02")
+        self.assertEqual(updated.description, "24吋以下")
+
+        deleted = app_main.delete_asset_category_api("03", "02")
+        self.assertEqual(deleted, {"success": True})
+
+    def test_asset_category_rejects_duplicate_pair(self) -> None:
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_asset_category_api(
+                app_main.AssetCategoryLookupCreate(
+                    name_code="01",
+                    asset_category_name="筆記型電腦",
+                    name_code2="01",
+                    description="重複",
+                )
+            )
+        self.assertEqual(exc.exception.status_code, 409)
+
+    def test_delete_asset_category_rejects_when_in_use(self) -> None:
+        app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="0",
+                name="測試品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                borrower="",
+                count=1,
+            )
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.delete_asset_category_api("01", "01")
+        self.assertEqual(exc.exception.status_code, 409)
+
+    def test_item_api_rejects_invalid_name_code_pair(self) -> None:
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_inventory_item_api(
+                app_main.InventoryItemCreate(
+                    asset_type="A1",
+                    asset_status="0",
+                    condition_status="0",
+                    name="測試品項",
+                    model="M1",
+                    name_code="99",
+                    name_code2="99",
+                    borrower="",
+                    count=1,
+                )
+            )
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertIn("invalid name_code/name_code2 pair", str(exc.exception.detail))
+
+    def test_item_response_contains_new_fields(self) -> None:
+        created = app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="1",
+                name="測試品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                borrower="借用人A",
+                start_date="2026-04-22",
+                count=1,
+            )
+        )
+        self.assertEqual(created.condition_status, "1")
+        self.assertEqual(created.borrower, "借用人A")
+        self.assertIsNotNone(created.start_date)
+        self.assertIsNotNone(created.create_at)
+        self.assertIsNotNone(created.created_at)
+        self.assertEqual(created.create_by, "system")
+        self.assertEqual(created.created_by, "system")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_condition_status_lookup_api.py
+++ b/backend/tests/test_condition_status_lookup_api.py
@@ -1,0 +1,105 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+
+import db
+import main as app_main
+
+
+class ConditionStatusLookupApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
+        self._tmpdir.cleanup()
+
+    def test_condition_status_lookup_crud(self) -> None:
+        created = app_main.create_condition_status_code_api(
+            app_main.ConditionStatusCodeCreate(
+                code="8",
+                description="待維修",
+            )
+        )
+        self.assertEqual(created.code, "8")
+        self.assertEqual(created.description, "待維修")
+
+        rows = app_main.list_condition_status_codes_api()
+        self.assertTrue(any(row.code == "8" for row in rows))
+
+        updated = app_main.update_condition_status_code_api(
+            "8",
+            app_main.ConditionStatusCodeUpdate(
+                code="9",
+                description="已報廢",
+            ),
+        )
+        self.assertEqual(updated.code, "9")
+        self.assertEqual(updated.description, "已報廢")
+
+        deleted = app_main.delete_condition_status_code_api("9")
+        self.assertEqual(deleted, {"success": True})
+
+    def test_condition_status_rejects_duplicate_code(self) -> None:
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_condition_status_code_api(
+                app_main.ConditionStatusCodeCreate(
+                    code="0",
+                    description="重複",
+                )
+            )
+        self.assertEqual(exc.exception.status_code, 409)
+
+    def test_update_condition_status_code_syncs_inventory_items(self) -> None:
+        created = app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="1",
+                name="測試品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                count=1,
+            )
+        )
+
+        app_main.update_condition_status_code_api(
+            "1",
+            app_main.ConditionStatusCodeUpdate(code="9", description="測試改碼"),
+        )
+        fetched = app_main.get_inventory_item_api(created.id)
+        self.assertEqual(fetched.condition_status, "9")
+
+    def test_delete_condition_status_rejects_when_in_use(self) -> None:
+        app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="1",
+                name="測試品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                count=1,
+            )
+        )
+        with self.assertRaises(HTTPException) as exc:
+            app_main.delete_condition_status_code_api("1")
+        self.assertEqual(exc.exception.status_code, 409)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_restore_item_api.py
+++ b/backend/tests/test_restore_item_api.py
@@ -1,0 +1,96 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+
+import db
+import main as app_main
+
+
+class RestoreItemApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
+        self._tmpdir.cleanup()
+
+    def _create_item(self, name: str = "Restore Test Item") -> int:
+        created = app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="0",
+                name=name,
+                model="M1",
+                count=1,
+            )
+        )
+        return created.id
+
+    def test_restore_item_success_and_deleted_scope_filters(self) -> None:
+        item_id = self._create_item()
+
+        app_main.delete_inventory_item_api(item_id)
+
+        active_rows_before_restore = app_main.get_inventory_items(deleted_scope="active", page=1, page_size=100).items
+        deleted_rows_before_restore = app_main.get_inventory_items(deleted_scope="deleted", page=1, page_size=100).items
+        self.assertFalse(any(row.id == item_id for row in active_rows_before_restore))
+        self.assertTrue(any(row.id == item_id for row in deleted_rows_before_restore))
+
+        restore_response = app_main.restore_inventory_item_api(item_id)
+        self.assertEqual(restore_response, {"success": True})
+
+        active_rows_after_restore = app_main.get_inventory_items(deleted_scope="active", page=1, page_size=100).items
+        deleted_rows_after_restore = app_main.get_inventory_items(deleted_scope="deleted", page=1, page_size=100).items
+        self.assertTrue(any(row.id == item_id for row in active_rows_after_restore))
+        self.assertFalse(any(row.id == item_id for row in deleted_rows_after_restore))
+
+    def test_restore_missing_or_not_deleted_item_returns_404(self) -> None:
+        item_id = self._create_item(name="Not Deleted Item")
+
+        with self.assertRaises(HTTPException) as not_deleted_exc:
+            app_main.restore_inventory_item_api(item_id)
+        self.assertEqual(not_deleted_exc.exception.status_code, 404)
+
+        with self.assertRaises(HTTPException) as missing_exc:
+            app_main.restore_inventory_item_api(999999)
+        self.assertEqual(missing_exc.exception.status_code, 404)
+
+    def test_restore_logs_include_deleted_metadata(self) -> None:
+        item_id = self._create_item(name="Log Restore Item")
+        app_main.delete_inventory_item_api(item_id)
+
+        restore_response = app_main.restore_inventory_item_api(item_id)
+        self.assertEqual(restore_response, {"success": True})
+
+        logs = db.list_operation_logs(action="restore", entity="inventory_item", entity_id=item_id)
+        self.assertGreaterEqual(len(logs), 1)
+        latest = logs[0]
+        detail = latest.get("detail", {})
+
+        self.assertEqual(str(latest.get("status")), "success")
+        self.assertIn("deleted_at", detail)
+        self.assertIn("deleted_by", detail)
+        self.assertEqual(str(detail.get("restored_by")), "system")
+
+    def test_invalid_deleted_scope_returns_400(self) -> None:
+        self._create_item(name="Scope Test Item")
+        with self.assertRaises(HTTPException) as exc:
+            app_main.get_inventory_items(deleted_scope="invalid", page=1, page_size=10)
+        self.assertEqual(exc.exception.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_schema_alignment.py
+++ b/backend/tests/test_schema_alignment.py
@@ -1,0 +1,163 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+
+import db
+
+
+OLD_INVENTORY_HEADERS = [
+    "id",
+    "asset_type",
+    "asset_status",
+    "key",
+    "n_property_sn",
+    "property_sn",
+    "n_item_sn",
+    "item_sn",
+    "name",
+    "name_code",
+    "name_code2",
+    "model",
+    "specification",
+    "unit",
+    "count",
+    "purchase_date",
+    "due_date",
+    "return_date",
+    "location",
+    "memo",
+    "memo2",
+    "keeper",
+    "created_at",
+    "created_by",
+    "updated_at",
+    "updated_by",
+    "deleted_at",
+    "deleted_by",
+]
+
+
+class SchemaAlignmentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
+        self._original_asset_category_mapping_loaded = db.ASSET_CATEGORY_MAPPING_LOADED
+        self._original_valid_name_code_pairs = set(db.VALID_NAME_CODE_PAIRS)
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.ASSET_CATEGORY_MAPPING_LOADED = True
+        db.VALID_NAME_CODE_PAIRS.clear()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
+        db.ASSET_CATEGORY_MAPPING_LOADED = self._original_asset_category_mapping_loaded
+        db.VALID_NAME_CODE_PAIRS.clear()
+        db.VALID_NAME_CODE_PAIRS.update(self._original_valid_name_code_pairs)
+        self._tmpdir.cleanup()
+
+    def _write_old_inventory_workbook(self) -> None:
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "inventory_items"
+        ws.append(OLD_INVENTORY_HEADERS)
+        ws.append(
+            [
+                1,
+                "A1",
+                "0",
+                "tmp-20260422-0001",
+                "",
+                "",
+                "ABC123",
+                "",
+                "測試品項",
+                "",
+                "",
+                "M1",
+                "規格",
+                "個",
+                "1",
+                "2026/04/22",
+                "",
+                "",
+                "A倉",
+                "",
+                "",
+                "管理員",
+                "2026-04-22 10:00:00",
+                "system",
+                "",
+                "",
+                "",
+                "",
+            ]
+        )
+        wb.save(db.DB_PATH)
+
+    def test_init_db_migrates_inventory_headers_without_data_loss(self) -> None:
+        self._write_old_inventory_workbook()
+
+        db.init_db()
+
+        wb = load_workbook(db.DB_PATH)
+        ws = wb["inventory_items"]
+        headers = [cell.value for cell in ws[1]]
+        row = list(next(ws.iter_rows(min_row=2, max_row=2, values_only=True)))
+        row_map = {headers[idx]: row[idx] for idx in range(len(headers))}
+
+        self.assertEqual(headers, db.SHEETS["inventory_items"])
+        self.assertEqual(row_map["id"], 1)
+        self.assertEqual(row_map["name"], "測試品項")
+        self.assertEqual(row_map["asset_status"], "0")
+        self.assertEqual(row_map["keeper"], "管理員")
+        self.assertIn(row_map["condition_status"], ("", None))
+        self.assertIn(row_map["borrower"], ("", None))
+        self.assertIn(row_map["start_date"], ("", None))
+        self.assertIn(row_map["create_at"], ("", None))
+        self.assertIn(row_map["update_at"], ("", None))
+
+    def test_init_db_creates_pos_alignment_sheets_and_seeds(self) -> None:
+        self._write_old_inventory_workbook()
+
+        db.init_db()
+
+        wb = load_workbook(db.DB_PATH)
+        self.assertIn("condition_status_code", wb.sheetnames)
+        self.assertIn("asset_category_name", wb.sheetnames)
+        self.assertIn("inventory_items_schema", wb.sheetnames)
+        self.assertIn("transaction_log", wb.sheetnames)
+
+        condition_rows = db._read_rows(wb["condition_status_code"])  # noqa: SLF001
+        self.assertEqual(
+            {(str(row["condition_status"]), str(row["description"])) for row in condition_rows},
+            {("0", "良好"), ("1", "損壞"), ("2", "報廢")},
+        )
+
+        schema_rows = db._read_rows(wb["inventory_items_schema"])  # noqa: SLF001
+        schema_fields = {str(row["field"]) for row in schema_rows}
+        self.assertIn("condition_status", schema_fields)
+        self.assertIn("borrower", schema_fields)
+        self.assertIn("create_at", schema_fields)
+
+        category_rows = db._read_rows(wb["asset_category_name"])  # noqa: SLF001
+        category_pairs = {
+            (str(row["name_code"]), str(row["name_code2"]))
+            for row in category_rows
+            if row.get("name_code") and row.get("name_code2")
+        }
+        self.assertIn(("01", "01"), category_pairs)
+
+        transaction_headers = [cell.value for cell in wb["transaction_log"][1]]
+        self.assertEqual(transaction_headers, db.SHEETS["transaction_log"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_transaction_consistency.py
+++ b/backend/tests/test_transaction_consistency.py
@@ -161,7 +161,7 @@ class TransactionConsistencyTests(unittest.TestCase):
         self.assertEqual(item_after_create['asset_status'], '1')
         self.assertEqual(item_after_create['keeper'], '新領用人')
 
-    def test_borrow_reservation_pickup_return_flow_updates_status_only(self) -> None:
+    def test_borrow_reservation_pickup_return_flow_updates_borrower_only(self) -> None:
         first_id = db.create_item(
             {
                 'asset_type': 'A1',
@@ -205,18 +205,22 @@ class TransactionConsistencyTests(unittest.TestCase):
         item_after_pickup_2 = db.get_item_by_id(second_id)
         self.assertEqual(item_after_pickup_1['asset_status'], '2')
         self.assertEqual(item_after_pickup_2['asset_status'], '2')
-        self.assertEqual(item_after_pickup_1['keeper'], '借用人A')
-        self.assertEqual(item_after_pickup_2['keeper'], '借用人A')
+        self.assertEqual(item_after_pickup_1['keeper'], '原保管人A')
+        self.assertEqual(item_after_pickup_2['keeper'], '原保管人B')
+        self.assertEqual(item_after_pickup_1['borrower'], '借用人A')
+        self.assertEqual(item_after_pickup_2['borrower'], '借用人A')
 
         db.return_borrow_request(request_id)
         item_after_return_1 = db.get_item_by_id(first_id)
         item_after_return_2 = db.get_item_by_id(second_id)
         self.assertEqual(item_after_return_1['asset_status'], '0')
         self.assertEqual(item_after_return_2['asset_status'], '0')
-        self.assertEqual(item_after_return_1['keeper'], '')
-        self.assertEqual(item_after_return_2['keeper'], '')
+        self.assertEqual(item_after_return_1['keeper'], '原保管人A')
+        self.assertEqual(item_after_return_2['keeper'], '原保管人B')
+        self.assertEqual(item_after_return_1['borrower'], '')
+        self.assertEqual(item_after_return_2['borrower'], '')
 
-    def test_partial_pickup_updates_keeper_only_for_picked_items(self) -> None:
+    def test_partial_pickup_updates_borrower_only_for_picked_items(self) -> None:
         first_id = db.create_item(
             {
                 'asset_type': 'A1',
@@ -225,6 +229,7 @@ class TransactionConsistencyTests(unittest.TestCase):
                 'model': 'C1',
                 'count': 1,
                 'keeper': '原保管人A',
+                'borrower': '原借用人A',
             }
         )
         second_id = db.create_item(
@@ -235,6 +240,7 @@ class TransactionConsistencyTests(unittest.TestCase):
                 'model': 'C1',
                 'count': 1,
                 'keeper': '原保管人B',
+                'borrower': '原借用人B',
             }
         )
 
@@ -257,9 +263,11 @@ class TransactionConsistencyTests(unittest.TestCase):
         self.assertIsNotNone(picked_item)
         self.assertIsNotNone(unpicked_item)
         self.assertEqual(picked_item['asset_status'], '2')
-        self.assertEqual(picked_item['keeper'], '借用人B')
+        self.assertEqual(picked_item['keeper'], '原保管人A')
+        self.assertEqual(picked_item['borrower'], '借用人B')
         self.assertEqual(unpicked_item['asset_status'], '0')
         self.assertEqual(unpicked_item['keeper'], '原保管人B')
+        self.assertEqual(unpicked_item['borrower'], '原借用人B')
 
     def test_legacy_borrow_items_can_be_returned_without_allocations(self) -> None:
         item_id = self._create_item(asset_status='2', name='老資料設備', model='L1')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { InventoryListPage } from './components/pages/InventoryListPage'
 import { IssueListPage } from './components/pages/IssueListPage'
 import { IssuePage } from './components/pages/IssuePage'
 import { LogsPage } from './components/pages/LogsPage'
+import { MasterDataPage } from './components/pages/MasterDataPage'
 import { UploadPage } from './components/pages/UploadPage'
 import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card'
 
@@ -175,6 +176,12 @@ const logsRoute = createRoute({
   component: LogsPage,
 })
 
+const masterDataRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/features/master-data',
+  component: MasterDataPage,
+})
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   inventoryRoute,
@@ -191,6 +198,7 @@ const routeTree = rootRoute.addChildren([
   donationEditRoute,
   uploadRoute,
   logsRoute,
+  masterDataRoute,
 ])
 
 const router = createRouter({ routeTree, defaultPreload: 'intent' })

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo, useState } from 'react'
 import { Link, Outlet, useLocation } from '@tanstack/react-router'
-import { Boxes, ChevronDown, ClipboardList, FilePlus2, HandCoins, Handshake, LayoutDashboard, Logs, Menu, Upload, X } from 'lucide-react'
+import { Boxes, ChevronDown, ClipboardList, FilePlus2, HandCoins, Handshake, LayoutDashboard, Logs, Menu, Settings2, Upload, X } from 'lucide-react'
 import { cn } from '../../lib/utils'
 
 type NavigationLink = {
@@ -74,6 +74,10 @@ const NAVIGATION_SECTIONS: NavigationSection[] = [
     title: '稽核',
     links: [{ to: '/logs', label: '日誌查詢', icon: <Logs className="size-4" />, exact: true }],
   },
+  {
+    title: '功能選單',
+    links: [{ to: '/features/master-data', label: '主檔設定', icon: <Settings2 className="size-4" />, exact: true }],
+  },
 ]
 
 type PageMeta = {
@@ -126,6 +130,9 @@ function resolvePageMeta(pathname: string): PageMeta {
   }
   if (pathname === '/logs') {
     return { title: '日誌查詢', description: '檢視異動流水帳與操作日誌' }
+  }
+  if (pathname === '/features/master-data') {
+    return { title: '主檔設定', description: '維護資產狀態與分類主檔資料' }
   }
 
   return { title: '頁面', description: '系統頁面' }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -75,8 +75,8 @@ const NAVIGATION_SECTIONS: NavigationSection[] = [
     links: [{ to: '/logs', label: '日誌查詢', icon: <Logs className="size-4" />, exact: true }],
   },
   {
-    title: '功能選單',
-    links: [{ to: '/features/master-data', label: '主檔設定', icon: <Settings2 className="size-4" />, exact: true }],
+    title: '系統設定',
+    links: [{ to: '/features/master-data', label: '代碼設定', icon: <Settings2 className="size-4" />, exact: true }],
   },
 ]
 
@@ -132,7 +132,7 @@ function resolvePageMeta(pathname: string): PageMeta {
     return { title: '日誌查詢', description: '檢視異動流水帳與操作日誌' }
   }
   if (pathname === '/features/master-data') {
-    return { title: '主檔設定', description: '維護資產狀態與分類主檔資料' }
+    return { title: '代碼設定', description: '維護資產狀態與分類代碼設定' }
   }
 
   return { title: '頁面', description: '系統頁面' }

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -504,22 +504,6 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
                 <Label>保管人</Label>
                 <Input value={formData.keeper} onChange={(event) => handleInputChange('keeper', event.target.value)} />
               </div>
-              <div className="grid gap-1.5">
-                <Label>借用人</Label>
-                <Input value={formData.borrower} onChange={(event) => handleInputChange('borrower', event.target.value)} />
-              </div>
-              <div className="grid gap-1.5">
-                <Label>起始日期</Label>
-                <Input type="date" value={formData.start_date} onChange={(event) => handleInputChange('start_date', event.target.value)} />
-              </div>
-              <div className="grid gap-1.5">
-                <Label>到期日</Label>
-                <Input type="date" value={formData.due_date} onChange={(event) => handleInputChange('due_date', event.target.value)} />
-              </div>
-              <div className="grid gap-1.5">
-                <Label>歸還日</Label>
-                <Input type="date" value={formData.return_date} onChange={(event) => handleInputChange('return_date', event.target.value)} />
-              </div>
               <div className="grid gap-1.5 md:col-span-2 xl:col-span-3">
                 <Label>memo</Label>
                 <Textarea rows={4} value={formData.memo} onChange={(event) => handleInputChange('memo', event.target.value)} />
@@ -530,6 +514,30 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
               </div>
             </div>
           </SectionCard>
+
+          {isEditMode ? (
+            <SectionCard>
+              <h2 className="m-0 text-base font-semibold">借用資訊（唯讀）</h2>
+              <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-1.5">
+                  <Label>借用人</Label>
+                  <Input value={formData.borrower || '--'} readOnly disabled />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>起始日期</Label>
+                  <Input type="text" value={formData.start_date || '--'} readOnly disabled />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>到期日</Label>
+                  <Input type="text" value={formData.due_date || '--'} readOnly disabled />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>歸還日</Label>
+                  <Input type="text" value={formData.return_date || '--'} readOnly disabled />
+                </div>
+              </div>
+            </SectionCard>
+          ) : null}
 
           <SectionCard>
             <h2 className="m-0 text-base font-semibold">異動紀錄</h2>

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -157,7 +157,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
           setAssetStatusOptions([])
           setConditionStatusOptions([])
           setAssetCategoryOptions([])
-          setAssetCategoryLoadError('無法讀取分類主檔，請稍後再試。')
+          setAssetCategoryLoadError('無法讀取分類設定資料，請稍後再試。')
         }
       }
     }
@@ -300,7 +300,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
     setSuccessMessage('')
 
     if (assetCategoryLoadError || assetCategoryOptions.length === 0) {
-      setErrorMessage('分類主檔尚未就緒，暫時無法送出。')
+      setErrorMessage('分類設定尚未就緒，暫時無法送出。')
       return
     }
     if (!isCategoryPairSelected) {
@@ -464,7 +464,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
                     </option>
                   ))}
                   {!hasNameCodeOption && formData.name_code ? (
-                    <option value={formData.name_code}>{`${formData.name_code}（目前值，不在主檔）`}</option>
+                    <option value={formData.name_code}>{`${formData.name_code}（目前值，不在設定清單）`}</option>
                   ) : null}
                 </Select>
               </div>
@@ -482,13 +482,13 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
                     </option>
                   ))}
                   {!hasNameCode2Option && formData.name_code2 ? (
-                    <option value={formData.name_code2}>{`${formData.name_code2}（目前值，不在主檔）`}</option>
+                    <option value={formData.name_code2}>{`${formData.name_code2}（目前值，不在設定清單）`}</option>
                   ) : null}
                 </Select>
               </div>
               {assetCategoryLoadError ? <p className="m-0 text-xs text-red-700">{assetCategoryLoadError}</p> : null}
               {isCategoryPairSelected && !isCategoryPairValid ? (
-                <p className="m-0 text-xs text-amber-700">目前資料的主分類/次分類不在分類主檔，請改為合法組合後再儲存。</p>
+                <p className="m-0 text-xs text-amber-700">目前資料的主分類/次分類不在分類設定清單，請改為合法組合後再儲存。</p>
               ) : null}
             </div>
           </SectionCard>

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -8,6 +8,7 @@ import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
 import { fetchAssetCategoryOptions } from './assetCategoryLookup'
 import { fetchAssetStatusOptions } from './assetStatusLookup'
+import { fetchConditionStatusOptions } from './conditionStatusLookup'
 import type { InventoryItem } from './types'
 
 type InventoryFormPageProps = {
@@ -46,11 +47,6 @@ const ASSET_TYPE_OPTIONS = [
   { value: 'A1', label: '物品 (A1)' },
   { value: 'A2', label: '其他 (A2)' },
 ]
-const CONDITION_STATUS_OPTIONS = [
-  { value: '0', label: '0' },
-  { value: '1', label: '1' },
-]
-
 const DEFAULT_FORM_DATA: InventoryFormData = {
   asset_type: 'A2',
   asset_status: '0',
@@ -123,6 +119,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
   const [errorMessage, setErrorMessage] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
   const [assetStatusOptions, setAssetStatusOptions] = useState<Array<{ value: string; label: string }>>([])
+  const [conditionStatusOptions, setConditionStatusOptions] = useState<Array<{ value: string; label: string }>>([])
   const [assetCategoryOptions, setAssetCategoryOptions] = useState<
     Array<{ name_code: string; name_code2: string; asset_category_name: string; description: string }>
   >([])
@@ -133,7 +130,11 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
     const loadLookupOptions = async () => {
       try {
-        const [statusOptions, categoryOptions] = await Promise.all([fetchAssetStatusOptions(), fetchAssetCategoryOptions()])
+        const [statusOptions, conditionOptions, categoryOptions] = await Promise.all([
+          fetchAssetStatusOptions(),
+          fetchConditionStatusOptions(),
+          fetchAssetCategoryOptions(),
+        ])
         if (cancelled) {
           return
         }
@@ -143,11 +144,18 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
             label: `${option.description || option.code} (${option.code})`,
           })),
         )
+        setConditionStatusOptions(
+          conditionOptions.map((option) => ({
+            value: option.code,
+            label: `${option.description || option.code} (${option.code})`,
+          })),
+        )
         setAssetCategoryOptions(categoryOptions)
         setAssetCategoryLoadError('')
       } catch {
         if (!cancelled) {
           setAssetStatusOptions([])
+          setConditionStatusOptions([])
           setAssetCategoryOptions([])
           setAssetCategoryLoadError('無法讀取分類主檔，請稍後再試。')
         }
@@ -268,7 +276,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
   const hasNameCodeOption = nameCodeOptions.some((option) => option.value === formData.name_code)
   const hasNameCode2Option = nameCode2Options.some((option) => option.value === formData.name_code2)
-  const hasConditionStatusOption = CONDITION_STATUS_OPTIONS.some((option) => option.value === formData.condition_status)
+  const hasConditionStatusOption = conditionStatusOptions.some((option) => option.value === formData.condition_status)
 
   const handleNameCodeChange = (value: string) => {
     setFormData((previousData) => {
@@ -399,7 +407,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
               <div className="grid gap-1.5">
                 <Label>物料狀況</Label>
                 <Select value={formData.condition_status} onChange={(event) => handleInputChange('condition_status', event.target.value)}>
-                  {CONDITION_STATUS_OPTIONS.map((conditionStatusOption) => (
+                  {conditionStatusOptions.map((conditionStatusOption) => (
                     <option key={conditionStatusOption.value} value={conditionStatusOption.value}>
                       {conditionStatusOption.label}
                     </option>

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -5,8 +5,8 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SectionCard } from '../ui/section-card'
 import { Select } from '../ui/select'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
 import { Textarea } from '../ui/textarea'
+import { fetchAssetCategoryOptions } from './assetCategoryLookup'
 import { fetchAssetStatusOptions } from './assetStatusLookup'
 import type { InventoryItem } from './types'
 
@@ -17,6 +17,7 @@ type InventoryFormPageProps = {
 type InventoryFormData = {
   asset_type: string
   asset_status: string
+  condition_status: string
   key: string
   n_property_sn: string
   property_sn: string
@@ -36,6 +37,8 @@ type InventoryFormData = {
   memo: string
   memo2: string
   keeper: string
+  borrower: string
+  start_date: string
 }
 
 const ASSET_TYPE_OPTIONS = [
@@ -43,10 +46,15 @@ const ASSET_TYPE_OPTIONS = [
   { value: 'A1', label: '物品 (A1)' },
   { value: 'A2', label: '其他 (A2)' },
 ]
+const CONDITION_STATUS_OPTIONS = [
+  { value: '0', label: '0' },
+  { value: '1', label: '1' },
+]
 
 const DEFAULT_FORM_DATA: InventoryFormData = {
   asset_type: 'A2',
   asset_status: '0',
+  condition_status: '0',
   key: '',
   n_property_sn: '',
   property_sn: '',
@@ -66,6 +74,8 @@ const DEFAULT_FORM_DATA: InventoryFormData = {
   memo: '',
   memo2: '',
   keeper: '',
+  borrower: '',
+  start_date: '',
 }
 
 function normalizeDateForInput(value: string | null): string {
@@ -100,6 +110,7 @@ function toSubmitPayload(formData: InventoryFormData) {
     purchase_date: formData.purchase_date || null,
     due_date: formData.due_date || null,
     return_date: formData.return_date || null,
+    start_date: formData.start_date || null,
   }
 }
 
@@ -112,30 +123,38 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
   const [errorMessage, setErrorMessage] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
   const [assetStatusOptions, setAssetStatusOptions] = useState<Array<{ value: string; label: string }>>([])
+  const [assetCategoryOptions, setAssetCategoryOptions] = useState<
+    Array<{ name_code: string; name_code2: string; asset_category_name: string; description: string }>
+  >([])
+  const [assetCategoryLoadError, setAssetCategoryLoadError] = useState('')
 
   useEffect(() => {
     let cancelled = false
 
-    const loadAssetStatusOptions = async () => {
+    const loadLookupOptions = async () => {
       try {
-        const options = await fetchAssetStatusOptions()
+        const [statusOptions, categoryOptions] = await Promise.all([fetchAssetStatusOptions(), fetchAssetCategoryOptions()])
         if (cancelled) {
           return
         }
         setAssetStatusOptions(
-          options.map((option) => ({
+          statusOptions.map((option) => ({
             value: option.code,
             label: `${option.description || option.code} (${option.code})`,
           })),
         )
+        setAssetCategoryOptions(categoryOptions)
+        setAssetCategoryLoadError('')
       } catch {
         if (!cancelled) {
           setAssetStatusOptions([])
+          setAssetCategoryOptions([])
+          setAssetCategoryLoadError('無法讀取分類主檔，請稍後再試。')
         }
       }
     }
 
-    void loadAssetStatusOptions()
+    void loadLookupOptions()
     return () => {
       cancelled = true
     }
@@ -161,6 +180,7 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
         setFormData({
           asset_type: item.asset_type || 'A2',
           asset_status: item.asset_status || '0',
+          condition_status: item.condition_status || '0',
           key: item.key || '',
           n_property_sn: item.n_property_sn || '',
           property_sn: item.property_sn || '',
@@ -180,6 +200,8 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
           memo: item.memo || '',
           memo2: item.memo2 || '',
           keeper: item.keeper || '',
+          borrower: item.borrower || '',
+          start_date: normalizeDateForInput(item.start_date),
         })
       } catch {
         setErrorMessage('讀取財產資料失敗，請稍後再試。')
@@ -206,10 +228,82 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
     }))
   }
 
+  const nameCodeLabelMap = useMemo(() => {
+    const labelMap = new Map<string, string>()
+    for (const option of assetCategoryOptions) {
+      if (!labelMap.has(option.name_code)) {
+        const categoryName = option.asset_category_name?.trim()
+        labelMap.set(option.name_code, categoryName ? `${option.name_code} (${categoryName})` : option.name_code)
+      }
+    }
+    return labelMap
+  }, [assetCategoryOptions])
+
+  const nameCodeOptions = useMemo(
+    () =>
+      Array.from(nameCodeLabelMap.entries())
+        .map(([value, label]) => ({ value, label }))
+        .sort((left, right) => left.label.localeCompare(right.label, 'zh-TW', { numeric: true, sensitivity: 'base' })),
+    [nameCodeLabelMap],
+  )
+
+  const nameCode2Options = useMemo(
+    () =>
+      assetCategoryOptions
+        .filter((option) => option.name_code === formData.name_code)
+        .map((option) => ({
+          value: option.name_code2,
+          label: option.description?.trim() ? `${option.name_code2} (${option.description})` : option.name_code2,
+        }))
+        .sort((left, right) => left.label.localeCompare(right.label, 'zh-TW', { numeric: true, sensitivity: 'base' })),
+    [assetCategoryOptions, formData.name_code],
+  )
+
+  const validNameCodePairSet = useMemo(
+    () => new Set(assetCategoryOptions.map((option) => `${option.name_code}__${option.name_code2}`)),
+    [assetCategoryOptions],
+  )
+  const isCategoryPairSelected = Boolean(formData.name_code.trim() && formData.name_code2.trim())
+  const isCategoryPairValid = validNameCodePairSet.has(`${formData.name_code}__${formData.name_code2}`)
+
+  const hasNameCodeOption = nameCodeOptions.some((option) => option.value === formData.name_code)
+  const hasNameCode2Option = nameCode2Options.some((option) => option.value === formData.name_code2)
+  const hasConditionStatusOption = CONDITION_STATUS_OPTIONS.some((option) => option.value === formData.condition_status)
+
+  const handleNameCodeChange = (value: string) => {
+    setFormData((previousData) => {
+      if (previousData.name_code === value) {
+        return previousData
+      }
+      const hasNextNameCode2 = assetCategoryOptions.some(
+        (option) => option.name_code === value && option.name_code2 === previousData.name_code2,
+      )
+      return {
+        ...previousData,
+        name_code: value,
+        name_code2: hasNextNameCode2 ? previousData.name_code2 : '',
+      }
+    })
+  }
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setErrorMessage('')
     setSuccessMessage('')
+
+    if (assetCategoryLoadError || assetCategoryOptions.length === 0) {
+      setErrorMessage('分類主檔尚未就緒，暫時無法送出。')
+      return
+    }
+    if (!isCategoryPairSelected) {
+      setErrorMessage('請選擇主分類與次分類。')
+      return
+    }
+    if (!isCategoryPairValid) {
+      setErrorMessage('主分類與次分類不是合法組合，請重新選擇。')
+      return
+    }
+
     setSubmitting(true)
 
     try {
@@ -247,169 +341,213 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
 
       {!loading ? (
         <form className="grid gap-4" onSubmit={(event) => void handleSubmit(event)}>
-          <Tabs defaultValue="basic">
-            <TabsList>
-              <TabsTrigger value="basic">基本資料</TabsTrigger>
-              <TabsTrigger value="details">補充欄位</TabsTrigger>
-              <TabsTrigger value="meta">異動紀錄</TabsTrigger>
-            </TabsList>
+          <SectionCard>
+            <h2 className="m-0 text-base font-semibold">識別資料</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-1.5">
+                <Label>Key</Label>
+                <Input value={formData.key} onChange={(event) => handleInputChange('key', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>n_property_sn</Label>
+                <Input value={formData.n_property_sn} onChange={(event) => handleInputChange('n_property_sn', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>property_sn</Label>
+                <Input value={formData.property_sn} onChange={(event) => handleInputChange('property_sn', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>n_item_sn</Label>
+                <Input value={formData.n_item_sn} onChange={(event) => handleInputChange('n_item_sn', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>item_sn</Label>
+                <Input value={formData.item_sn} onChange={(event) => handleInputChange('item_sn', event.target.value)} />
+              </div>
+            </div>
+          </SectionCard>
 
-            <TabsContent value="basic">
-              <SectionCard>
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  <div className="grid gap-1.5">
-                    <Label>資產類型</Label>
-                    <Select value={formData.asset_type} onChange={(event) => handleInputChange('asset_type', event.target.value)}>
-                      {ASSET_TYPE_OPTIONS.map((assetTypeOption) => (
-                        <option key={assetTypeOption.value} value={assetTypeOption.value}>
-                          {assetTypeOption.label}
-                        </option>
-                      ))}
-                      {!ASSET_TYPE_OPTIONS.some((assetTypeOption) => assetTypeOption.value === formData.asset_type) && formData.asset_type ? (
-                        <option value={formData.asset_type}>{formData.asset_type}</option>
-                      ) : null}
-                    </Select>
-                  </div>
+          <SectionCard>
+            <h2 className="m-0 text-base font-semibold">狀態資料</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-1.5">
+                <Label>資產類型</Label>
+                <Select value={formData.asset_type} onChange={(event) => handleInputChange('asset_type', event.target.value)}>
+                  {ASSET_TYPE_OPTIONS.map((assetTypeOption) => (
+                    <option key={assetTypeOption.value} value={assetTypeOption.value}>
+                      {assetTypeOption.label}
+                    </option>
+                  ))}
+                  {!ASSET_TYPE_OPTIONS.some((assetTypeOption) => assetTypeOption.value === formData.asset_type) && formData.asset_type ? (
+                    <option value={formData.asset_type}>{formData.asset_type}</option>
+                  ) : null}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label>資產狀態</Label>
+                <Select value={formData.asset_status} onChange={(event) => handleInputChange('asset_status', event.target.value)}>
+                  {assetStatusOptions.map((statusOption) => (
+                    <option key={statusOption.value} value={statusOption.value}>
+                      {statusOption.label}
+                    </option>
+                  ))}
+                  {!assetStatusOptions.some((statusOption) => statusOption.value === formData.asset_status) && formData.asset_status ? (
+                    <option value={formData.asset_status}>{formData.asset_status}</option>
+                  ) : null}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label>物料狀況</Label>
+                <Select value={formData.condition_status} onChange={(event) => handleInputChange('condition_status', event.target.value)}>
+                  {CONDITION_STATUS_OPTIONS.map((conditionStatusOption) => (
+                    <option key={conditionStatusOption.value} value={conditionStatusOption.value}>
+                      {conditionStatusOption.label}
+                    </option>
+                  ))}
+                  {!hasConditionStatusOption && formData.condition_status ? (
+                    <option value={formData.condition_status}>{formData.condition_status}</option>
+                  ) : null}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label>數量</Label>
+                <Input type="number" min={1} max={1} value={1} disabled />
+                {loadedItem && loadedItem.count > 1 ? (
+                  <p className="m-0 text-xs text-amber-700">此筆為歷史資料（count &gt; 1），目前單件模式僅允許新異動固定為 1。</p>
+                ) : null}
+              </div>
+            </div>
+          </SectionCard>
 
-                  <div className="grid gap-1.5">
-                    <Label>資產狀態</Label>
-                    <Select value={formData.asset_status} onChange={(event) => handleInputChange('asset_status', event.target.value)}>
-                      {assetStatusOptions.map((statusOption) => (
-                        <option key={statusOption.value} value={statusOption.value}>
-                          {statusOption.label}
-                        </option>
-                      ))}
-                      {!assetStatusOptions.some((statusOption) => statusOption.value === formData.asset_status) && formData.asset_status ? (
-                        <option value={formData.asset_status}>{formData.asset_status}</option>
-                      ) : null}
-                    </Select>
-                  </div>
+          <SectionCard>
+            <h2 className="m-0 text-base font-semibold">基本資料</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-1.5">
+                <Label>品名</Label>
+                <Input value={formData.name} onChange={(event) => handleInputChange('name', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>型號</Label>
+                <Input value={formData.model} onChange={(event) => handleInputChange('model', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>規格</Label>
+                <Input value={formData.specification} onChange={(event) => handleInputChange('specification', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>單位</Label>
+                <Input value={formData.unit} onChange={(event) => handleInputChange('unit', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>購置日期</Label>
+                <Input type="date" value={formData.purchase_date} onChange={(event) => handleInputChange('purchase_date', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>name_code</Label>
+                <Select
+                  value={formData.name_code}
+                  onChange={(event) => handleNameCodeChange(event.target.value)}
+                  disabled={Boolean(assetCategoryLoadError) || assetCategoryOptions.length === 0}
+                >
+                  <option value="">請選擇主分類</option>
+                  {nameCodeOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                  {!hasNameCodeOption && formData.name_code ? (
+                    <option value={formData.name_code}>{`${formData.name_code}（目前值，不在主檔）`}</option>
+                  ) : null}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label>name_code2</Label>
+                <Select
+                  value={formData.name_code2}
+                  onChange={(event) => handleInputChange('name_code2', event.target.value)}
+                  disabled={Boolean(assetCategoryLoadError) || !formData.name_code}
+                >
+                  <option value="">{formData.name_code ? '請選擇次分類' : '請先選擇主分類'}</option>
+                  {nameCode2Options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                  {!hasNameCode2Option && formData.name_code2 ? (
+                    <option value={formData.name_code2}>{`${formData.name_code2}（目前值，不在主檔）`}</option>
+                  ) : null}
+                </Select>
+              </div>
+              {assetCategoryLoadError ? <p className="m-0 text-xs text-red-700">{assetCategoryLoadError}</p> : null}
+              {isCategoryPairSelected && !isCategoryPairValid ? (
+                <p className="m-0 text-xs text-amber-700">目前資料的主分類/次分類不在分類主檔，請改為合法組合後再儲存。</p>
+              ) : null}
+            </div>
+          </SectionCard>
 
-                  <div className="grid gap-1.5">
-                    <Label>Key</Label>
-                    <Input value={formData.key} onChange={(event) => handleInputChange('key', event.target.value)} />
-                  </div>
+          <SectionCard>
+            <h2 className="m-0 text-base font-semibold">管理資料</h2>
+            <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-1.5">
+                <Label>放置地點</Label>
+                <Input value={formData.location} onChange={(event) => handleInputChange('location', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>保管人</Label>
+                <Input value={formData.keeper} onChange={(event) => handleInputChange('keeper', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>借用人</Label>
+                <Input value={formData.borrower} onChange={(event) => handleInputChange('borrower', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>起始日期</Label>
+                <Input type="date" value={formData.start_date} onChange={(event) => handleInputChange('start_date', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>到期日</Label>
+                <Input type="date" value={formData.due_date} onChange={(event) => handleInputChange('due_date', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>歸還日</Label>
+                <Input type="date" value={formData.return_date} onChange={(event) => handleInputChange('return_date', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5 md:col-span-2 xl:col-span-3">
+                <Label>memo</Label>
+                <Textarea rows={4} value={formData.memo} onChange={(event) => handleInputChange('memo', event.target.value)} />
+              </div>
+              <div className="grid gap-1.5 md:col-span-2 xl:col-span-3">
+                <Label>memo2</Label>
+                <Textarea rows={4} value={formData.memo2} onChange={(event) => handleInputChange('memo2', event.target.value)} />
+              </div>
+            </div>
+          </SectionCard>
 
-                  <div className="grid gap-1.5">
-                    <Label>n_property_sn</Label>
-                    <Input value={formData.n_property_sn} onChange={(event) => handleInputChange('n_property_sn', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>property_sn</Label>
-                    <Input value={formData.property_sn} onChange={(event) => handleInputChange('property_sn', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>n_item_sn</Label>
-                    <Input value={formData.n_item_sn} onChange={(event) => handleInputChange('n_item_sn', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>item_sn</Label>
-                    <Input value={formData.item_sn} onChange={(event) => handleInputChange('item_sn', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>品名</Label>
-                    <Input value={formData.name} onChange={(event) => handleInputChange('name', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>型號</Label>
-                    <Input value={formData.model} onChange={(event) => handleInputChange('model', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>規格</Label>
-                    <Input value={formData.specification} onChange={(event) => handleInputChange('specification', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>單位</Label>
-                    <Input value={formData.unit} onChange={(event) => handleInputChange('unit', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>數量</Label>
-                    <Input type="number" min={1} max={1} value={1} disabled />
-                    {loadedItem && loadedItem.count > 1 ? (
-                      <p className="m-0 text-xs text-amber-700">此筆為歷史資料（count &gt; 1），目前單件模式僅允許新異動固定為 1。</p>
-                    ) : null}
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>購置日期</Label>
-                    <Input type="date" value={formData.purchase_date} onChange={(event) => handleInputChange('purchase_date', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>到期日</Label>
-                    <Input type="date" value={formData.due_date} onChange={(event) => handleInputChange('due_date', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>歸還日</Label>
-                    <Input type="date" value={formData.return_date} onChange={(event) => handleInputChange('return_date', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>放置地點</Label>
-                    <Input value={formData.location} onChange={(event) => handleInputChange('location', event.target.value)} />
-                  </div>
-
-                  <div className="grid gap-1.5">
-                    <Label>保管人</Label>
-                    <Input value={formData.keeper} onChange={(event) => handleInputChange('keeper', event.target.value)} />
-                  </div>
+          <SectionCard>
+            <h2 className="m-0 text-base font-semibold">異動紀錄</h2>
+            <div className="mt-3">
+              {loadedItem ? (
+                <div className="grid gap-2 rounded-md bg-[hsl(var(--card-soft))] p-3 text-sm text-[hsl(var(--muted-foreground))] md:grid-cols-2">
+                  <div>建立時間：{formatDateTime(loadedItem.created_at)}</div>
+                  <div>建立者：{loadedItem.created_by || '--'}</div>
+                  <div>更新時間：{formatDateTime(loadedItem.updated_at)}</div>
+                  <div>更新者：{loadedItem.updated_by || '--'}</div>
+                  <div>刪除時間：{formatDateTime(loadedItem.deleted_at)}</div>
+                  <div>刪除者：{loadedItem.deleted_by || '--'}</div>
                 </div>
-              </SectionCard>
-            </TabsContent>
+              ) : (
+                <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">新增模式尚無異動紀錄。</p>
+              )}
+            </div>
+          </SectionCard>
 
-            <TabsContent value="details">
-              <SectionCard>
-                <div className="grid gap-3 md:grid-cols-2">
-                  <div className="grid gap-1.5">
-                    <Label>name_code</Label>
-                    <Input value={formData.name_code} onChange={(event) => handleInputChange('name_code', event.target.value)} />
-                  </div>
-                  <div className="grid gap-1.5">
-                    <Label>name_code2</Label>
-                    <Input value={formData.name_code2} onChange={(event) => handleInputChange('name_code2', event.target.value)} />
-                  </div>
-                  <div className="grid gap-1.5 md:col-span-2">
-                    <Label>memo</Label>
-                    <Textarea rows={4} value={formData.memo} onChange={(event) => handleInputChange('memo', event.target.value)} />
-                  </div>
-                  <div className="grid gap-1.5 md:col-span-2">
-                    <Label>memo2</Label>
-                    <Textarea rows={4} value={formData.memo2} onChange={(event) => handleInputChange('memo2', event.target.value)} />
-                  </div>
-                </div>
-              </SectionCard>
-            </TabsContent>
-
-            <TabsContent value="meta">
-              <SectionCard>
-                {loadedItem ? (
-                  <div className="grid gap-2 rounded-md bg-[hsl(var(--card-soft))] p-3 text-sm text-[hsl(var(--muted-foreground))] md:grid-cols-2">
-                    <div>建立時間：{formatDateTime(loadedItem.created_at)}</div>
-                    <div>建立者：{loadedItem.created_by || '--'}</div>
-                    <div>更新時間：{formatDateTime(loadedItem.updated_at)}</div>
-                    <div>更新者：{loadedItem.updated_by || '--'}</div>
-                    <div>刪除時間：{formatDateTime(loadedItem.deleted_at)}</div>
-                    <div>刪除者：{loadedItem.deleted_by || '--'}</div>
-                  </div>
-                ) : (
-                  <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">新增模式尚無異動紀錄。</p>
-                )}
-              </SectionCard>
-            </TabsContent>
-          </Tabs>
-
-          <div className="sticky bottom-0 z-10 flex justify-end rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))]/95 p-3 backdrop-blur">
-            <Button type="submit" disabled={submitting}>{submitButtonLabel}</Button>
-          </div>
+          <SectionCard>
+            <div className="flex justify-end">
+              <Button type="submit" disabled={submitting || Boolean(assetCategoryLoadError)}>
+                {submitButtonLabel}
+              </Button>
+            </div>
+          </SectionCard>
         </form>
       ) : null}
     </>

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { MoreHorizontal, Plus } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { DataPagination } from '../ui/data-pagination'
 import { Button } from '../ui/button'
 import { Dialog } from '../ui/dialog'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu'
 import { FilterBar } from '../ui/filter-bar'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -41,6 +40,7 @@ type ScanBuffer = {
 
 type InventorySortKey = 'id' | 'asset_type' | 'serial' | 'name' | 'specification' | 'location' | 'keeper' | 'asset_status'
 type SortDirection = 'asc' | 'desc'
+type DeletedScope = 'active' | 'deleted'
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   if (!value) {
@@ -72,6 +72,10 @@ function parseInventorySortKey(value: string | null, fallback: InventorySortKey)
   return value && allowed.includes(value as InventorySortKey) ? (value as InventorySortKey) : fallback
 }
 
+function parseDeletedScope(value: string | null, fallback: DeletedScope): DeletedScope {
+  return value === 'deleted' || value === 'active' ? value : fallback
+}
+
 function readInitialState() {
   const params = new URLSearchParams(window.location.search)
   const correctionParam = params.get('correction_status')
@@ -85,6 +89,7 @@ function readInitialState() {
     selectedKeeper: params.get('keeper') ?? 'all',
     selectedCorrectionStatus: correctionStatus as 'all' | 'needs_fix',
     showDonated: parseBoolean(params.get('include_donated'), false),
+    deletedScope: parseDeletedScope(params.get('deleted_scope'), 'active'),
     sortBy: parseInventorySortKey(params.get('sort_by'), 'id'),
     sortDir: parseSortDirection(params.get('sort_dir'), 'desc'),
     page: parsePositiveInt(params.get('page'), 1),
@@ -109,6 +114,7 @@ export function InventoryListPage() {
   const [selectedKeeper, setSelectedKeeper] = useState(initialState.selectedKeeper)
   const [selectedCorrectionStatus, setSelectedCorrectionStatus] = useState<'all' | 'needs_fix'>(initialState.selectedCorrectionStatus)
   const [showDonated, setShowDonated] = useState(initialState.showDonated)
+  const [deletedScope, setDeletedScope] = useState<DeletedScope>(initialState.deletedScope)
   const [sortBy, setSortBy] = useState<InventorySortKey>(initialState.sortBy)
   const [sortDir, setSortDir] = useState<SortDirection>(initialState.sortDir)
   const [page, setPage] = useState(initialState.page)
@@ -147,6 +153,9 @@ export function InventoryListPage() {
     if (showDonated) {
       params.set('include_donated', 'true')
     }
+    if (deletedScope !== 'active') {
+      params.set('deleted_scope', deletedScope)
+    }
     if (sortBy !== 'id') {
       params.set('sort_by', sortBy)
     }
@@ -162,7 +171,7 @@ export function InventoryListPage() {
     const queryString = params.toString()
     const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
     window.history.replaceState(null, '', url)
-  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize])
+  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, deletedScope, sortBy, sortDir, page, pageSize])
 
   useEffect(() => {
     const requestSeq = ++listRequestSeqRef.current
@@ -176,6 +185,7 @@ export function InventoryListPage() {
           page: '1',
           page_size: '100000',
           include_donated: String(showDonated),
+          deleted_scope: deletedScope,
           correction_status: selectedCorrectionStatus,
           sort_by: sortBy,
           sort_dir: sortDir,
@@ -247,7 +257,7 @@ export function InventoryListPage() {
     return () => {
       controller.abort()
     }
-  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize, reloadKey])
+  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, deletedScope, sortBy, sortDir, page, pageSize, reloadKey])
 
   useEffect(() => {
     const loadAssetTypes = async () => {
@@ -256,6 +266,7 @@ export function InventoryListPage() {
           page: '1',
           page_size: '100000',
           include_donated: String(showDonated),
+          deleted_scope: deletedScope,
         })
         const response = await fetch(apiUrl(`/api/items?${params.toString()}`))
         if (!response.ok) {
@@ -270,7 +281,7 @@ export function InventoryListPage() {
     }
 
     void loadAssetTypes()
-  }, [showDonated, reloadKey])
+  }, [showDonated, deletedScope, reloadKey])
 
   useEffect(() => {
     let cancelled = false
@@ -397,6 +408,33 @@ export function InventoryListPage() {
       setConfirmDeleteItem(null)
     } catch {
       setLoadError('刪除財產資料失敗，請稍後再試。')
+    } finally {
+      setDeletingItemId(null)
+    }
+  }
+
+  const handleRestoreItem = async (item: InventoryItem) => {
+    if (!item.id) {
+      return
+    }
+
+    setLoadError('')
+    setActionMessage('')
+    setDeletingItemId(item.id)
+
+    try {
+      const response = await fetch(apiUrl(`/api/items/${item.id}/restore`), {
+        method: 'POST',
+      })
+
+      if (!response.ok) {
+        throw new Error('還原失敗')
+      }
+
+      setActionMessage('財產資料已還原。')
+      setReloadKey((previous) => previous + 1)
+    } catch {
+      setLoadError('還原財產資料失敗，請稍後再試。')
     } finally {
       setDeletingItemId(null)
     }
@@ -553,6 +591,17 @@ export function InventoryListPage() {
               />
               顯示已捐贈資料
             </Label>
+            <Label className="inline-flex cursor-pointer items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={deletedScope === 'deleted'}
+                onChange={(event) => {
+                  setDeletedScope(event.target.checked ? 'deleted' : 'active')
+                  setPage(1)
+                }}
+              />
+              顯示已刪除資料
+            </Label>
             <div className="text-sm text-[hsl(var(--muted-foreground))]">
               共 {total} 筆資料{correctionSummary !== null ? `，本頁待修正 ${correctionSummary} 筆` : ''}
             </div>
@@ -588,7 +637,7 @@ export function InventoryListPage() {
                   {items.length === 0 ? (
                     <TableRow>
                       <TableCell className="text-center text-[hsl(var(--muted-foreground))]" colSpan={9}>
-                        查無符合條件的財產資料。
+                        {deletedScope === 'deleted' ? '查無已刪除財產資料。' : '查無符合條件的財產資料。'}
                       </TableCell>
                     </TableRow>
                   ) : (
@@ -614,23 +663,27 @@ export function InventoryListPage() {
                         <TableCell>{item.keeper || '--'}</TableCell>
                         <TableCell>{toAssetStatusLabel(item.asset_status, assetStatusLabelMap)}</TableCell>
                         <TableCell>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger>
-                              <MoreHorizontal className="size-4" />
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent>
-                              <Link
-                                className="flex items-center rounded-sm px-2 py-1.5 text-sm text-[hsl(var(--foreground))] no-underline hover:bg-[hsl(var(--secondary))]"
-                                to="/inventory/edit/$itemId"
-                                params={{ itemId: String(item.id) }}
-                              >
-                                編輯
+                          {deletedScope === 'deleted' ? (
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              disabled={deletingItemId === item.id}
+                              onClick={() => {
+                                void handleRestoreItem(item)
+                              }}
+                            >
+                              {deletingItemId === item.id ? '還原中...' : '還原'}
+                            </Button>
+                          ) : (
+                            <div className="flex items-center gap-2">
+                              <Link to="/inventory/edit/$itemId" params={{ itemId: String(item.id) }}>
+                                <Button size="sm" variant="secondary">編輯</Button>
                               </Link>
-                              <DropdownMenuItem className="text-red-600" onClick={() => setConfirmDeleteItem(item)}>
+                              <Button size="sm" variant="destructive" onClick={() => setConfirmDeleteItem(item)}>
                                 刪除
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                              </Button>
+                            </div>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))
@@ -642,7 +695,7 @@ export function InventoryListPage() {
             <div className="grid gap-3 md:hidden">
               {items.length === 0 ? (
                 <p className="m-0 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card-soft))] px-3 py-2 text-sm text-[hsl(var(--muted-foreground))]">
-                  查無符合條件的財產資料。
+                  {deletedScope === 'deleted' ? '查無已刪除財產資料。' : '查無符合條件的財產資料。'}
                 </p>
               ) : (
                 items.map((item) => (
@@ -656,12 +709,28 @@ export function InventoryListPage() {
                     <p className="mt-1 mb-0 text-sm">地點：{item.location || '--'}</p>
                     <p className="mt-1 mb-0 text-sm">狀態：{toAssetStatusLabel(item.asset_status, assetStatusLabelMap)}</p>
                     <div className="mt-3 flex gap-2">
-                      <Link className="flex-1" to="/inventory/edit/$itemId" params={{ itemId: String(item.id) }}>
-                        <Button className="w-full" size="sm" variant="secondary">編輯</Button>
-                      </Link>
-                      <Button size="sm" variant="destructive" onClick={() => setConfirmDeleteItem(item)}>
-                        刪除
-                      </Button>
+                      {deletedScope === 'deleted' ? (
+                        <Button
+                          className="w-full"
+                          size="sm"
+                          variant="secondary"
+                          disabled={deletingItemId === item.id}
+                          onClick={() => {
+                            void handleRestoreItem(item)
+                          }}
+                        >
+                          {deletingItemId === item.id ? '還原中...' : '還原'}
+                        </Button>
+                      ) : (
+                        <>
+                          <Link className="flex-1" to="/inventory/edit/$itemId" params={{ itemId: String(item.id) }}>
+                            <Button className="w-full" size="sm" variant="secondary">編輯</Button>
+                          </Link>
+                          <Button size="sm" variant="destructive" onClick={() => setConfirmDeleteItem(item)}>
+                            刪除
+                          </Button>
+                        </>
+                      )}
                     </div>
                   </article>
                 ))

--- a/frontend/src/components/pages/InventoryListPage.tsx
+++ b/frontend/src/components/pages/InventoryListPage.tsx
@@ -80,6 +80,9 @@ function readInitialState() {
   return {
     keyword: params.get('keyword') ?? '',
     selectedAssetType: params.get('asset_type') ?? 'all',
+    selectedAssetStatus: params.get('asset_status') ?? 'all',
+    selectedLocation: params.get('location') ?? 'all',
+    selectedKeeper: params.get('keeper') ?? 'all',
     selectedCorrectionStatus: correctionStatus as 'all' | 'needs_fix',
     showDonated: parseBoolean(params.get('include_donated'), false),
     sortBy: parseInventorySortKey(params.get('sort_by'), 'id'),
@@ -93,12 +96,17 @@ export function InventoryListPage() {
   const initialState = readInitialState()
   const [items, setItems] = useState<InventoryItem[]>([])
   const [assetTypeOptions, setAssetTypeOptions] = useState<string[]>(['all'])
+  const [locationOptions, setLocationOptions] = useState<string[]>(['all'])
+  const [keeperOptions, setKeeperOptions] = useState<string[]>(['all'])
   const [assetStatusLabelMap, setAssetStatusLabelMap] = useState<Record<string, string>>({})
   const [loadError, setLoadError] = useState('')
   const [actionMessage, setActionMessage] = useState('')
   const [loading, setLoading] = useState(true)
   const [keyword, setKeyword] = useState(initialState.keyword)
   const [selectedAssetType, setSelectedAssetType] = useState(initialState.selectedAssetType)
+  const [selectedAssetStatus, setSelectedAssetStatus] = useState(initialState.selectedAssetStatus)
+  const [selectedLocation, setSelectedLocation] = useState(initialState.selectedLocation)
+  const [selectedKeeper, setSelectedKeeper] = useState(initialState.selectedKeeper)
   const [selectedCorrectionStatus, setSelectedCorrectionStatus] = useState<'all' | 'needs_fix'>(initialState.selectedCorrectionStatus)
   const [showDonated, setShowDonated] = useState(initialState.showDonated)
   const [sortBy, setSortBy] = useState<InventorySortKey>(initialState.sortBy)
@@ -124,6 +132,15 @@ export function InventoryListPage() {
     if (selectedAssetType !== 'all') {
       params.set('asset_type', selectedAssetType)
     }
+    if (selectedAssetStatus !== 'all') {
+      params.set('asset_status', selectedAssetStatus)
+    }
+    if (selectedLocation !== 'all') {
+      params.set('location', selectedLocation)
+    }
+    if (selectedKeeper !== 'all') {
+      params.set('keeper', selectedKeeper)
+    }
     if (selectedCorrectionStatus !== 'all') {
       params.set('correction_status', selectedCorrectionStatus)
     }
@@ -145,7 +162,7 @@ export function InventoryListPage() {
     const queryString = params.toString()
     const url = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
     window.history.replaceState(null, '', url)
-  }, [keyword, selectedAssetType, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize])
+  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize])
 
   useEffect(() => {
     const requestSeq = ++listRequestSeqRef.current
@@ -156,8 +173,8 @@ export function InventoryListPage() {
       setLoadError('')
       try {
         const params = new URLSearchParams({
-          page: String(page),
-          page_size: String(pageSize),
+          page: '1',
+          page_size: '100000',
           include_donated: String(showDonated),
           correction_status: selectedCorrectionStatus,
           sort_by: sortBy,
@@ -179,9 +196,41 @@ export function InventoryListPage() {
         if (listRequestSeqRef.current !== requestSeq) {
           return
         }
-        setItems(payload.items)
-        setTotal(payload.total)
-        setTotalPages(payload.total_pages)
+        const rows = payload.items
+        const toUniqueSortedOptions = (values: string[]) => {
+          const uniqueValues = Array.from(new Set(values.filter((value) => value.trim())))
+          uniqueValues.sort((left, right) => left.localeCompare(right, 'zh-TW', { sensitivity: 'base', numeric: true }))
+          return ['all', ...uniqueValues]
+        }
+
+        setLocationOptions(toUniqueSortedOptions(rows.map((item) => item.location || '')))
+        setKeeperOptions(toUniqueSortedOptions(rows.map((item) => item.keeper || '')))
+
+        const filteredRows = rows.filter((item) => {
+          if (selectedAssetStatus !== 'all' && item.asset_status !== selectedAssetStatus) {
+            return false
+          }
+          if (selectedLocation !== 'all' && (item.location || '') !== selectedLocation) {
+            return false
+          }
+          if (selectedKeeper !== 'all' && (item.keeper || '') !== selectedKeeper) {
+            return false
+          }
+          return true
+        })
+
+        const filteredTotal = filteredRows.length
+        const filteredTotalPages = filteredTotal > 0 ? Math.ceil(filteredTotal / pageSize) : 1
+        const normalizedPage = Math.min(page, filteredTotalPages)
+        if (normalizedPage !== page) {
+          setPage(normalizedPage)
+        }
+        const startIndex = (normalizedPage - 1) * pageSize
+        const pagedRows = filteredRows.slice(startIndex, startIndex + pageSize)
+
+        setItems(pagedRows)
+        setTotal(filteredTotal)
+        setTotalPages(filteredTotalPages)
       } catch {
         if (controller.signal.aborted || listRequestSeqRef.current !== requestSeq) {
           return
@@ -198,7 +247,7 @@ export function InventoryListPage() {
     return () => {
       controller.abort()
     }
-  }, [keyword, selectedAssetType, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize, reloadKey])
+  }, [keyword, selectedAssetType, selectedAssetStatus, selectedLocation, selectedKeeper, selectedCorrectionStatus, showDonated, sortBy, sortDir, page, pageSize, reloadKey])
 
   useEffect(() => {
     const loadAssetTypes = async () => {
@@ -427,6 +476,69 @@ export function InventoryListPage() {
               <option value="all">全部資料</option>
               <option value="needs_fix">僅顯示待修正資料</option>
             </Select>
+          </div>
+
+          <div className="grid gap-2 xl:col-span-4">
+            <Label>進階篩選</Label>
+            <div className="grid gap-2 md:grid-cols-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="asset-status-filter">資產狀態</Label>
+                <Select
+                  id="asset-status-filter"
+                  value={selectedAssetStatus}
+                  onChange={(event) => {
+                    setSelectedAssetStatus(event.target.value)
+                    setPage(1)
+                  }}
+                >
+                  <option value="all">全部狀態</option>
+                  {Object.entries(assetStatusLabelMap).map(([statusCode, statusLabel]) => (
+                    <option key={statusCode} value={statusCode}>
+                      {statusLabel}
+                    </option>
+                  ))}
+                  {selectedAssetStatus !== 'all' && !(selectedAssetStatus in assetStatusLabelMap) ? (
+                    <option value={selectedAssetStatus}>{selectedAssetStatus}</option>
+                  ) : null}
+                </Select>
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="location-filter">放置地點</Label>
+                <Select
+                  id="location-filter"
+                  value={selectedLocation}
+                  onChange={(event) => {
+                    setSelectedLocation(event.target.value)
+                    setPage(1)
+                  }}
+                >
+                  {locationOptions.map((locationOption) => (
+                    <option key={locationOption} value={locationOption}>
+                      {locationOption === 'all' ? '全部地點' : locationOption}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="grid gap-1.5">
+                <Label htmlFor="keeper-filter">保管人</Label>
+                <Select
+                  id="keeper-filter"
+                  value={selectedKeeper}
+                  onChange={(event) => {
+                    setSelectedKeeper(event.target.value)
+                    setPage(1)
+                  }}
+                >
+                  {keeperOptions.map((keeperOption) => (
+                    <option key={keeperOption} value={keeperOption}>
+                      {keeperOption === 'all' ? '全部保管人' : keeperOption}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            </div>
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2 xl:col-span-4">

--- a/frontend/src/components/pages/MasterDataPage.tsx
+++ b/frontend/src/components/pages/MasterDataPage.tsx
@@ -1,0 +1,525 @@
+import { useEffect, useState } from 'react'
+import { Button } from '../ui/button'
+import { Dialog } from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SectionCard } from '../ui/section-card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
+import {
+  createAssetCategoryOption,
+  deleteAssetCategoryOption,
+  fetchAssetCategoryOptions,
+  updateAssetCategoryOption,
+} from './assetCategoryLookup'
+import {
+  createAssetStatusOption,
+  deleteAssetStatusOption,
+  fetchAssetStatusOptions,
+  updateAssetStatusOption,
+} from './assetStatusLookup'
+import type { AssetCategoryOption, AssetStatusOption } from './types'
+
+type AssetStatusDialogState = {
+  open: boolean
+  mode: 'create' | 'edit'
+  originalCode: string
+  code: string
+  description: string
+}
+
+type AssetCategoryDialogState = {
+  open: boolean
+  mode: 'create' | 'edit'
+  originalNameCode: string
+  originalNameCode2: string
+  name_code: string
+  name_code2: string
+  asset_category_name: string
+  description: string
+}
+
+const emptyAssetStatusDialog = (): AssetStatusDialogState => ({
+  open: false,
+  mode: 'create',
+  originalCode: '',
+  code: '',
+  description: '',
+})
+
+const emptyAssetCategoryDialog = (): AssetCategoryDialogState => ({
+  open: false,
+  mode: 'create',
+  originalNameCode: '',
+  originalNameCode2: '',
+  name_code: '',
+  name_code2: '',
+  asset_category_name: '',
+  description: '',
+})
+
+export function MasterDataPage() {
+  const [assetStatuses, setAssetStatuses] = useState<AssetStatusOption[]>([])
+  const [assetCategories, setAssetCategories] = useState<AssetCategoryOption[]>([])
+  const [loadingStatus, setLoadingStatus] = useState(false)
+  const [loadingCategory, setLoadingCategory] = useState(false)
+  const [statusError, setStatusError] = useState('')
+  const [categoryError, setCategoryError] = useState('')
+  const [statusActionError, setStatusActionError] = useState('')
+  const [categoryActionError, setCategoryActionError] = useState('')
+  const [savingStatus, setSavingStatus] = useState(false)
+  const [savingCategory, setSavingCategory] = useState(false)
+  const [deletingStatusCode, setDeletingStatusCode] = useState<string | null>(null)
+  const [deletingCategory, setDeletingCategory] = useState<{ name_code: string; name_code2: string } | null>(null)
+  const [statusDialog, setStatusDialog] = useState<AssetStatusDialogState>(emptyAssetStatusDialog())
+  const [categoryDialog, setCategoryDialog] = useState<AssetCategoryDialogState>(emptyAssetCategoryDialog())
+
+  const loadAssetStatuses = async () => {
+    setLoadingStatus(true)
+    setStatusError('')
+    try {
+      const rows = await fetchAssetStatusOptions()
+      setAssetStatuses(rows.sort((left, right) => left.code.localeCompare(right.code, 'zh-TW', { numeric: true, sensitivity: 'base' })))
+    } catch (error) {
+      setStatusError(error instanceof Error ? error.message : '無法讀取資產狀態主檔。')
+    } finally {
+      setLoadingStatus(false)
+    }
+  }
+
+  const loadAssetCategories = async () => {
+    setLoadingCategory(true)
+    setCategoryError('')
+    try {
+      const rows = await fetchAssetCategoryOptions()
+      setAssetCategories(
+        rows.sort((left, right) => {
+          const leftKey = `${left.name_code}-${left.name_code2}`
+          const rightKey = `${right.name_code}-${right.name_code2}`
+          return leftKey.localeCompare(rightKey, 'zh-TW', { numeric: true, sensitivity: 'base' })
+        }),
+      )
+    } catch (error) {
+      setCategoryError(error instanceof Error ? error.message : '無法讀取資產分類主檔。')
+    } finally {
+      setLoadingCategory(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadAssetStatuses()
+    void loadAssetCategories()
+  }, [])
+
+  const openCreateStatusDialog = () => {
+    setStatusActionError('')
+    setStatusDialog({
+      open: true,
+      mode: 'create',
+      originalCode: '',
+      code: '',
+      description: '',
+    })
+  }
+
+  const openEditStatusDialog = (row: AssetStatusOption) => {
+    setStatusActionError('')
+    setStatusDialog({
+      open: true,
+      mode: 'edit',
+      originalCode: row.code,
+      code: row.code,
+      description: row.description || '',
+    })
+  }
+
+  const closeStatusDialog = () => {
+    if (savingStatus) {
+      return
+    }
+    setStatusDialog(emptyAssetStatusDialog())
+  }
+
+  const submitStatusDialog = async () => {
+    const code = statusDialog.code.trim()
+    const description = statusDialog.description.trim()
+
+    if (!code) {
+      setStatusActionError('狀態碼為必填。')
+      return
+    }
+
+    setSavingStatus(true)
+    setStatusActionError('')
+    try {
+      if (statusDialog.mode === 'create') {
+        await createAssetStatusOption({ code, description })
+      } else {
+        await updateAssetStatusOption(statusDialog.originalCode, { code, description })
+      }
+      setStatusDialog(emptyAssetStatusDialog())
+      await loadAssetStatuses()
+    } catch (error) {
+      setStatusActionError(error instanceof Error ? error.message : '儲存資產狀態失敗。')
+    } finally {
+      setSavingStatus(false)
+    }
+  }
+
+  const confirmDeleteStatus = (code: string) => {
+    setStatusActionError('')
+    setDeletingStatusCode(code)
+  }
+
+  const deleteStatus = async () => {
+    if (!deletingStatusCode) {
+      return
+    }
+    setSavingStatus(true)
+    setStatusActionError('')
+    try {
+      await deleteAssetStatusOption(deletingStatusCode)
+      setDeletingStatusCode(null)
+      await loadAssetStatuses()
+    } catch (error) {
+      setStatusActionError(error instanceof Error ? error.message : '刪除資產狀態失敗。')
+    } finally {
+      setSavingStatus(false)
+    }
+  }
+
+  const openCreateCategoryDialog = () => {
+    setCategoryActionError('')
+    setCategoryDialog({
+      open: true,
+      mode: 'create',
+      originalNameCode: '',
+      originalNameCode2: '',
+      name_code: '',
+      name_code2: '',
+      asset_category_name: '',
+      description: '',
+    })
+  }
+
+  const openEditCategoryDialog = (row: AssetCategoryOption) => {
+    setCategoryActionError('')
+    setCategoryDialog({
+      open: true,
+      mode: 'edit',
+      originalNameCode: row.name_code,
+      originalNameCode2: row.name_code2,
+      name_code: row.name_code,
+      name_code2: row.name_code2,
+      asset_category_name: row.asset_category_name || '',
+      description: row.description || '',
+    })
+  }
+
+  const closeCategoryDialog = () => {
+    if (savingCategory) {
+      return
+    }
+    setCategoryDialog(emptyAssetCategoryDialog())
+  }
+
+  const submitCategoryDialog = async () => {
+    const nameCode = categoryDialog.name_code.trim()
+    const nameCode2 = categoryDialog.name_code2.trim()
+    const categoryName = categoryDialog.asset_category_name.trim()
+    const description = categoryDialog.description.trim()
+
+    if (!nameCode || !nameCode2 || !categoryName) {
+      setCategoryActionError('大類代碼、小類代碼、分類名稱皆為必填。')
+      return
+    }
+
+    setSavingCategory(true)
+    setCategoryActionError('')
+    try {
+      if (categoryDialog.mode === 'create') {
+        await createAssetCategoryOption({
+          name_code: nameCode,
+          name_code2: nameCode2,
+          asset_category_name: categoryName,
+          description,
+        })
+      } else {
+        await updateAssetCategoryOption(categoryDialog.originalNameCode, categoryDialog.originalNameCode2, {
+          name_code: nameCode,
+          name_code2: nameCode2,
+          asset_category_name: categoryName,
+          description,
+        })
+      }
+      setCategoryDialog(emptyAssetCategoryDialog())
+      await loadAssetCategories()
+    } catch (error) {
+      setCategoryActionError(error instanceof Error ? error.message : '儲存資產分類失敗。')
+    } finally {
+      setSavingCategory(false)
+    }
+  }
+
+  const confirmDeleteCategory = (row: AssetCategoryOption) => {
+    setCategoryActionError('')
+    setDeletingCategory({ name_code: row.name_code, name_code2: row.name_code2 })
+  }
+
+  const deleteCategory = async () => {
+    if (!deletingCategory) {
+      return
+    }
+    setSavingCategory(true)
+    setCategoryActionError('')
+    try {
+      await deleteAssetCategoryOption(deletingCategory.name_code, deletingCategory.name_code2)
+      setDeletingCategory(null)
+      await loadAssetCategories()
+    } catch (error) {
+      setCategoryActionError(error instanceof Error ? error.message : '刪除資產分類失敗。')
+    } finally {
+      setSavingCategory(false)
+    }
+  }
+
+  return (
+    <div className="grid gap-4">
+      <Tabs defaultValue="asset-status">
+        <TabsList>
+          <TabsTrigger value="asset-status">資產狀態碼</TabsTrigger>
+          <TabsTrigger value="asset-category">資產分類</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="asset-status">
+          <SectionCard title="資產狀態碼主檔" description="維護資產狀態下拉選單（新增、編輯、刪除）。">
+            <div className="mb-3 flex justify-end">
+              <Button type="button" onClick={openCreateStatusDialog}>
+                新增狀態碼
+              </Button>
+            </div>
+            {statusActionError ? <p className="mt-0 mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{statusActionError}</p> : null}
+            {statusError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{statusError}</p> : null}
+            {!statusError && loadingStatus ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
+            {!statusError && !loadingStatus && assetStatuses.length === 0 ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有資產狀態資料。</p>
+            ) : null}
+            {!statusError && !loadingStatus && assetStatuses.length > 0 ? (
+              <div className="overflow-x-auto rounded-md border border-[hsl(var(--border))]">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>狀態碼</TableHead>
+                      <TableHead>說明</TableHead>
+                      <TableHead className="w-[180px]">操作</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {assetStatuses.map((row) => (
+                      <TableRow key={row.code}>
+                        <TableCell className="font-semibold">{row.code}</TableCell>
+                        <TableCell>{row.description || '--'}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button type="button" variant="secondary" size="sm" onClick={() => openEditStatusDialog(row)}>
+                              編輯
+                            </Button>
+                            <Button type="button" variant="destructive" size="sm" onClick={() => confirmDeleteStatus(row.code)}>
+                              刪除
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : null}
+          </SectionCard>
+        </TabsContent>
+
+        <TabsContent value="asset-category">
+          <SectionCard title="資產分類主檔" description="維護資產分類代碼對照（新增、編輯、刪除）。">
+            <div className="mb-3 flex justify-end">
+              <Button type="button" onClick={openCreateCategoryDialog}>
+                新增分類
+              </Button>
+            </div>
+            {categoryActionError ? <p className="mt-0 mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{categoryActionError}</p> : null}
+            {categoryError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{categoryError}</p> : null}
+            {!categoryError && loadingCategory ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p> : null}
+            {!categoryError && !loadingCategory && assetCategories.length === 0 ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有資產分類資料。</p>
+            ) : null}
+            {!categoryError && !loadingCategory && assetCategories.length > 0 ? (
+              <div className="overflow-x-auto rounded-md border border-[hsl(var(--border))]">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>大類代碼</TableHead>
+                      <TableHead>分類名稱</TableHead>
+                      <TableHead>小類代碼</TableHead>
+                      <TableHead>小類說明</TableHead>
+                      <TableHead className="w-[180px]">操作</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {assetCategories.map((row) => (
+                      <TableRow key={`${row.name_code}__${row.name_code2}`}>
+                        <TableCell className="font-semibold">{row.name_code}</TableCell>
+                        <TableCell>{row.asset_category_name || '--'}</TableCell>
+                        <TableCell>{row.name_code2}</TableCell>
+                        <TableCell>{row.description || '--'}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button type="button" variant="secondary" size="sm" onClick={() => openEditCategoryDialog(row)}>
+                              編輯
+                            </Button>
+                            <Button type="button" variant="destructive" size="sm" onClick={() => confirmDeleteCategory(row)}>
+                              刪除
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : null}
+          </SectionCard>
+        </TabsContent>
+      </Tabs>
+
+      <Dialog
+        open={statusDialog.open}
+        onClose={closeStatusDialog}
+        title={statusDialog.mode === 'create' ? '新增資產狀態碼' : '編輯資產狀態碼'}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={closeStatusDialog} disabled={savingStatus}>
+              取消
+            </Button>
+            <Button type="button" onClick={() => void submitStatusDialog()} disabled={savingStatus}>
+              {savingStatus ? '儲存中...' : '儲存'}
+            </Button>
+          </>
+        }
+      >
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="asset-status-code">狀態碼</Label>
+            <Input
+              id="asset-status-code"
+              value={statusDialog.code}
+              onChange={(event) => setStatusDialog((prev) => ({ ...prev, code: event.target.value }))}
+              disabled={savingStatus}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="asset-status-description">說明</Label>
+            <Input
+              id="asset-status-description"
+              value={statusDialog.description}
+              onChange={(event) => setStatusDialog((prev) => ({ ...prev, description: event.target.value }))}
+              disabled={savingStatus}
+            />
+          </div>
+        </div>
+      </Dialog>
+
+      <Dialog
+        open={deletingStatusCode !== null}
+        onClose={() => (savingStatus ? null : setDeletingStatusCode(null))}
+        title="刪除資產狀態碼"
+        description={`確定要刪除狀態碼 ${deletingStatusCode ?? ''} 嗎？此操作無法復原。`}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setDeletingStatusCode(null)} disabled={savingStatus}>
+              取消
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => void deleteStatus()} disabled={savingStatus}>
+              {savingStatus ? '刪除中...' : '確認刪除'}
+            </Button>
+          </>
+        }
+      />
+
+      <Dialog
+        open={categoryDialog.open}
+        onClose={closeCategoryDialog}
+        title={categoryDialog.mode === 'create' ? '新增資產分類' : '編輯資產分類'}
+        panelClassName="max-w-xl"
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={closeCategoryDialog} disabled={savingCategory}>
+              取消
+            </Button>
+            <Button type="button" onClick={() => void submitCategoryDialog()} disabled={savingCategory}>
+              {savingCategory ? '儲存中...' : '儲存'}
+            </Button>
+          </>
+        }
+      >
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="grid gap-1.5">
+            <Label htmlFor="asset-category-name-code">大類代碼</Label>
+            <Input
+              id="asset-category-name-code"
+              value={categoryDialog.name_code}
+              onChange={(event) => setCategoryDialog((prev) => ({ ...prev, name_code: event.target.value }))}
+              disabled={savingCategory}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="asset-category-name-code2">小類代碼</Label>
+            <Input
+              id="asset-category-name-code2"
+              value={categoryDialog.name_code2}
+              onChange={(event) => setCategoryDialog((prev) => ({ ...prev, name_code2: event.target.value }))}
+              disabled={savingCategory}
+            />
+          </div>
+          <div className="grid gap-1.5 md:col-span-2">
+            <Label htmlFor="asset-category-name">分類名稱</Label>
+            <Input
+              id="asset-category-name"
+              value={categoryDialog.asset_category_name}
+              onChange={(event) => setCategoryDialog((prev) => ({ ...prev, asset_category_name: event.target.value }))}
+              disabled={savingCategory}
+            />
+          </div>
+          <div className="grid gap-1.5 md:col-span-2">
+            <Label htmlFor="asset-category-description">小類說明</Label>
+            <Input
+              id="asset-category-description"
+              value={categoryDialog.description}
+              onChange={(event) => setCategoryDialog((prev) => ({ ...prev, description: event.target.value }))}
+              disabled={savingCategory}
+            />
+          </div>
+        </div>
+      </Dialog>
+
+      <Dialog
+        open={deletingCategory !== null}
+        onClose={() => (savingCategory ? null : setDeletingCategory(null))}
+        title="刪除資產分類"
+        description={
+          deletingCategory
+            ? `確定要刪除分類 ${deletingCategory.name_code} / ${deletingCategory.name_code2} 嗎？此操作無法復原。`
+            : undefined
+        }
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setDeletingCategory(null)} disabled={savingCategory}>
+              取消
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => void deleteCategory()} disabled={savingCategory}>
+              {savingCategory ? '刪除中...' : '確認刪除'}
+            </Button>
+          </>
+        }
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/pages/MasterDataPage.tsx
+++ b/frontend/src/components/pages/MasterDataPage.tsx
@@ -113,7 +113,7 @@ export function MasterDataPage() {
       const rows = await fetchAssetStatusOptions()
       setAssetStatuses(sortByCode(rows))
     } catch (error) {
-      setStatusError(error instanceof Error ? error.message : '無法讀取資產狀態主檔。')
+      setStatusError(error instanceof Error ? error.message : '無法讀取資產狀態設定資料。')
     } finally {
       setLoadingStatus(false)
     }
@@ -126,7 +126,7 @@ export function MasterDataPage() {
       const rows = await fetchConditionStatusOptions()
       setConditionStatuses(sortByCode(rows))
     } catch (error) {
-      setConditionStatusError(error instanceof Error ? error.message : '無法讀取物品狀況主檔。')
+      setConditionStatusError(error instanceof Error ? error.message : '無法讀取物品狀況設定資料。')
     } finally {
       setLoadingConditionStatus(false)
     }
@@ -145,7 +145,7 @@ export function MasterDataPage() {
         }),
       )
     } catch (error) {
-      setCategoryError(error instanceof Error ? error.message : '無法讀取資產分類主檔。')
+      setCategoryError(error instanceof Error ? error.message : '無法讀取資產分類設定資料。')
     } finally {
       setLoadingCategory(false)
     }
@@ -416,7 +416,7 @@ export function MasterDataPage() {
         </TabsList>
 
         <TabsContent value="asset-status">
-          <SectionCard title="資產狀態碼主檔" description="維護資產狀態下拉選單（新增、編輯、刪除）。">
+          <SectionCard title="資產狀態碼設定" description="維護資產狀態下拉選單（新增、編輯、刪除）。">
             <div className="mb-3 flex justify-end">
               <Button type="button" onClick={openCreateStatusDialog}>
                 新增狀態碼
@@ -463,7 +463,7 @@ export function MasterDataPage() {
         </TabsContent>
 
         <TabsContent value="condition-status">
-          <SectionCard title="物品狀況碼主檔" description="維護物品狀況下拉選單（新增、編輯、刪除）。">
+          <SectionCard title="物品狀況碼設定" description="維護物品狀況下拉選單（新增、編輯、刪除）。">
             <div className="mb-3 flex justify-end">
               <Button type="button" onClick={openCreateConditionStatusDialog}>
                 新增狀況碼
@@ -519,7 +519,7 @@ export function MasterDataPage() {
         </TabsContent>
 
         <TabsContent value="asset-category">
-          <SectionCard title="資產分類主檔" description="維護資產分類代碼對照（新增、編輯、刪除）。">
+          <SectionCard title="資產分類設定" description="維護資產分類代碼對照（新增、編輯、刪除）。">
             <div className="mb-3 flex justify-end">
               <Button type="button" onClick={openCreateCategoryDialog}>
                 新增分類

--- a/frontend/src/components/pages/MasterDataPage.tsx
+++ b/frontend/src/components/pages/MasterDataPage.tsx
@@ -18,9 +18,23 @@ import {
   fetchAssetStatusOptions,
   updateAssetStatusOption,
 } from './assetStatusLookup'
-import type { AssetCategoryOption, AssetStatusOption } from './types'
+import {
+  createConditionStatusOption,
+  deleteConditionStatusOption,
+  fetchConditionStatusOptions,
+  updateConditionStatusOption,
+} from './conditionStatusLookup'
+import type { AssetCategoryOption, AssetStatusOption, ConditionStatusOption } from './types'
 
 type AssetStatusDialogState = {
+  open: boolean
+  mode: 'create' | 'edit'
+  originalCode: string
+  code: string
+  description: string
+}
+
+type ConditionStatusDialogState = {
   open: boolean
   mode: 'create' | 'edit'
   originalCode: string
@@ -47,6 +61,14 @@ const emptyAssetStatusDialog = (): AssetStatusDialogState => ({
   description: '',
 })
 
+const emptyConditionStatusDialog = (): ConditionStatusDialogState => ({
+  open: false,
+  mode: 'create',
+  originalCode: '',
+  code: '',
+  description: '',
+})
+
 const emptyAssetCategoryDialog = (): AssetCategoryDialogState => ({
   open: false,
   mode: 'create',
@@ -60,30 +82,53 @@ const emptyAssetCategoryDialog = (): AssetCategoryDialogState => ({
 
 export function MasterDataPage() {
   const [assetStatuses, setAssetStatuses] = useState<AssetStatusOption[]>([])
+  const [conditionStatuses, setConditionStatuses] = useState<ConditionStatusOption[]>([])
   const [assetCategories, setAssetCategories] = useState<AssetCategoryOption[]>([])
   const [loadingStatus, setLoadingStatus] = useState(false)
+  const [loadingConditionStatus, setLoadingConditionStatus] = useState(false)
   const [loadingCategory, setLoadingCategory] = useState(false)
   const [statusError, setStatusError] = useState('')
+  const [conditionStatusError, setConditionStatusError] = useState('')
   const [categoryError, setCategoryError] = useState('')
   const [statusActionError, setStatusActionError] = useState('')
+  const [conditionStatusActionError, setConditionStatusActionError] = useState('')
   const [categoryActionError, setCategoryActionError] = useState('')
   const [savingStatus, setSavingStatus] = useState(false)
+  const [savingConditionStatus, setSavingConditionStatus] = useState(false)
   const [savingCategory, setSavingCategory] = useState(false)
   const [deletingStatusCode, setDeletingStatusCode] = useState<string | null>(null)
+  const [deletingConditionStatusCode, setDeletingConditionStatusCode] = useState<string | null>(null)
   const [deletingCategory, setDeletingCategory] = useState<{ name_code: string; name_code2: string } | null>(null)
   const [statusDialog, setStatusDialog] = useState<AssetStatusDialogState>(emptyAssetStatusDialog())
+  const [conditionStatusDialog, setConditionStatusDialog] = useState<ConditionStatusDialogState>(emptyConditionStatusDialog())
   const [categoryDialog, setCategoryDialog] = useState<AssetCategoryDialogState>(emptyAssetCategoryDialog())
+
+  const sortByCode = <T extends { code: string }>(rows: T[]) =>
+    rows.sort((left, right) => left.code.localeCompare(right.code, 'zh-TW', { numeric: true, sensitivity: 'base' }))
 
   const loadAssetStatuses = async () => {
     setLoadingStatus(true)
     setStatusError('')
     try {
       const rows = await fetchAssetStatusOptions()
-      setAssetStatuses(rows.sort((left, right) => left.code.localeCompare(right.code, 'zh-TW', { numeric: true, sensitivity: 'base' })))
+      setAssetStatuses(sortByCode(rows))
     } catch (error) {
       setStatusError(error instanceof Error ? error.message : '無法讀取資產狀態主檔。')
     } finally {
       setLoadingStatus(false)
+    }
+  }
+
+  const loadConditionStatuses = async () => {
+    setLoadingConditionStatus(true)
+    setConditionStatusError('')
+    try {
+      const rows = await fetchConditionStatusOptions()
+      setConditionStatuses(sortByCode(rows))
+    } catch (error) {
+      setConditionStatusError(error instanceof Error ? error.message : '無法讀取物品狀況主檔。')
+    } finally {
+      setLoadingConditionStatus(false)
     }
   }
 
@@ -108,6 +153,7 @@ export function MasterDataPage() {
 
   useEffect(() => {
     void loadAssetStatuses()
+    void loadConditionStatuses()
     void loadAssetCategories()
   }, [])
 
@@ -185,6 +231,83 @@ export function MasterDataPage() {
       setStatusActionError(error instanceof Error ? error.message : '刪除資產狀態失敗。')
     } finally {
       setSavingStatus(false)
+    }
+  }
+
+  const openCreateConditionStatusDialog = () => {
+    setConditionStatusActionError('')
+    setConditionStatusDialog({
+      open: true,
+      mode: 'create',
+      originalCode: '',
+      code: '',
+      description: '',
+    })
+  }
+
+  const openEditConditionStatusDialog = (row: ConditionStatusOption) => {
+    setConditionStatusActionError('')
+    setConditionStatusDialog({
+      open: true,
+      mode: 'edit',
+      originalCode: row.code,
+      code: row.code,
+      description: row.description || '',
+    })
+  }
+
+  const closeConditionStatusDialog = () => {
+    if (savingConditionStatus) {
+      return
+    }
+    setConditionStatusDialog(emptyConditionStatusDialog())
+  }
+
+  const submitConditionStatusDialog = async () => {
+    const code = conditionStatusDialog.code.trim()
+    const description = conditionStatusDialog.description.trim()
+
+    if (!code) {
+      setConditionStatusActionError('狀況碼為必填。')
+      return
+    }
+
+    setSavingConditionStatus(true)
+    setConditionStatusActionError('')
+    try {
+      if (conditionStatusDialog.mode === 'create') {
+        await createConditionStatusOption({ code, description })
+      } else {
+        await updateConditionStatusOption(conditionStatusDialog.originalCode, { code, description })
+      }
+      setConditionStatusDialog(emptyConditionStatusDialog())
+      await loadConditionStatuses()
+    } catch (error) {
+      setConditionStatusActionError(error instanceof Error ? error.message : '儲存物品狀況失敗。')
+    } finally {
+      setSavingConditionStatus(false)
+    }
+  }
+
+  const confirmDeleteConditionStatus = (code: string) => {
+    setConditionStatusActionError('')
+    setDeletingConditionStatusCode(code)
+  }
+
+  const deleteConditionStatus = async () => {
+    if (!deletingConditionStatusCode) {
+      return
+    }
+    setSavingConditionStatus(true)
+    setConditionStatusActionError('')
+    try {
+      await deleteConditionStatusOption(deletingConditionStatusCode)
+      setDeletingConditionStatusCode(null)
+      await loadConditionStatuses()
+    } catch (error) {
+      setConditionStatusActionError(error instanceof Error ? error.message : '刪除物品狀況失敗。')
+    } finally {
+      setSavingConditionStatus(false)
     }
   }
 
@@ -288,6 +411,7 @@ export function MasterDataPage() {
       <Tabs defaultValue="asset-status">
         <TabsList>
           <TabsTrigger value="asset-status">資產狀態碼</TabsTrigger>
+          <TabsTrigger value="condition-status">物品狀況碼</TabsTrigger>
           <TabsTrigger value="asset-category">資產分類</TabsTrigger>
         </TabsList>
 
@@ -325,6 +449,62 @@ export function MasterDataPage() {
                               編輯
                             </Button>
                             <Button type="button" variant="destructive" size="sm" onClick={() => confirmDeleteStatus(row.code)}>
+                              刪除
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : null}
+          </SectionCard>
+        </TabsContent>
+
+        <TabsContent value="condition-status">
+          <SectionCard title="物品狀況碼主檔" description="維護物品狀況下拉選單（新增、編輯、刪除）。">
+            <div className="mb-3 flex justify-end">
+              <Button type="button" onClick={openCreateConditionStatusDialog}>
+                新增狀況碼
+              </Button>
+            </div>
+            {conditionStatusActionError ? (
+              <p className="mt-0 mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{conditionStatusActionError}</p>
+            ) : null}
+            {conditionStatusError ? <p className="m-0 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{conditionStatusError}</p> : null}
+            {!conditionStatusError && loadingConditionStatus ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">資料載入中...</p>
+            ) : null}
+            {!conditionStatusError && !loadingConditionStatus && conditionStatuses.length === 0 ? (
+              <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">目前沒有物品狀況資料。</p>
+            ) : null}
+            {!conditionStatusError && !loadingConditionStatus && conditionStatuses.length > 0 ? (
+              <div className="overflow-x-auto rounded-md border border-[hsl(var(--border))]">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>狀況碼</TableHead>
+                      <TableHead>說明</TableHead>
+                      <TableHead className="w-[180px]">操作</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {conditionStatuses.map((row) => (
+                      <TableRow key={row.code}>
+                        <TableCell className="font-semibold">{row.code}</TableCell>
+                        <TableCell>{row.description || '--'}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button type="button" variant="secondary" size="sm" onClick={() => openEditConditionStatusDialog(row)}>
+                              編輯
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => confirmDeleteConditionStatus(row.code)}
+                            >
                               刪除
                             </Button>
                           </div>
@@ -439,6 +619,65 @@ export function MasterDataPage() {
             </Button>
             <Button type="button" variant="destructive" onClick={() => void deleteStatus()} disabled={savingStatus}>
               {savingStatus ? '刪除中...' : '確認刪除'}
+            </Button>
+          </>
+        }
+      />
+
+      <Dialog
+        open={conditionStatusDialog.open}
+        onClose={closeConditionStatusDialog}
+        title={conditionStatusDialog.mode === 'create' ? '新增物品狀況碼' : '編輯物品狀況碼'}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={closeConditionStatusDialog} disabled={savingConditionStatus}>
+              取消
+            </Button>
+            <Button type="button" onClick={() => void submitConditionStatusDialog()} disabled={savingConditionStatus}>
+              {savingConditionStatus ? '儲存中...' : '儲存'}
+            </Button>
+          </>
+        }
+      >
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="condition-status-code">狀況碼</Label>
+            <Input
+              id="condition-status-code"
+              value={conditionStatusDialog.code}
+              onChange={(event) => setConditionStatusDialog((prev) => ({ ...prev, code: event.target.value }))}
+              disabled={savingConditionStatus}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="condition-status-description">說明</Label>
+            <Input
+              id="condition-status-description"
+              value={conditionStatusDialog.description}
+              onChange={(event) => setConditionStatusDialog((prev) => ({ ...prev, description: event.target.value }))}
+              disabled={savingConditionStatus}
+            />
+          </div>
+        </div>
+      </Dialog>
+
+      <Dialog
+        open={deletingConditionStatusCode !== null}
+        onClose={() => (savingConditionStatus ? null : setDeletingConditionStatusCode(null))}
+        title="刪除物品狀況碼"
+        description={`確定要刪除狀況碼 ${deletingConditionStatusCode ?? ''} 嗎？此操作無法復原。`}
+        actions={
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setDeletingConditionStatusCode(null)}
+              disabled={savingConditionStatus}
+            >
+              取消
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => void deleteConditionStatus()} disabled={savingConditionStatus}>
+              {savingConditionStatus ? '刪除中...' : '確認刪除'}
             </Button>
           </>
         }

--- a/frontend/src/components/pages/assetCategoryLookup.ts
+++ b/frontend/src/components/pages/assetCategoryLookup.ts
@@ -1,0 +1,11 @@
+import { apiUrl } from '../../api'
+import type { AssetCategoryOption } from './types'
+
+export async function fetchAssetCategoryOptions(): Promise<AssetCategoryOption[]> {
+  const response = await fetch(apiUrl('/api/lookups/asset-category'))
+  if (!response.ok) {
+    throw new Error('failed to load asset category options')
+  }
+  const payload = (await response.json()) as AssetCategoryOption[]
+  return payload.filter((option) => Boolean(option?.name_code?.trim()) && Boolean(option?.name_code2?.trim()))
+}

--- a/frontend/src/components/pages/assetCategoryLookup.ts
+++ b/frontend/src/components/pages/assetCategoryLookup.ts
@@ -1,11 +1,71 @@
 import { apiUrl } from '../../api'
 import type { AssetCategoryOption } from './types'
 
+type AssetCategoryCreatePayload = {
+  name_code: string
+  asset_category_name: string
+  name_code2: string
+  description: string
+}
+
+type AssetCategoryUpdatePayload = {
+  name_code?: string
+  asset_category_name: string
+  name_code2?: string
+  description: string
+}
+
+async function toApiErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+  const payload = await response.json().catch(() => null)
+  const detail = typeof payload?.detail === 'string' ? payload.detail : null
+  return detail ?? fallbackMessage
+}
+
 export async function fetchAssetCategoryOptions(): Promise<AssetCategoryOption[]> {
   const response = await fetch(apiUrl('/api/lookups/asset-category'))
   if (!response.ok) {
-    throw new Error('failed to load asset category options')
+    throw new Error(await toApiErrorMessage(response, '無法讀取資產分類主檔'))
   }
   const payload = (await response.json()) as AssetCategoryOption[]
   return payload.filter((option) => Boolean(option?.name_code?.trim()) && Boolean(option?.name_code2?.trim()))
+}
+
+export async function createAssetCategoryOption(payload: AssetCategoryCreatePayload): Promise<AssetCategoryOption> {
+  const response = await fetch(apiUrl('/api/lookups/asset-category'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '新增資產分類失敗'))
+  }
+  return (await response.json()) as AssetCategoryOption
+}
+
+export async function updateAssetCategoryOption(
+  currentNameCode: string,
+  currentNameCode2: string,
+  payload: AssetCategoryUpdatePayload,
+): Promise<AssetCategoryOption> {
+  const response = await fetch(
+    apiUrl(`/api/lookups/asset-category/${encodeURIComponent(currentNameCode)}/${encodeURIComponent(currentNameCode2)}`),
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  )
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '更新資產分類失敗'))
+  }
+  return (await response.json()) as AssetCategoryOption
+}
+
+export async function deleteAssetCategoryOption(nameCode: string, nameCode2: string): Promise<void> {
+  const response = await fetch(apiUrl(`/api/lookups/asset-category/${encodeURIComponent(nameCode)}/${encodeURIComponent(nameCode2)}`), {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '刪除資產分類失敗'))
+  }
 }

--- a/frontend/src/components/pages/assetCategoryLookup.ts
+++ b/frontend/src/components/pages/assetCategoryLookup.ts
@@ -24,7 +24,7 @@ async function toApiErrorMessage(response: Response, fallbackMessage: string): P
 export async function fetchAssetCategoryOptions(): Promise<AssetCategoryOption[]> {
   const response = await fetch(apiUrl('/api/lookups/asset-category'))
   if (!response.ok) {
-    throw new Error(await toApiErrorMessage(response, '無法讀取資產分類主檔'))
+    throw new Error(await toApiErrorMessage(response, '無法讀取資產分類設定資料'))
   }
   const payload = (await response.json()) as AssetCategoryOption[]
   return payload.filter((option) => Boolean(option?.name_code?.trim()) && Boolean(option?.name_code2?.trim()))

--- a/frontend/src/components/pages/assetStatusLookup.ts
+++ b/frontend/src/components/pages/assetStatusLookup.ts
@@ -20,7 +20,7 @@ async function toApiErrorMessage(response: Response, fallbackMessage: string): P
 export async function fetchAssetStatusOptions(): Promise<AssetStatusOption[]> {
   const response = await fetch(apiUrl('/api/lookups/asset-status'))
   if (!response.ok) {
-    throw new Error(await toApiErrorMessage(response, '無法讀取資產狀態主檔'))
+    throw new Error(await toApiErrorMessage(response, '無法讀取資產狀態設定資料'))
   }
   const payload = (await response.json()) as AssetStatusOption[]
   return payload.filter((option) => Boolean(option?.code?.trim()))

--- a/frontend/src/components/pages/assetStatusLookup.ts
+++ b/frontend/src/components/pages/assetStatusLookup.ts
@@ -1,13 +1,62 @@
 import { apiUrl } from '../../api'
 import type { AssetStatusOption } from './types'
 
+type AssetStatusCreatePayload = {
+  code: string
+  description: string
+}
+
+type AssetStatusUpdatePayload = {
+  code?: string
+  description: string
+}
+
+async function toApiErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+  const payload = await response.json().catch(() => null)
+  const detail = typeof payload?.detail === 'string' ? payload.detail : null
+  return detail ?? fallbackMessage
+}
+
 export async function fetchAssetStatusOptions(): Promise<AssetStatusOption[]> {
   const response = await fetch(apiUrl('/api/lookups/asset-status'))
   if (!response.ok) {
-    throw new Error('failed to load asset status options')
+    throw new Error(await toApiErrorMessage(response, '無法讀取資產狀態主檔'))
   }
   const payload = (await response.json()) as AssetStatusOption[]
   return payload.filter((option) => Boolean(option?.code?.trim()))
+}
+
+export async function createAssetStatusOption(payload: AssetStatusCreatePayload): Promise<AssetStatusOption> {
+  const response = await fetch(apiUrl('/api/lookups/asset-status'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '新增資產狀態失敗'))
+  }
+  return (await response.json()) as AssetStatusOption
+}
+
+export async function updateAssetStatusOption(currentCode: string, payload: AssetStatusUpdatePayload): Promise<AssetStatusOption> {
+  const response = await fetch(apiUrl(`/api/lookups/asset-status/${encodeURIComponent(currentCode)}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '更新資產狀態失敗'))
+  }
+  return (await response.json()) as AssetStatusOption
+}
+
+export async function deleteAssetStatusOption(code: string): Promise<void> {
+  const response = await fetch(apiUrl(`/api/lookups/asset-status/${encodeURIComponent(code)}`), {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '刪除資產狀態失敗'))
+  }
 }
 
 export function buildAssetStatusLabelMap(options: AssetStatusOption[]): Record<string, string> {

--- a/frontend/src/components/pages/conditionStatusLookup.ts
+++ b/frontend/src/components/pages/conditionStatusLookup.ts
@@ -20,7 +20,7 @@ async function toApiErrorMessage(response: Response, fallbackMessage: string): P
 export async function fetchConditionStatusOptions(): Promise<ConditionStatusOption[]> {
   const response = await fetch(apiUrl('/api/lookups/condition-status'))
   if (!response.ok) {
-    throw new Error(await toApiErrorMessage(response, '無法讀取物品狀況主檔'))
+    throw new Error(await toApiErrorMessage(response, '無法讀取物品狀況設定資料'))
   }
   const payload = (await response.json()) as ConditionStatusOption[]
   return payload.filter((option) => Boolean(option?.code?.trim()))

--- a/frontend/src/components/pages/conditionStatusLookup.ts
+++ b/frontend/src/components/pages/conditionStatusLookup.ts
@@ -1,0 +1,63 @@
+import { apiUrl } from '../../api'
+import type { ConditionStatusOption } from './types'
+
+type ConditionStatusCreatePayload = {
+  code: string
+  description: string
+}
+
+type ConditionStatusUpdatePayload = {
+  code?: string
+  description: string
+}
+
+async function toApiErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+  const payload = await response.json().catch(() => null)
+  const detail = typeof payload?.detail === 'string' ? payload.detail : null
+  return detail ?? fallbackMessage
+}
+
+export async function fetchConditionStatusOptions(): Promise<ConditionStatusOption[]> {
+  const response = await fetch(apiUrl('/api/lookups/condition-status'))
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '無法讀取物品狀況主檔'))
+  }
+  const payload = (await response.json()) as ConditionStatusOption[]
+  return payload.filter((option) => Boolean(option?.code?.trim()))
+}
+
+export async function createConditionStatusOption(payload: ConditionStatusCreatePayload): Promise<ConditionStatusOption> {
+  const response = await fetch(apiUrl('/api/lookups/condition-status'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '新增物品狀況失敗'))
+  }
+  return (await response.json()) as ConditionStatusOption
+}
+
+export async function updateConditionStatusOption(
+  currentCode: string,
+  payload: ConditionStatusUpdatePayload,
+): Promise<ConditionStatusOption> {
+  const response = await fetch(apiUrl(`/api/lookups/condition-status/${encodeURIComponent(currentCode)}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '更新物品狀況失敗'))
+  }
+  return (await response.json()) as ConditionStatusOption
+}
+
+export async function deleteConditionStatusOption(code: string): Promise<void> {
+  const response = await fetch(apiUrl(`/api/lookups/condition-status/${encodeURIComponent(code)}`), {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    throw new Error(await toApiErrorMessage(response, '刪除物品狀況失敗'))
+  }
+}

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -69,6 +69,11 @@ export type AssetStatusOption = {
   description: string
 }
 
+export type ConditionStatusOption = {
+  code: string
+  description: string
+}
+
 export type AssetCategoryOption = {
   name_code: string
   asset_category_name: string

--- a/frontend/src/components/pages/types.ts
+++ b/frontend/src/components/pages/types.ts
@@ -32,6 +32,7 @@ export type InventoryItem = {
   id: number
   asset_type: string
   asset_status: string
+  condition_status: string
   key: string
   n_property_sn: string
   property_sn: string
@@ -51,6 +52,8 @@ export type InventoryItem = {
   memo: string
   memo2: string
   keeper: string
+  borrower: string
+  start_date: string | null
   created_at: string | null
   created_by: string
   updated_at: string | null
@@ -63,6 +66,13 @@ export type InventoryItem = {
 
 export type AssetStatusOption = {
   code: string
+  description: string
+}
+
+export type AssetCategoryOption = {
+  name_code: string
+  asset_category_name: string
+  name_code2: string
   description: string
 }
 


### PR DESCRIPTION
## Summary
- add and validate inventory restore flow end-to-end (API, list filter/action, operation log)
- rename settings/master-data UI copy for consistency
- keep keeper unchanged during borrow pickup/return and move borrow ownership to borrower
- update inventory form to make borrow info read-only on edit and hidden on create

## Validation
- npm run build (frontend)
- PYTHONPATH=. .venv/bin/python tests/test_restore_item_api.py
- PYTHONPATH=. .venv/bin/python tests/test_transaction_consistency.py

Closes #26