### PR TITLE
fix(issue-30): enforce condition_status lookup consistency in bulk path

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -998,6 +998,16 @@ def _normalize_condition_status_description(value: Any) -> str:
     return _to_str(value).strip()
 
 
+def _assert_condition_status_code_exists(code: str, code_rows: list[dict[str, Any]]) -> None:
+    normalized_code = _normalize_condition_status_code(code)
+    existing_codes = {
+        _normalize_condition_status_code(row.get("condition_status"))
+        for row in code_rows
+    }
+    if normalized_code not in existing_codes:
+        raise ValueError("condition_status code not found")
+
+
 def _asset_status_sort_key(code: str) -> tuple[int, int | str]:
     stripped = code.strip()
     if stripped.isdigit():
@@ -1661,7 +1671,11 @@ def create_item(item_data: dict[str, Any]) -> int:
 
     with _locked_workbook() as wb:
         ws = wb["inventory_items"]
+        condition_status_ws = wb["condition_status_code"]
         rows = _read_rows(ws)
+        condition_status_rows = _read_rows(condition_status_ws)
+        next_condition_status = _to_str(item_data.get("condition_status")).strip() or "0"
+        _assert_condition_status_code_exists(next_condition_status, condition_status_rows)
         new_id = _next_id(rows)
         rows.append(_to_inventory_create_row(new_id, item_data, property_number))
         _write_rows(ws, SHEETS["inventory_items"], rows)
@@ -1673,8 +1687,10 @@ def detach_item(parent_item_id: int, detach_data: dict[str, Any]) -> int:
     with _locked_workbook() as wb:
         inventory_ws = wb["inventory_items"]
         movement_ws = wb["movement_ledger"]
+        condition_status_ws = wb["condition_status_code"]
         inventory_rows = _read_rows(inventory_ws)
         movement_rows = _read_rows(movement_ws)
+        condition_status_rows = _read_rows(condition_status_ws)
 
         parent_row = None
         for row in inventory_rows:
@@ -1705,6 +1721,7 @@ def detach_item(parent_item_id: int, detach_data: dict[str, Any]) -> int:
         next_condition_status = _to_str(detach_data.get("condition_status")).strip()
         if not next_condition_status:
             next_condition_status = _to_str(parent_row.get("condition_status")).strip() or "0"
+        _assert_condition_status_code_exists(next_condition_status, condition_status_rows)
         def pick_parent_default(field_name: str) -> Any:
             value = detach_data.get(field_name)
             return parent_row.get(field_name) if value is None else value
@@ -1800,7 +1817,9 @@ def create_items_bulk(items: list[dict[str, Any]]) -> int:
 def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
     with _locked_workbook() as wb:
         ws = wb["inventory_items"]
+        condition_status_ws = wb["condition_status_code"]
         rows = _read_rows(ws)
+        condition_status_rows = _read_rows(condition_status_ws)
         updated = False
         for row in rows:
             if _to_int(row.get("id")) == item_id and _is_blank(row.get("deleted_at")):
@@ -1816,6 +1835,7 @@ def update_item(item_id: int, item_data: dict[str, Any]) -> bool:
                 next_key = _to_str(item_data.get("key")).strip()
                 next_condition_status = _to_str(item_data.get("condition_status", row.get("condition_status"))).strip()
                 next_condition_status = next_condition_status or _to_str(row.get("condition_status")).strip() or "0"
+                _assert_condition_status_code_exists(next_condition_status, condition_status_rows)
                 next_borrower = _to_str(item_data.get("borrower", row.get("borrower")))
                 next_start_date = _to_str(item_data.get("start_date", row.get("start_date")))
                 if not next_key:

--- a/backend/db.py
+++ b/backend/db.py
@@ -1776,8 +1776,10 @@ def create_items_bulk(items: list[dict[str, Any]]) -> int:
     with _locked_workbook() as wb:
         inventory_ws = wb["inventory_items"]
         order_ws = wb["order_sn"]
+        condition_status_ws = wb["condition_status_code"]
         inventory_rows = _read_rows(inventory_ws)
         order_rows = _read_rows(order_ws)
