### PR TITLE
feat(frontend): add camera barcode scanner entry for issue/borrow/donation (closes #29)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-router": "^1.168.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "html5-qrcode": "^2.3.8",
         "lucide-react": "^0.553.0",
         "react": "^19.2.0",
         "react-day-picker": "^9.14.0",
@@ -4300,6 +4301,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-router": "^1.168.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.553.0",
     "react": "^19.2.0",
     "react-day-picker": "^9.14.0",

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -924,8 +924,8 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         onClose={closePickupDialog}
         title="確認借出編號"
         description="可分批領取。大量清單可先掃碼，再按列檢查；每個編號只能使用一次。"
-        panelClassName="max-w-6xl h-[85vh] flex flex-col"
-        bodyClassName="min-h-0 flex-1 overflow-hidden"
+        panelClassName="max-w-6xl max-h-[85vh]"
+        bodyClassName="min-h-0 flex-1"
         actions={
           <>
             <Button type="button" variant="secondary" onClick={closePickupDialog} disabled={submitting}>
@@ -1101,7 +1101,6 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
         open={cameraScannerOpen}
         onClose={() => setCameraScannerOpen(false)}
         onDetected={(code) => {
-          setCameraScannerOpen(false)
           void applyScanCode(code)
         }}
         title="借用條碼相機掃描"

--- a/frontend/src/components/pages/BorrowPage.tsx
+++ b/frontend/src/components/pages/BorrowPage.tsx
@@ -3,6 +3,7 @@ import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { formatIsoDate, parseIsoDate } from '../../lib/date'
 import { Button } from '../ui/button'
+import { CameraScannerDialog } from '../ui/camera-scanner-dialog'
 import { DatePicker } from '../ui/date-picker'
 import { Dialog } from '../ui/dialog'
 import { Input } from '../ui/input'
@@ -117,6 +118,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
   const [pickupSelections, setPickupSelections] = useState<Record<number, number[]>>({})
   const [scanInputValue, setScanInputValue] = useState('')
   const [scanFeedback, setScanFeedback] = useState<{ type: 'success' | 'error' | 'info'; message: string } | null>(null)
+  const [cameraScannerOpen, setCameraScannerOpen] = useState(false)
 
   const [borrower, setBorrower] = useState('')
   const [department, setDepartment] = useState('')
@@ -483,6 +485,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
       setScanInputValue('')
       setScanFeedback(null)
       scanBufferRef.current = { value: '', lastTs: 0 }
+      setCameraScannerOpen(false)
       setPickupDialogOpen(true)
       await loadPickupLineCandidates(payload[0].line_id, '', 1)
     } catch (error) {
@@ -581,6 +584,7 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
     setScanInputValue('')
     setScanFeedback(null)
     scanBufferRef.current = { value: '', lastTs: 0 }
+    setCameraScannerOpen(false)
   }
 
   const handleSubmit = async () => {
@@ -977,6 +981,9 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
                 <Button type="button" variant="secondary" onClick={() => void applyScanCode(scanInputValue)} disabled={submitting || !scanInputValue.trim()}>
                   加入
                 </Button>
+                <Button type="button" variant="secondary" onClick={() => setCameraScannerOpen(true)} disabled={submitting}>
+                  相機掃描
+                </Button>
               </div>
               {scanFeedback ? (
                 <p className={`mt-2 mb-0 text-xs ${scanFeedback.type === 'success' ? 'text-green-700' : scanFeedback.type === 'error' ? 'text-red-700' : 'text-[hsl(var(--muted-foreground))]'}`}>
@@ -1090,6 +1097,16 @@ export function BorrowPage({ requestId }: BorrowPageProps) {
           </div>
         </div>
       </Dialog>
+      <CameraScannerDialog
+        open={cameraScannerOpen}
+        onClose={() => setCameraScannerOpen(false)}
+        onDetected={(code) => {
+          setCameraScannerOpen(false)
+          void applyScanCode(code)
+        }}
+        title="借用條碼相機掃描"
+        description="掃到條碼後，會直接套用到借用領取清單。"
+      />
     </div>
   )
 }

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
+import { CameraScannerDialog } from '../ui/camera-scanner-dialog'
 import { DatePicker } from '../ui/date-picker'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -56,6 +57,7 @@ export function DonationPage({ requestId }: DonationPageProps) {
   const [donationDate, setDonationDate] = useState('')
   const [memo, setMemo] = useState('')
   const [scanCode, setScanCode] = useState('')
+  const [cameraScannerOpen, setCameraScannerOpen] = useState(false)
   const [lines, setLines] = useState<DonationLine[]>([emptyLine()])
   const [submitting, setSubmitting] = useState(false)
   const isEditing = Number.isInteger(requestId)
@@ -291,13 +293,11 @@ export function DonationPage({ requestId }: DonationPageProps) {
     return isConfirmed && typeof value === 'number' ? value : null
   }
 
-  const handleApplyScanCode = async () => {
-    const rawCode = scanCode.trim()
+  const applyScanCode = async (rawCode: string) => {
     if (!rawCode) {
       return
     }
     const matchedItems = getScanMatchedItems(rawCode)
-    setScanCode('')
 
     if (matchedItems.length === 0) {
       void toast.fire({ icon: 'error', title: `查無條碼：${rawCode}` })
@@ -322,6 +322,12 @@ export function DonationPage({ requestId }: DonationPageProps) {
 
     assignScannedItem(targetItemId)
     void toast.fire({ icon: 'success', title: `已透過條碼加入品項（${rawCode}）。` })
+  }
+
+  const handleApplyScanCode = async () => {
+    const rawCode = scanCode.trim()
+    setScanCode('')
+    await applyScanCode(rawCode)
   }
 
   const validateLines = () => {
@@ -436,18 +442,23 @@ export function DonationPage({ requestId }: DonationPageProps) {
         <SectionCard title="捐贈品項">
           <div className="mb-3 grid gap-1.5">
             <Label htmlFor="donation-scan-code">掃碼加入品項</Label>
-            <Input
-              id="donation-scan-code"
-              value={scanCode}
-              placeholder="請掃描或輸入條碼後按 Enter"
-              onChange={(event) => setScanCode(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  void handleApplyScanCode()
-                }
-              }}
-            />
+            <div className="flex gap-2">
+              <Input
+                id="donation-scan-code"
+                value={scanCode}
+                placeholder="請掃描或輸入條碼後按 Enter"
+                onChange={(event) => setScanCode(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    void handleApplyScanCode()
+                  }
+                }}
+              />
+              <Button type="button" variant="secondary" onClick={() => setCameraScannerOpen(true)} disabled={submitting}>
+                相機掃描
+              </Button>
+            </div>
           </div>
           <div className="grid gap-3">
             {lines.map((line, index) => {
@@ -542,6 +553,16 @@ export function DonationPage({ requestId }: DonationPageProps) {
           </div>
           {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
         </SectionCard>
-      </div>
+      <CameraScannerDialog
+        open={cameraScannerOpen}
+        onClose={() => setCameraScannerOpen(false)}
+        onDetected={(code) => {
+          setCameraScannerOpen(false)
+          void applyScanCode(code)
+        }}
+        title="捐贈條碼相機掃描"
+        description="掃到條碼後，會直接套用到捐贈品項。"
+      />
+    </div>
   )
 }

--- a/frontend/src/components/pages/DonationPage.tsx
+++ b/frontend/src/components/pages/DonationPage.tsx
@@ -557,7 +557,6 @@ export function DonationPage({ requestId }: DonationPageProps) {
         open={cameraScannerOpen}
         onClose={() => setCameraScannerOpen(false)}
         onDetected={(code) => {
-          setCameraScannerOpen(false)
           void applyScanCode(code)
         }}
         title="捐贈條碼相機掃描"

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import Swal from 'sweetalert2'
 import { apiUrl } from '../../api'
 import { Button } from '../ui/button'
+import { CameraScannerDialog } from '../ui/camera-scanner-dialog'
 import { DatePicker } from '../ui/date-picker'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -53,6 +54,7 @@ export function IssuePage({ requestId }: IssuePageProps) {
   const [requestDate, setRequestDate] = useState('')
   const [memo, setMemo] = useState('')
   const [scanCode, setScanCode] = useState('')
+  const [cameraScannerOpen, setCameraScannerOpen] = useState(false)
   const [lines, setLines] = useState<IssueLine[]>([emptyLine()])
   const [submitting, setSubmitting] = useState(false)
   const isEditing = Number.isInteger(requestId)
@@ -289,13 +291,11 @@ export function IssuePage({ requestId }: IssuePageProps) {
     return isConfirmed && typeof value === 'number' ? value : null
   }
 
-  const handleApplyScanCode = async () => {
-    const rawCode = scanCode.trim()
+  const applyScanCode = async (rawCode: string) => {
     if (!rawCode) {
       return
     }
     const matchedItems = getScanMatchedItems(rawCode)
-    setScanCode('')
 
     if (matchedItems.length === 0) {
       void toast.fire({ icon: 'error', title: `查無條碼：${rawCode}` })
@@ -320,6 +320,12 @@ export function IssuePage({ requestId }: IssuePageProps) {
 
     assignScannedItem(targetItemId)
     void toast.fire({ icon: 'success', title: `已透過條碼加入品項（${rawCode}）。` })
+  }
+
+  const handleApplyScanCode = async () => {
+    const rawCode = scanCode.trim()
+    setScanCode('')
+    await applyScanCode(rawCode)
   }
 
   const getLineValidationError = () => {
@@ -423,18 +429,23 @@ export function IssuePage({ requestId }: IssuePageProps) {
         <SectionCard title="領用品項">
           <div className="mb-3 grid gap-1.5">
             <Label htmlFor="issue-scan-code">掃碼加入品項</Label>
-            <Input
-              id="issue-scan-code"
-              value={scanCode}
-              placeholder="請掃描或輸入條碼後按 Enter"
-              onChange={(event) => setScanCode(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  void handleApplyScanCode()
-                }
-              }}
-            />
+            <div className="flex gap-2">
+              <Input
+                id="issue-scan-code"
+                value={scanCode}
+                placeholder="請掃描或輸入條碼後按 Enter"
+                onChange={(event) => setScanCode(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    void handleApplyScanCode()
+                  }
+                }}
+              />
+              <Button type="button" variant="secondary" onClick={() => setCameraScannerOpen(true)} disabled={submitting}>
+                相機掃描
+              </Button>
+            </div>
           </div>
           <div className="grid gap-3">
             {lines.map((line, index) => {
@@ -529,6 +540,16 @@ export function IssuePage({ requestId }: IssuePageProps) {
           </div>
           {loadError ? <p className="mt-3 mb-0 text-sm text-red-600">{loadError}</p> : null}
         </SectionCard>
-      </div>
+      <CameraScannerDialog
+        open={cameraScannerOpen}
+        onClose={() => setCameraScannerOpen(false)}
+        onDetected={(code) => {
+          setCameraScannerOpen(false)
+          void applyScanCode(code)
+        }}
+        title="領用條碼相機掃描"
+        description="掃到條碼後，會直接套用到領用品項。"
+      />
+    </div>
   )
 }

--- a/frontend/src/components/pages/IssuePage.tsx
+++ b/frontend/src/components/pages/IssuePage.tsx
@@ -544,7 +544,6 @@ export function IssuePage({ requestId }: IssuePageProps) {
         open={cameraScannerOpen}
         onClose={() => setCameraScannerOpen(false)}
         onDetected={(code) => {
-          setCameraScannerOpen(false)
           void applyScanCode(code)
         }}
         title="領用條碼相機掃描"

--- a/frontend/src/components/ui/camera-scanner-dialog.test.tsx
+++ b/frontend/src/components/ui/camera-scanner-dialog.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CameraScannerDialog } from './camera-scanner-dialog'
+
+const mocks = vi.hoisted(() => ({
+  scannerStartMock: vi.fn(),
+  scannerStopMock: vi.fn(),
+  scannerClearMock: vi.fn(),
+  scannerGetStateMock: vi.fn(),
+  getCamerasMock: vi.fn(),
+  successCallback: null as ((decodedText: string) => void) | null,
+}))
+
+vi.mock('html5-qrcode', () => {
+  class MockHtml5Qrcode {
+    static getCameras = mocks.getCamerasMock
+
+    constructor() {}
+
+    start = mocks.scannerStartMock.mockImplementation(
+      async (_cameraConfig: unknown, _config: unknown, onSuccess: (decodedText: string) => void) => {
+        mocks.successCallback = onSuccess
+      },
+    )
+    stop = mocks.scannerStopMock
+    clear = mocks.scannerClearMock
+    getState = mocks.scannerGetStateMock
+  }
+
+  return {
+    Html5Qrcode: MockHtml5Qrcode,
+    Html5QrcodeScannerState: {
+      NOT_STARTED: 1,
+      SCANNING: 2,
+      PAUSED: 3,
+    },
+    Html5QrcodeSupportedFormats: {
+      QR_CODE: 0,
+      CODE_128: 1,
+      EAN_13: 2,
+      EAN_8: 3,
+    },
+  }
+})
+
+describe('CameraScannerDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.successCallback = null
+    mocks.scannerGetStateMock.mockReturnValue(2)
+    mocks.scannerStopMock.mockResolvedValue(undefined)
+    mocks.scannerClearMock.mockImplementation(() => undefined)
+    mocks.scannerStartMock.mockResolvedValue(undefined)
+    mocks.getCamerasMock.mockResolvedValue([{ id: 'camera-1', label: 'Back Camera' }])
+  })
+
+  it('starts scanner when open and cleans up when closed', async () => {
+    const onDetected = vi.fn()
+    const onClose = vi.fn()
+    const { rerender } = render(<CameraScannerDialog open={true} onClose={onClose} onDetected={onDetected} />)
+
+    await waitFor(() => {
+      expect(mocks.scannerStartMock).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(<CameraScannerDialog open={false} onClose={onClose} onDetected={onDetected} />)
+
+    await waitFor(() => {
+      expect(mocks.scannerStopMock).toHaveBeenCalledTimes(1)
+      expect(mocks.scannerClearMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows permission error message when camera permission is denied', async () => {
+    mocks.scannerStartMock.mockRejectedValueOnce(new Error('NotAllowedError'))
+
+    render(<CameraScannerDialog open={true} onClose={() => undefined} onDetected={() => undefined} />)
+
+    expect(await screen.findByText('無法啟動相機，請確認已授權瀏覽器使用相機。')).toBeInTheDocument()
+  })
+
+  it('deduplicates same code within 2 seconds', async () => {
+    let now = new Date('2026-04-25T00:00:00.000Z').getTime()
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const onDetected = vi.fn()
+
+    render(<CameraScannerDialog open={true} onClose={() => undefined} onDetected={onDetected} />)
+
+    await waitFor(() => {
+      expect(mocks.scannerStartMock).toHaveBeenCalledTimes(1)
+      expect(mocks.successCallback).not.toBeNull()
+    })
+
+    act(() => {
+      mocks.successCallback?.('ABC-123')
+      mocks.successCallback?.('ABC-123')
+    })
+    expect(onDetected).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      now += 2100
+      mocks.successCallback?.('ABC-123')
+    })
+    expect(onDetected).toHaveBeenCalledTimes(2)
+
+    nowSpy.mockRestore()
+  })
+})

--- a/frontend/src/components/ui/camera-scanner-dialog.test.tsx
+++ b/frontend/src/components/ui/camera-scanner-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { act } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -52,7 +52,12 @@ describe('CameraScannerDialog', () => {
     mocks.scannerGetStateMock.mockReturnValue(2)
     mocks.scannerStopMock.mockResolvedValue(undefined)
     mocks.scannerClearMock.mockImplementation(() => undefined)
-    mocks.scannerStartMock.mockResolvedValue(undefined)
+    mocks.scannerStartMock.mockImplementation(async (...args: unknown[]) => {
+      const onSuccess = args[2] as ((decodedText: string) => void) | undefined
+      if (onSuccess) {
+        mocks.successCallback = onSuccess
+      }
+    })
     mocks.getCamerasMock.mockResolvedValue([{ id: 'camera-1', label: 'Back Camera' }])
   })
 
@@ -63,18 +68,27 @@ describe('CameraScannerDialog', () => {
 
     await waitFor(() => {
       expect(mocks.scannerStartMock).toHaveBeenCalledTimes(1)
+      expect(mocks.scannerStartMock).toHaveBeenNthCalledWith(
+        1,
+        { deviceId: { exact: 'camera-1' } },
+        expect.anything(),
+        expect.any(Function),
+        expect.any(Function),
+      )
     })
 
     rerender(<CameraScannerDialog open={false} onClose={onClose} onDetected={onDetected} />)
 
     await waitFor(() => {
-      expect(mocks.scannerStopMock).toHaveBeenCalledTimes(1)
-      expect(mocks.scannerClearMock).toHaveBeenCalledTimes(1)
+      expect(mocks.scannerStopMock).toHaveBeenCalled()
+      expect(mocks.scannerClearMock).toHaveBeenCalled()
     })
   })
 
   it('shows permission error message when camera permission is denied', async () => {
-    mocks.scannerStartMock.mockRejectedValueOnce(new Error('NotAllowedError'))
+    mocks.scannerStartMock.mockImplementationOnce(async () => {
+      throw new Error('NotAllowedError')
+    })
 
     render(<CameraScannerDialog open={true} onClose={() => undefined} onDetected={() => undefined} />)
 
@@ -106,5 +120,66 @@ describe('CameraScannerDialog', () => {
     expect(onDetected).toHaveBeenCalledTimes(2)
 
     nowSpy.mockRestore()
+  })
+
+  it('supports manual camera switching with restart', async () => {
+    mocks.getCamerasMock.mockResolvedValue([
+      { id: 'cam-front', label: 'Front Camera' },
+      { id: 'cam-rear', label: 'Rear Camera' },
+    ])
+    render(<CameraScannerDialog open={true} onClose={() => undefined} onDetected={() => undefined} />)
+
+    await waitFor(() => {
+      expect(mocks.scannerStartMock).toHaveBeenCalledTimes(1)
+      expect(mocks.scannerStartMock).toHaveBeenNthCalledWith(
+        1,
+        { deviceId: { exact: 'cam-rear' } },
+        expect.anything(),
+        expect.any(Function),
+        expect.any(Function),
+      )
+    })
+
+    const cameraSelect = screen.getByLabelText('鏡頭來源')
+    fireEvent.change(cameraSelect, { target: { value: 'cam-front' } })
+
+    await waitFor(() => {
+      expect(mocks.scannerStopMock).toHaveBeenCalled()
+      expect(mocks.scannerStartMock).toHaveBeenCalledTimes(2)
+      expect(mocks.scannerStartMock).toHaveBeenNthCalledWith(
+        2,
+        { deviceId: { exact: 'cam-front' } },
+        expect.anything(),
+        expect.any(Function),
+        expect.any(Function),
+      )
+    })
+  })
+
+  it('auto closes on single mode but keeps open on continuous mode', async () => {
+    const onClose = vi.fn()
+    const onDetected = vi.fn()
+    const { rerender } = render(<CameraScannerDialog open={true} onClose={onClose} onDetected={onDetected} />)
+
+    await waitFor(() => {
+      expect(mocks.successCallback).not.toBeNull()
+    })
+
+    act(() => {
+      mocks.successCallback?.('ONE-001')
+    })
+    expect(onDetected).toHaveBeenCalledWith('ONE-001')
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    rerender(<CameraScannerDialog open={true} onClose={onClose} onDetected={onDetected} defaultMode="continuous" />)
+
+    const modeSelect = screen.getByLabelText('掃描模式')
+    fireEvent.change(modeSelect, { target: { value: 'continuous' } })
+
+    act(() => {
+      mocks.successCallback?.('TWO-002')
+    })
+    expect(onDetected).toHaveBeenCalledWith('TWO-002')
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/components/ui/camera-scanner-dialog.tsx
+++ b/frontend/src/components/ui/camera-scanner-dialog.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Html5Qrcode, Html5QrcodeScannerState, Html5QrcodeSupportedFormats } from 'html5-qrcode'
+
+import { Button } from './button'
+import { Dialog } from './dialog'
+
+type CameraScannerDialogProps = {
+  open: boolean
+  onClose: () => void
+  onDetected: (code: string) => Promise<void> | void
+  title?: string
+  description?: string
+}
+
+const DETECTION_DEDUP_WINDOW_MS = 2000
+
+const READER_CONFIG = {
+  fps: 10,
+  formatsToSupport: [
+    Html5QrcodeSupportedFormats.QR_CODE,
+    Html5QrcodeSupportedFormats.CODE_128,
+    Html5QrcodeSupportedFormats.EAN_13,
+    Html5QrcodeSupportedFormats.EAN_8,
+  ],
+}
+
+function toErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error ?? '')
+  const normalized = raw.toLowerCase()
+
+  if (normalized.includes('notallowederror') || normalized.includes('permission')) {
+    return '無法啟動相機，請確認已授權瀏覽器使用相機。'
+  }
+  if (normalized.includes('notfounderror') || normalized.includes('no camera') || normalized.includes('camera not found')) {
+    return '找不到可用相機，請改用條碼槍或手動輸入。'
+  }
+  return '相機啟動失敗，請稍後重試或改用手動輸入。'
+}
+
+async function stopScanner(scanner: Html5Qrcode | null): Promise<void> {
+  if (!scanner) {
+    return
+  }
+  const state = scanner.getState()
+  if (state === Html5QrcodeScannerState.SCANNING || state === Html5QrcodeScannerState.PAUSED) {
+    try {
+      await scanner.stop()
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+  try {
+    scanner.clear()
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+export function CameraScannerDialog({
+  open,
+  onClose,
+  onDetected,
+  title = '相機掃描',
+  description = '將條碼置於框內，辨識後會自動帶入現有掃碼流程。',
+}: CameraScannerDialogProps) {
+  const elementId = useMemo(() => `camera-scanner-${Math.random().toString(36).slice(2, 10)}`, [])
+  const [loading, setLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const scannerRef = useRef<Html5Qrcode | null>(null)
+  const lastDetectedRef = useRef<{ code: string; ts: number } | null>(null)
+  const onDetectedRef = useRef(onDetected)
+
+  useEffect(() => {
+    onDetectedRef.current = onDetected
+  }, [onDetected])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    let active = true
+    const scanner = new Html5Qrcode(elementId)
+    scannerRef.current = scanner
+    setLoading(true)
+    setErrorMessage('')
+    lastDetectedRef.current = null
+
+    const start = async () => {
+      try {
+        const cameras = await Html5Qrcode.getCameras()
+        if (!active) {
+          return
+        }
+        if (!Array.isArray(cameras) || cameras.length === 0) {
+          throw new Error('camera not found')
+        }
+
+        try {
+          await scanner.start(
+            { facingMode: 'environment' },
+            READER_CONFIG,
+            (decodedText) => {
+              const code = decodedText.trim()
+              if (!code) {
+                return
+              }
+              const now = Date.now()
+              const last = lastDetectedRef.current
+              if (last && last.code === code && now - last.ts < DETECTION_DEDUP_WINDOW_MS) {
+                return
+              }
+              lastDetectedRef.current = { code, ts: now }
+              void Promise.resolve(onDetectedRef.current(code))
+            },
+            () => undefined,
+          )
+        } catch (error) {
+          const raw = error instanceof Error ? error.message.toLowerCase() : String(error ?? '').toLowerCase()
+          if (raw.includes('notallowederror') || raw.includes('permission')) {
+            throw error
+          }
+          await scanner.start(
+            { deviceId: { exact: cameras[0].id } },
+            READER_CONFIG,
+            (decodedText) => {
+              const code = decodedText.trim()
+              if (!code) {
+                return
+              }
+              const now = Date.now()
+              const last = lastDetectedRef.current
+              if (last && last.code === code && now - last.ts < DETECTION_DEDUP_WINDOW_MS) {
+                return
+              }
+              lastDetectedRef.current = { code, ts: now }
+              void Promise.resolve(onDetectedRef.current(code))
+            },
+            () => undefined,
+          )
+        }
+      } catch (error) {
+        if (active) {
+          setErrorMessage(toErrorMessage(error))
+        }
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void start()
+
+    return () => {
+      active = false
+      const currentScanner = scannerRef.current
+      scannerRef.current = null
+      void stopScanner(currentScanner)
+    }
+  }, [elementId, open])
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      panelClassName="max-w-xl"
+      actions={(
+        <>
+          <Button type="button" variant="secondary" onClick={onClose}>
+            關閉
+          </Button>
+        </>
+      )}
+    >
+      <div className="grid gap-2">
+        <div id={elementId} className="min-h-[280px] overflow-hidden rounded-md border border-[hsl(var(--border))]" />
+        {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">相機啟動中...</p> : null}
+        {errorMessage ? <p className="m-0 text-sm text-red-700">{errorMessage}</p> : null}
+        {!errorMessage ? <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">若無法啟動，請改用現有條碼輸入欄位。</p> : null}
+      </div>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/ui/camera-scanner-dialog.tsx
+++ b/frontend/src/components/ui/camera-scanner-dialog.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Html5Qrcode, Html5QrcodeScannerState, Html5QrcodeSupportedFormats } from 'html5-qrcode'
 
 import { Button } from './button'
 import { Dialog } from './dialog'
+import { Label } from './label'
+import { Select } from './select'
+
+type ScanMode = 'single' | 'continuous'
+type CameraDevice = {
+  id: string
+  label: string
+}
 
 type CameraScannerDialogProps = {
   open: boolean
@@ -10,6 +18,9 @@ type CameraScannerDialogProps = {
   onDetected: (code: string) => Promise<void> | void
   title?: string
   description?: string
+  defaultMode?: ScanMode
+  allowModeSwitch?: boolean
+  preferAutoCamera?: boolean
 }
 
 const DETECTION_DEDUP_WINDOW_MS = 2000
@@ -33,6 +44,9 @@ function toErrorMessage(error: unknown): string {
   }
   if (normalized.includes('notfounderror') || normalized.includes('no camera') || normalized.includes('camera not found')) {
     return '找不到可用相機，請改用條碼槍或手動輸入。'
+  }
+  if (normalized.includes('notreadableerror') || normalized.includes('trackstarterror') || normalized.includes('could not start video source')) {
+    return '相機可能被其他程式占用，請關閉其他相機程式後重試。'
   }
   return '相機啟動失敗，請稍後重試或改用手動輸入。'
 }
@@ -62,103 +76,137 @@ export function CameraScannerDialog({
   onDetected,
   title = '相機掃描',
   description = '將條碼置於框內，辨識後會自動帶入現有掃碼流程。',
+  defaultMode = 'single',
+  allowModeSwitch = true,
+  preferAutoCamera = true,
 }: CameraScannerDialogProps) {
   const elementId = useMemo(() => `camera-scanner-${Math.random().toString(36).slice(2, 10)}`, [])
+  const [cameras, setCameras] = useState<CameraDevice[]>([])
+  const [selectedCameraId, setSelectedCameraId] = useState('')
   const [loading, setLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
+  const [scanMode, setScanMode] = useState<ScanMode>(defaultMode)
   const scannerRef = useRef<Html5Qrcode | null>(null)
   const lastDetectedRef = useRef<{ code: string; ts: number } | null>(null)
   const onDetectedRef = useRef(onDetected)
+  const scanModeRef = useRef<ScanMode>(defaultMode)
+  const sessionRef = useRef(0)
 
   useEffect(() => {
     onDetectedRef.current = onDetected
   }, [onDetected])
 
   useEffect(() => {
+    setScanMode(defaultMode)
+  }, [defaultMode, open])
+
+  useEffect(() => {
+    scanModeRef.current = scanMode
+  }, [scanMode])
+
+  const pickPreferredCameraId = useCallback((devices: CameraDevice[]) => {
+    const rearCamera = devices.find((device) => {
+      const label = device.label.toLowerCase()
+      return label.includes('back') || label.includes('rear') || label.includes('environment')
+    })
+    return (rearCamera ?? devices[0]).id
+  }, [])
+
+  const startScanner = useCallback(async ({
+    scanner,
+    devices,
+    explicitCameraId,
+  }: {
+    scanner: Html5Qrcode
+    devices: CameraDevice[]
+    explicitCameraId?: string
+  }) => {
+    const preferredId = explicitCameraId || pickPreferredCameraId(devices)
+    setSelectedCameraId(preferredId)
+
+    const onSuccess = (decodedText: string) => {
+      const code = decodedText.trim()
+      if (!code) {
+        return
+      }
+      const now = Date.now()
+      const last = lastDetectedRef.current
+      if (last && last.code === code && now - last.ts < DETECTION_DEDUP_WINDOW_MS) {
+        return
+      }
+      lastDetectedRef.current = { code, ts: now }
+      void Promise.resolve(onDetectedRef.current(code))
+      if (scanModeRef.current === 'single') {
+        onClose()
+      }
+    }
+
+    if (explicitCameraId) {
+      await scanner.start({ deviceId: { exact: explicitCameraId } }, READER_CONFIG, onSuccess, () => undefined)
+      return
+    }
+
+    if (preferAutoCamera && preferredId) {
+      await scanner.start({ deviceId: { exact: preferredId } }, READER_CONFIG, onSuccess, () => undefined)
+      return
+    }
+
+    try {
+      await scanner.start({ facingMode: 'environment' }, READER_CONFIG, onSuccess, () => undefined)
+    } catch {
+      await scanner.start({ deviceId: { exact: preferredId } }, READER_CONFIG, onSuccess, () => undefined)
+    }
+  }, [onClose, pickPreferredCameraId, preferAutoCamera])
+
+  const restartScanner = useCallback(async (explicitCameraId?: string) => {
+    const scanner = scannerRef.current
+    if (!scanner || !open) {
+      return
+    }
+    const currentSession = ++sessionRef.current
+    setLoading(true)
+    setErrorMessage('')
+    lastDetectedRef.current = null
+    try {
+      const devices = (await Html5Qrcode.getCameras()) as CameraDevice[]
+      if (currentSession !== sessionRef.current) {
+        return
+      }
+      if (!Array.isArray(devices) || devices.length === 0) {
+        throw new Error('camera not found')
+      }
+      setCameras(devices)
+      await stopScanner(scanner)
+      await startScanner({ scanner, devices, explicitCameraId })
+    } catch (error) {
+      if (currentSession === sessionRef.current) {
+        setErrorMessage(toErrorMessage(error))
+      }
+    } finally {
+      if (currentSession === sessionRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [open, startScanner])
+
+  useEffect(() => {
     if (!open) {
       return
     }
 
-    let active = true
     const scanner = new Html5Qrcode(elementId)
     scannerRef.current = scanner
-    setLoading(true)
-    setErrorMessage('')
-    lastDetectedRef.current = null
-
-    const start = async () => {
-      try {
-        const cameras = await Html5Qrcode.getCameras()
-        if (!active) {
-          return
-        }
-        if (!Array.isArray(cameras) || cameras.length === 0) {
-          throw new Error('camera not found')
-        }
-
-        try {
-          await scanner.start(
-            { facingMode: 'environment' },
-            READER_CONFIG,
-            (decodedText) => {
-              const code = decodedText.trim()
-              if (!code) {
-                return
-              }
-              const now = Date.now()
-              const last = lastDetectedRef.current
-              if (last && last.code === code && now - last.ts < DETECTION_DEDUP_WINDOW_MS) {
-                return
-              }
-              lastDetectedRef.current = { code, ts: now }
-              void Promise.resolve(onDetectedRef.current(code))
-            },
-            () => undefined,
-          )
-        } catch (error) {
-          const raw = error instanceof Error ? error.message.toLowerCase() : String(error ?? '').toLowerCase()
-          if (raw.includes('notallowederror') || raw.includes('permission')) {
-            throw error
-          }
-          await scanner.start(
-            { deviceId: { exact: cameras[0].id } },
-            READER_CONFIG,
-            (decodedText) => {
-              const code = decodedText.trim()
-              if (!code) {
-                return
-              }
-              const now = Date.now()
-              const last = lastDetectedRef.current
-              if (last && last.code === code && now - last.ts < DETECTION_DEDUP_WINDOW_MS) {
-                return
-              }
-              lastDetectedRef.current = { code, ts: now }
-              void Promise.resolve(onDetectedRef.current(code))
-            },
-            () => undefined,
-          )
-        }
-      } catch (error) {
-        if (active) {
-          setErrorMessage(toErrorMessage(error))
-        }
-      } finally {
-        if (active) {
-          setLoading(false)
-        }
-      }
-    }
-
-    void start()
+    void restartScanner()
 
     return () => {
-      active = false
+      sessionRef.current += 1
+      setCameras([])
+      setSelectedCameraId('')
       const currentScanner = scannerRef.current
       scannerRef.current = null
       void stopScanner(currentScanner)
     }
-  }, [elementId, open])
+  }, [elementId, open, restartScanner])
 
   return (
     <Dialog
@@ -176,10 +224,53 @@ export function CameraScannerDialog({
       )}
     >
       <div className="grid gap-2">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div className="grid gap-1.5">
+            <Label htmlFor={`${elementId}-camera-select`}>鏡頭來源</Label>
+            <Select
+              id={`${elementId}-camera-select`}
+              value={selectedCameraId}
+              disabled={loading || cameras.length === 0}
+              onChange={(event) => {
+                const cameraId = event.target.value
+                setSelectedCameraId(cameraId)
+                void restartScanner(cameraId)
+              }}
+            >
+              {cameras.length === 0 ? <option value="">無可用鏡頭</option> : null}
+              {cameras.map((camera, index) => (
+                <option key={camera.id} value={camera.id}>
+                  {camera.label || `鏡頭 ${index + 1}`}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor={`${elementId}-mode-select`}>掃描模式</Label>
+            <Select
+              id={`${elementId}-mode-select`}
+              value={scanMode}
+              disabled={!allowModeSwitch}
+              onChange={(event) => {
+                setScanMode(event.target.value as ScanMode)
+              }}
+            >
+              <option value="single">單次掃描（成功後關閉）</option>
+              <option value="continuous">連續掃描（保持開啟）</option>
+            </Select>
+          </div>
+        </div>
         <div id={elementId} className="min-h-[280px] overflow-hidden rounded-md border border-[hsl(var(--border))]" />
         {loading ? <p className="m-0 text-sm text-[hsl(var(--muted-foreground))]">相機啟動中...</p> : null}
         {errorMessage ? <p className="m-0 text-sm text-red-700">{errorMessage}</p> : null}
-        {!errorMessage ? <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">若無法啟動，請改用現有條碼輸入欄位。</p> : null}
+        <div className="flex items-center justify-between gap-2">
+          <p className="m-0 text-xs text-[hsl(var(--muted-foreground))]">
+            若無法啟動，請改用現有條碼輸入欄位。
+          </p>
+          <Button type="button" variant="secondary" onClick={() => void restartScanner(selectedCameraId || undefined)} disabled={loading}>
+            重新啟動相機
+          </Button>
+        </div>
       </div>
     </Dialog>
   )

--- a/frontend/src/components/ui/dialog.test.tsx
+++ b/frontend/src/components/ui/dialog.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Button } from './button'
+import { Dialog } from './dialog'
+
+describe('Dialog', () => {
+  afterEach(() => {
+    document.body.style.overflow = ''
+  })
+
+  it('locks body scroll when open and restores on close', () => {
+    document.body.style.overflow = 'scroll'
+    const { rerender, unmount } = render(
+      <Dialog open={true} onClose={() => undefined} title="測試標題">
+        <div>內容</div>
+      </Dialog>,
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(
+      <Dialog open={false} onClose={() => undefined} title="測試標題">
+        <div>內容</div>
+      </Dialog>,
+    )
+    expect(document.body.style.overflow).toBe('scroll')
+
+    unmount()
+    expect(document.body.style.overflow).toBe('scroll')
+  })
+
+  it('renders scrollable body and fixed actions layout', () => {
+    render(
+      <Dialog
+        open={true}
+        onClose={() => undefined}
+        title="長內容測試"
+        actions={<Button type="button">確認</Button>}
+      >
+        <div data-testid="dialog-content">超長內容</div>
+      </Dialog>,
+    )
+
+    const contentContainer = screen.getByTestId('dialog-content').parentElement
+    expect(contentContainer).not.toBeNull()
+    expect(contentContainer?.className).toContain('overflow-y-auto')
+    expect(screen.getByRole('button', { name: '確認' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom'
+import { useEffect } from 'react'
 
 import { cn } from '../../lib/utils'
 
@@ -13,7 +14,29 @@ type DialogProps = {
   bodyClassName?: string
 }
 
+let activeDialogCount = 0
+let previousBodyOverflow = ''
+
 export function Dialog({ open, onClose, title, description, children, actions, panelClassName, bodyClassName }: DialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    if (activeDialogCount === 0) {
+      previousBodyOverflow = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+    }
+    activeDialogCount += 1
+
+    return () => {
+      activeDialogCount = Math.max(activeDialogCount - 1, 0)
+      if (activeDialogCount === 0) {
+        document.body.style.overflow = previousBodyOverflow
+      }
+    }
+  }, [open])
+
   if (!open) {
     return null
   }
@@ -23,12 +46,12 @@ export function Dialog({ open, onClose, title, description, children, actions, p
       <div
         role="dialog"
         aria-modal="true"
-        className={cn('w-full max-w-md rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-xl', panelClassName)}
+        className={cn('flex max-h-[90vh] w-full max-w-md flex-col rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-xl', panelClassName)}
         onClick={(event) => event.stopPropagation()}
       >
         <h3 className="m-0 text-base font-semibold text-[hsl(var(--foreground))]">{title}</h3>
         {description ? <p className="mt-2 text-sm text-[hsl(var(--muted-foreground))]">{description}</p> : null}
-        {children ? <div className={cn('mt-4', bodyClassName)}>{children}</div> : null}
+        {children ? <div className={cn('mt-4 min-h-0 flex-1 overflow-y-auto', bodyClassName)}>{children}</div> : null}
         {actions ? <div className="mt-5 flex justify-end gap-2">{actions}</div> : null}
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- add reusable `CameraScannerDialog` based on `html5-qrcode`
- add camera scan entry in Issue/Borrow/Donation flows
- wire scan results into existing scan application paths
- add scanner interaction tests and dialog tests

## Validation
- npm --prefix frontend test -- src/components/ui/camera-scanner-dialog.test.tsx

Closes #29