+        condition_status_rows = _read_rows(condition_status_ws)
 
         order_map = {
             str(row.get("name", "")).strip(): row
@@ -1791,20 +1793,26 @@ def create_items_bulk(items: list[dict[str, Any]]) -> int:
         created = 0
 
         for item_data in items:
+            next_condition_status = _to_str(item_data.get("condition_status")).strip() or "0"
+            _assert_condition_status_code_exists(next_condition_status, condition_status_rows)
+
+            item_payload = dict(item_data)
+            item_payload["condition_status"] = next_condition_status
+
             property_number = (
-                _to_str(item_data.get("n_property_sn")).strip()
-                or _to_str(item_data.get("property_sn")).strip()
-                or _to_str(item_data.get("n_item_sn")).strip()
-                or _to_str(item_data.get("item_sn")).strip()
+                _to_str(item_payload.get("n_property_sn")).strip()
+                or _to_str(item_payload.get("property_sn")).strip()
+                or _to_str(item_payload.get("n_item_sn")).strip()
+                or _to_str(item_payload.get("item_sn")).strip()
             )
             if not property_number:
-                order_sn_name = _asset_type_to_order_sn_name(item_data.get("asset_type"))
+                order_sn_name = _asset_type_to_order_sn_name(item_payload.get("asset_type"))
                 order_row = order_map.get(order_sn_name)
                 current_value = _to_int(order_row.get("current_value")) + 1
                 order_row["current_value"] = current_value
                 property_number = f"tmp-{_date_sn()}-{current_value:04d}"
 
-            inventory_rows.append(_to_inventory_create_row(next_id, item_data, property_number))
+            inventory_rows.append(_to_inventory_create_row(next_id, item_payload, property_number))
             next_id += 1
             created += 1
 

--- a/backend/tests/test_inventory_condition_status_validation_api.py
+++ b/backend/tests/test_inventory_condition_status_validation_api.py
@@ -118,6 +118,38 @@ class InventoryConditionStatusValidationApiTests(unittest.TestCase):
         self.assertEqual(exc.exception.status_code, 400)
         self.assertEqual(exc.exception.detail, "condition_status code not found")
 
+    def test_bulk_create_rejects_unknown_condition_status(self) -> None:
+        valid_item = app_main.to_db_payload(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="0",
+                name="合法品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                count=1,
+            )
+        )
+        invalid_item = app_main.to_db_payload(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="9",
+                name="非法品項",
+                model="M2",
+                name_code="01",
+                name_code2="01",
+                count=1,
+            )
+        )
+
+        with self.assertRaises(ValueError) as exc:
+            db.create_items_bulk([valid_item, invalid_item])
+
+        self.assertEqual(str(exc.exception), "condition_status code not found")
+        self.assertEqual(len(db.list_items()), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_inventory_condition_status_validation_api.py
+++ b/backend/tests/test_inventory_condition_status_validation_api.py
@@ -1,0 +1,123 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+
+import db
+import main as app_main
+
+
+class InventoryConditionStatusValidationApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._original_db_path = db.DB_PATH
+        self._original_lock_path = db.LOCK_PATH
+        self._original_log_archive_dir = db.LOG_ARCHIVE_DIR
+
+        db.DB_PATH = Path(self._tmpdir.name) / "inventory.xlsx"
+        db.LOCK_PATH = Path(self._tmpdir.name) / "inventory.xlsx.lock"
+        db.LOG_ARCHIVE_DIR = Path(self._tmpdir.name) / "log_archive"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self._original_db_path
+        db.LOCK_PATH = self._original_lock_path
+        db.LOG_ARCHIVE_DIR = self._original_log_archive_dir
+        self._tmpdir.cleanup()
+
+    def _create_valid_item(self) -> app_main.InventoryItem:
+        return app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="A1",
+                asset_status="0",
+                condition_status="0",
+                name="測試品項",
+                model="M1",
+                name_code="01",
+                name_code2="01",
+                count=1,
+            )
+        )
+
+    def test_create_item_rejects_unknown_condition_status(self) -> None:
+        with self.assertRaises(HTTPException) as exc:
+            app_main.create_inventory_item_api(
+                app_main.InventoryItemCreate(
+                    asset_type="A1",
+                    asset_status="0",
+                    condition_status="9",
+                    name="測試品項",
+                    model="M1",
+                    name_code="01",
+                    name_code2="01",
+                    count=1,
+                )
+            )
+
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, "condition_status code not found")
+
+    def test_update_item_rejects_unknown_condition_status(self) -> None:
+        created = self._create_valid_item()
+
+        with self.assertRaises(HTTPException) as exc:
+            app_main.update_inventory_item_api(
+                created.id,
+                app_main.InventoryItemCreate(
+                    asset_type="A1",
+                    asset_status="0",
+                    condition_status="9",
+                    key=created.key,
+                    name=created.name,
+                    model=created.model,
+                    name_code=created.name_code,
+                    name_code2=created.name_code2,
+                    count=1,
+                    specification=created.specification,
+                    unit=created.unit,
+                    location=created.location,
+                    memo=created.memo,
+                    memo2=created.memo2,
+                    keeper=created.keeper,
+                    borrower=created.borrower,
+                ),
+            )
+
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, "condition_status code not found")
+
+    def test_detach_rejects_unknown_condition_status(self) -> None:
+        parent = app_main.create_inventory_item_api(
+            app_main.InventoryItemCreate(
+                asset_type="11",
+                asset_status="0",
+                condition_status="0",
+                key="11-3140101-0030-0006351-000000",
+                name="母件設備",
+                name_code="01",
+                name_code2="01",
+                model="PARENT-M",
+                specification="PARENT-S",
+                location="A1",
+                keeper="admin",
+            )
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            app_main.detach_inventory_item_api(
+                parent.id,
+                app_main.InventoryItemDetachCreate(
+                    name_code="01",
+                    name_code2="99",
+                    seq="00",
+                    condition_status="9",
+                ),
+            )
+
+        self.assertEqual(exc.exception.status_code, 400)
+        self.assertEqual(exc.exception.detail, "condition_status code not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/pages/InventoryFormPage.test.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { InventoryFormPage } from './InventoryFormPage'
@@ -203,5 +203,123 @@ describe('InventoryFormPage AI recognition', () => {
     expect(screen.getByLabelText('品名')).toHaveValue('手動品名')
     expect(screen.getByLabelText('型號')).toHaveValue('手動型號')
     expect(screen.getByLabelText('規格')).toHaveValue('手動規格')
+  })
+})
+
+describe('InventoryFormPage condition status consistency', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('blocks submit for legacy condition_status not in lookup until re-selected', async () => {
+    const fetchMock = setupFetchMock((url, init) => {
+      if (url.endsWith('/api/lookups/asset-status')) {
+        return jsonResponse([{ code: '0', description: '在庫' }])
+      }
+      if (url.endsWith('/api/lookups/condition-status')) {
+        return jsonResponse([{ code: '0', description: '良好' }])
+      }
+      if (url.endsWith('/api/lookups/asset-category')) {
+        return jsonResponse([{ name_code: '01', name_code2: '01', asset_category_name: '筆電', description: '一般' }])
+      }
+      if (url.endsWith('/api/ai/spec-recognition/quota')) {
+        return jsonResponse({
+          enabled: false,
+          provider: 'gemini',
+          model: 'gemini-2.0-flash',
+          quota: { status: 'unknown' },
+          message: 'Gemini token 尚未設定，AI 規格辨識功能未啟用。',
+        })
+      }
+      if (url.endsWith('/api/items/1') && !init?.method) {
+        return jsonResponse({
+          id: 1,
+          asset_type: 'A1',
+          asset_status: '0',
+          condition_status: '9',
+          key: 'A1-0001',
+          n_property_sn: '',
+          property_sn: '',
+          n_item_sn: '',
+          item_sn: '',
+          name: '測試品項',
+          name_code: '01',
+          name_code2: '01',
+          model: 'M1',
+          specification: '',
+          unit: '',
+          count: 1,
+          purchase_date: '',
+          due_date: '',
+          return_date: '',
+          location: '',
+          memo: '',
+          memo2: '',
+          keeper: '',
+          borrower: '',
+          start_date: '',
+        })
+      }
+      if (url.endsWith('/api/items/1') && init?.method === 'PUT') {
+        return jsonResponse({
+          id: 1,
+          asset_type: 'A1',
+          asset_status: '0',
+          condition_status: '0',
+          key: 'A1-0001',
+          n_property_sn: '',
+          property_sn: '',
+          n_item_sn: '',
+          item_sn: '',
+          name: '測試品項',
+          name_code: '01',
+          name_code2: '01',
+          model: 'M1',
+          specification: '',
+          unit: '',
+          count: 1,
+          purchase_date: '',
+          due_date: '',
+          return_date: '',
+          location: '',
+          memo: '',
+          memo2: '',
+          keeper: '',
+          borrower: '',
+          start_date: '',
+        })
+      }
+      throw new Error(`Unhandled URL: ${url}`)
+    })
+
+    render(<InventoryFormPage itemId={1} />)
+
+    await screen.findByText('目前資料的物料狀況代碼已不存在於設定，請重新選擇可用狀況碼。')
+
+    fireEvent.click(screen.getByRole('button', { name: '儲存修改' }))
+    await screen.findAllByText('目前資料的物料狀況代碼已不存在於設定，請重新選擇可用狀況碼。')
+
+    const putCallsBeforeReselect = fetchMock.mock.calls.filter(([input, init]) => {
+      const requestUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      return requestUrl.endsWith('/api/items/1') && init?.method === 'PUT'
+    })
+    expect(putCallsBeforeReselect).toHaveLength(0)
+
+    const statusSection = screen.getByText('狀態資料').closest('section')
+    expect(statusSection).not.toBeNull()
+    const statusSelects = within(statusSection as HTMLElement).getAllByRole('combobox')
+    fireEvent.change(statusSelects[2], { target: { value: '0' } })
+    fireEvent.click(screen.getByRole('button', { name: '儲存修改' }))
+
+    await screen.findByText('財產資料已更新。')
+    const putCalls = fetchMock.mock.calls.filter(([input, init]) => {
+      const requestUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      return requestUrl.endsWith('/api/items/1') && init?.method === 'PUT'
+    })
+    expect(putCalls).toHaveLength(1)
   })
 })

--- a/frontend/src/components/pages/InventoryFormPage.tsx
+++ b/frontend/src/components/pages/InventoryFormPage.tsx
@@ -321,6 +321,10 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
   const hasNameCodeOption = nameCodeOptions.some((option) => option.value === formData.name_code)
   const hasNameCode2Option = nameCode2Options.some((option) => option.value === formData.name_code2)
   const hasConditionStatusOption = conditionStatusOptions.some((option) => option.value === formData.condition_status)
+  const conditionStatusMismatchError =
+    conditionStatusOptions.length > 0 && formData.condition_status && !hasConditionStatusOption
+      ? '目前資料的物料狀況代碼已不存在於設定，請重新選擇可用狀況碼。'
+      : ''
   const aiEnabled = Boolean(aiQuotaPayload?.enabled)
   const aiQuotaRemainingLabel =
     aiQuotaPayload?.quota.remaining === null || aiQuotaPayload?.quota.remaining === undefined ? '未知' : String(aiQuotaPayload.quota.remaining)
@@ -457,6 +461,10 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
       setErrorMessage('主分類與次分類不是合法組合，請重新選擇。')
       return
     }
+    if (conditionStatusMismatchError) {
+      setErrorMessage(conditionStatusMismatchError)
+      return
+    }
 
     setSubmitting(true)
 
@@ -558,10 +566,10 @@ export function InventoryFormPage({ itemId }: InventoryFormPageProps) {
                       {conditionStatusOption.label}
                     </option>
                   ))}
-                  {!hasConditionStatusOption && formData.condition_status ? (
-                    <option value={formData.condition_status}>{formData.condition_status}</option>
-                  ) : null}
                 </Select>
+                {conditionStatusMismatchError ? (
+                  <p className="m-0 text-xs text-red-700">{conditionStatusMismatchError}</p>
+                ) : null}
               </div>
               <div className="grid gap-1.5">
                 <Label>數量</Label>


### PR DESCRIPTION
## Summary
- enforce `condition_status` lookup validation in `create_items_bulk`
- normalize bulk payload condition_status before row creation
- add regression test for unknown condition_status rejection in bulk create

## Validation
- backend: `UV_CACHE_DIR=.uv-cache uv run python -m unittest -q tests.test_condition_status_lookup_api tests.test_inventory_condition_status_validation_api tests.test_request_api_guards`
- frontend: `npm run test -- --run src/components/pages/InventoryFormPage.test.tsx`

Closes #30